### PR TITLE
feat(chat): support cross chat window PPL fix apply

### DIFF
--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -454,6 +454,8 @@ export {
   ChatServiceStart,
   ChatImplementationFunctions,
   Message,
+  UserMessage,
+  InputContent,
   ChatWindowState,
   SavedConversation,
   ConversationMemoryProvider,

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -328,6 +328,34 @@ describe('ChatService', () => {
       expect(result.userMessage.content).toBe('Hello');
     });
 
+    it('excludes the PPL lint fix request-id context from the agent payload', async () => {
+      const mockObservable = new Observable<BaseEvent>();
+      mockAgent.runAgent.mockReturnValue(mockObservable);
+
+      (global as any).window.assistantContextStore = {
+        getAllContexts: jest.fn().mockReturnValue([
+          { categories: ['page', 'chat'], description: 'Page context', value: 'page-data' },
+          {
+            categories: ['page', 'ppl-lint-fix-request'],
+            description: 'PPL lint quick-fix request id',
+            value: 'req-123',
+          },
+        ]),
+      };
+
+      await chatService.sendMessage('test', []);
+      // Reassigning global.window is a no-op under jsdom, so the shared store
+      // property must be cleared here or it leaks into later tests.
+      delete (global as any).window.assistantContextStore;
+
+      expect(mockAgent.runAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: [{ description: 'Page context', value: 'page-data' }],
+        }),
+        undefined
+      );
+    });
+
     it('should include available tools in request', async () => {
       const mockObservable = new Observable<BaseEvent>();
       mockAgent.runAgent.mockReturnValue(mockObservable);

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -8,6 +8,7 @@ import { AgUiAgent } from './ag_ui_agent';
 import { RunAgentInput, Message, UserMessage, ToolMessage, InputContent } from '../../common/types';
 import type { ToolDefinition } from '../../../context_provider/public';
 import { AssistantActionService } from '../../../context_provider/public';
+import type { PPLLintFixRequestCategory } from '../../../data/common/chat_tools/ppl_lint_fix_protocol';
 import type { ChatWindowInstance } from '../components/chat_window';
 import {
   IUiSettingsClient,
@@ -304,6 +305,24 @@ export class ChatService {
   }
 
   /**
+   * Contexts sent to the agent, in AG-UI `{description, value}` form. The PPL
+   * quick-fix stamps its approved request id under this category purely so a
+   * cross-window caller can recover it from the store; the model must never
+   * receive it, or it could echo the id back as an apply arg and stand in for
+   * the user's Approve click. Typed against data's category so a rename there
+   * fails to compile here.
+   */
+  private getAgentContexts(): Array<{ description: string; value: string }> {
+    const pplLintFixRequestCategory: PPLLintFixRequestCategory = 'ppl-lint-fix-request';
+    return this.getAllAssistantContexts()
+      .filter((ctx) => !ctx.categories?.includes(pplLintFixRequestCategory))
+      .map((ctx) => ({
+        description: ctx.description,
+        value: typeof ctx.value === 'string' ? ctx.value : JSON.stringify(ctx.value),
+      }));
+  }
+
+  /**
    * Resolve the parsed value of the current page context (the one carrying appId).
    */
   private getPageContextValue(): any | undefined {
@@ -432,15 +451,7 @@ export class ChatService {
     // Get workspace-aware data source ID
     const dataSourceId = await this.getCurrentDataSourceId();
 
-    // Get all contexts from the assistant context store (static + dynamic)
-    const contextStore = (window as any).assistantContextStore;
-    const allContexts = contextStore ? contextStore.getAllContexts() : [];
-
-    // Convert to AG-UI format: {description: string, value: string}
-    const context = allContexts.map((ctx: any) => ({
-      description: ctx.description,
-      value: typeof ctx.value === 'string' ? ctx.value : JSON.stringify(ctx.value),
-    }));
+    const context = this.getAgentContexts();
     const threadId = this.getThreadId();
 
     if (!threadId) {
@@ -674,15 +685,7 @@ export class ChatService {
     // Get workspace-aware data source ID
     const dataSourceId = await this.getWorkspaceAwareDataSourceId();
 
-    // Get all contexts from the assistant context store (static + dynamic)
-    const contextStore = (window as any).assistantContextStore;
-    const allContexts = contextStore ? contextStore.getAllContexts() : [];
-
-    // Convert to AG-UI format: {description: string, value: string}
-    const context = allContexts.map((ctx: any) => ({
-      description: ctx.description,
-      value: typeof ctx.value === 'string' ? ctx.value : JSON.stringify(ctx.value),
-    }));
+    const context = this.getAgentContexts();
 
     // Send the tool result back to the agent with full conversation history
     const includeFullHistory =

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -8,7 +8,7 @@ import { AgUiAgent } from './ag_ui_agent';
 import { RunAgentInput, Message, UserMessage, ToolMessage, InputContent } from '../../common/types';
 import type { ToolDefinition } from '../../../context_provider/public';
 import { AssistantActionService } from '../../../context_provider/public';
-import type { PPLLintFixRequestCategory } from '../../../data/common/chat_tools/ppl_lint_fix_protocol';
+import type { PPLLintFixRequestCategory } from '../../../data/public';
 import type { ChatWindowInstance } from '../components/chat_window';
 import {
   IUiSettingsClient,

--- a/src/plugins/chat/server/plugin.ts
+++ b/src/plugins/chat/server/plugin.ts
@@ -60,7 +60,10 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
       getHttpAuth
     );
 
-    return {};
+    return {
+      mlCommonsAgentId: config.mlCommonsAgentId,
+      observabilityAgentId: config.observabilityAgentId,
+    };
   }
 
   public start(core: CoreStart) {

--- a/src/plugins/chat/server/types.ts
+++ b/src/plugins/chat/server/types.ts
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ChatPluginSetup {}
+export interface ChatPluginSetup {
+  mlCommonsAgentId?: string;
+  observabilityAgentId?: string;
+}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ChatPluginStart {}

--- a/src/plugins/context_provider/public/plugin.ts
+++ b/src/plugins/context_provider/public/plugin.ts
@@ -52,6 +52,9 @@ export class ContextProviderPlugin implements Plugin<
         actions: {
           registerAssistantAction: () => undefined,
           unregisterAssistantAction: () => undefined,
+          getToolDefinitions: () => [],
+          hasAction: () => false,
+          executeAction: async () => undefined,
           suppressDefaultPageContext: () => undefined,
           unsuppressDefaultPageContext: () => undefined,
         },
@@ -70,6 +73,10 @@ export class ContextProviderPlugin implements Plugin<
       actions: {
         registerAssistantAction: AssistantActionService.getInstance().registerAction,
         unregisterAssistantAction: AssistantActionService.getInstance().unregisterAction,
+        getToolDefinitions: () => AssistantActionService.getInstance().getToolDefinitions(),
+        hasAction: (name) => AssistantActionService.getInstance().hasAction(name),
+        executeAction: (name, args) =>
+          AssistantActionService.getInstance().executeAction(name, args),
         suppressDefaultPageContext: () => this.contextCaptureService!.suppressDefaultPageContext(),
         unsuppressDefaultPageContext: () =>
           this.contextCaptureService!.unsuppressDefaultPageContext(),

--- a/src/plugins/context_provider/public/types.ts
+++ b/src/plugins/context_provider/public/types.ts
@@ -4,6 +4,7 @@
  */
 
 import { AssistantAction } from './hooks/use_assistant_action';
+import { ToolDefinition } from './services/assistant_action_service';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ContextProviderSetupDeps {}
@@ -40,6 +41,9 @@ export interface ContextProviderStart {
   actions: {
     registerAssistantAction: (action: AssistantAction) => void;
     unregisterAssistantAction: (id: string) => void;
+    getToolDefinitions: () => ToolDefinition[];
+    hasAction: (name: string) => boolean;
+    executeAction: (name: string, args: any) => Promise<any>;
     suppressDefaultPageContext: () => void;
     unsuppressDefaultPageContext: () => void;
   };

--- a/src/plugins/context_provider/public/types.ts
+++ b/src/plugins/context_provider/public/types.ts
@@ -43,7 +43,7 @@ export interface ContextProviderStart {
     unregisterAssistantAction: (id: string) => void;
     getToolDefinitions: () => ToolDefinition[];
     hasAction: (name: string) => boolean;
-    executeAction: (name: string, args: any) => Promise<any>;
+    executeAction: (name: string, args: unknown) => Promise<unknown>;
     suppressDefaultPageContext: () => void;
     unsuppressDefaultPageContext: () => void;
   };

--- a/src/plugins/context_provider/public/types.ts
+++ b/src/plugins/context_provider/public/types.ts
@@ -43,6 +43,13 @@ export interface ContextProviderStart {
     unregisterAssistantAction: (id: string) => void;
     getToolDefinitions: () => ToolDefinition[];
     hasAction: (name: string) => boolean;
+    /**
+     * Runs an action's handler directly. It does NOT enforce the
+     * `requiresConfirmation` gate — that lives in the chat tool executor. A
+     * caller invoking a confirmation-required action (e.g. the PPL apply tools)
+     * is responsible for obtaining the user's approval out-of-band first, and
+     * the action's own handler must stay fail-closed rather than trust the args.
+     */
     executeAction: (name: string, args: unknown) => Promise<unknown>;
     suppressDefaultPageContext: () => void;
     unsuppressDefaultPageContext: () => void;

--- a/src/plugins/data/common/chat_tools/ppl_lint_fix_protocol.ts
+++ b/src/plugins/data/common/chat_tools/ppl_lint_fix_protocol.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Cross-realm contract for the PPL lint quick-fix, shared by the query editors
+ * (data/explore) and any external assistant that drives the fix from a separate
+ * realm. An out-of-tree consumer imports these as types only (erased at build),
+ * so it stays a compile-time contract with no cross-bundle runtime dependency.
+ */
+
+export const PPL_LINT_FIX_REQUEST_CATEGORY = 'ppl-lint-fix-request';
+
+export type PPLLintFixRequestCategory = typeof PPL_LINT_FIX_REQUEST_CATEGORY;
+
+export const PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX = '::request-id';
+
+/**
+ * Args an out-of-realm caller sets to bind a confirmed apply to its request,
+ * standing in for the in-process symbol binding the card uses (a Symbol cannot
+ * survive postMessage serialization).
+ */
+export interface PPLLintFixApprovalArgs {
+  __approvedRequestId?: string;
+}

--- a/src/plugins/data/common/chat_tools/ppl_lint_fix_protocol.ts
+++ b/src/plugins/data/common/chat_tools/ppl_lint_fix_protocol.ts
@@ -14,13 +14,17 @@ export const PPL_LINT_FIX_REQUEST_CATEGORY = 'ppl-lint-fix-request';
 
 export type PPLLintFixRequestCategory = typeof PPL_LINT_FIX_REQUEST_CATEGORY;
 
-export const PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX = '::request-id';
+export const PPL_LINT_FIX_APPROVAL_NONCE_CONTEXT_SUFFIX = '::approval-nonce';
 
 /**
- * Args an out-of-realm caller sets to bind a confirmed apply to its request,
- * standing in for the in-process symbol binding the card uses (a Symbol cannot
- * survive postMessage serialization).
+ * Args an out-of-realm caller sets to authorize a confirmed apply, standing in
+ * for the in-process symbol binding the card uses (a Symbol cannot survive
+ * postMessage serialization). The value is a per-request nonce, minted with the
+ * request and published only under PPL_LINT_FIX_REQUEST_CATEGORY, which every
+ * agent payload strips — so the model never sees it and cannot authorize an
+ * apply by naming the (public) request id. Never carry this over a channel the
+ * model can read, and never substitute the request id for it.
  */
 export interface PPLLintFixApprovalArgs {
-  __approvedRequestId?: string;
+  __approvedNonce?: string;
 }

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_card.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_card.tsx
@@ -23,6 +23,7 @@ import {
   subscribePPLLintFixOutcome,
 } from './ppl_lint_fix_session';
 import type { RemovePPLLintFixContextById } from './ppl_lint_fix_session';
+import type { PPLLintFixApprovalArgs } from '../../common/chat_tools/ppl_lint_fix_protocol';
 import { PERFORMANCE_RULE_IDS } from './ppl_lint_fix_host';
 import type { PPLLintFixHost } from './ppl_lint_fix_host';
 
@@ -40,6 +41,16 @@ export interface PPLLintFixToolArgs {
 export type BoundPPLLintFixToolArgs = PPLLintFixToolArgs & {
   [PPL_LINT_FIX_UI_BINDING]?: string;
 };
+
+/**
+ * The request id a confirmed apply is bound to: the in-process symbol the card's
+ * Approve click sets, falling back to the explicit key an out-of-realm caller
+ * passes when the symbol cannot survive serialization. Never trusts a
+ * model-supplied request id.
+ */
+export const resolveApprovedRequestId = (args: unknown): string | undefined =>
+  (args as BoundPPLLintFixToolArgs | null | undefined)?.[PPL_LINT_FIX_UI_BINDING] ??
+  (args as PPLLintFixApprovalArgs | null | undefined)?.__approvedRequestId;
 
 /**
  * Subset of the assistant framework's render props the card needs. Declared here

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_card.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_card.tsx
@@ -48,9 +48,12 @@ export type BoundPPLLintFixToolArgs = PPLLintFixToolArgs & {
  * passes when the symbol cannot survive serialization. Never trusts a
  * model-supplied request id.
  */
-export const resolveApprovedRequestId = (args: unknown): string | undefined =>
-  (args as BoundPPLLintFixToolArgs | null | undefined)?.[PPL_LINT_FIX_UI_BINDING] ??
-  (args as PPLLintFixApprovalArgs | null | undefined)?.__approvedRequestId;
+export const resolveApprovedRequestId = (args: unknown): string | undefined => {
+  const bound = (args as BoundPPLLintFixToolArgs | null | undefined)?.[PPL_LINT_FIX_UI_BINDING];
+  if (typeof bound === 'string') return bound;
+  const explicit = (args as PPLLintFixApprovalArgs | null | undefined)?.__approvedRequestId;
+  return typeof explicit === 'string' ? explicit : undefined;
+};
 
 /**
  * Subset of the assistant framework's render props the card needs. Declared here

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_card.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_card.tsx
@@ -20,6 +20,7 @@ import {
   getPPLLintFixOutcome,
   getPPLLintFixSession,
   markPPLLintFixDismissed,
+  resolveRequestIdByApprovalNonce,
   subscribePPLLintFixOutcome,
 } from './ppl_lint_fix_session';
 import type { RemovePPLLintFixContextById } from './ppl_lint_fix_session';
@@ -44,15 +45,16 @@ export type BoundPPLLintFixToolArgs = PPLLintFixToolArgs & {
 
 /**
  * The request id a confirmed apply is bound to: the in-process symbol the card's
- * Approve click sets, falling back to the explicit key an out-of-realm caller
- * passes when the symbol cannot survive serialization. Never trusts a
- * model-supplied request id.
+ * Approve click sets, falling back to the approval nonce an out-of-realm caller
+ * passes when the symbol cannot survive serialization. The nonce is resolved
+ * against the nonces issued in this realm, so a value the model invented (it
+ * never sees a real nonce) resolves to nothing and the apply fails closed.
  */
 export const resolveApprovedRequestId = (args: unknown): string | undefined => {
   const bound = (args as BoundPPLLintFixToolArgs | null | undefined)?.[PPL_LINT_FIX_UI_BINDING];
   if (typeof bound === 'string') return bound;
-  const explicit = (args as PPLLintFixApprovalArgs | null | undefined)?.__approvedRequestId;
-  return typeof explicit === 'string' ? explicit : undefined;
+  const nonce = (args as PPLLintFixApprovalArgs | null | undefined)?.__approvedNonce;
+  return typeof nonce === 'string' ? resolveRequestIdByApprovalNonce(nonce) : undefined;
 };
 
 /**

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_session.test.ts
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_session.test.ts
@@ -7,11 +7,13 @@ import {
   armPPLLintFixRequest,
   cleanupPPLLintFixRequest,
   clearPPLLintFixSession,
+  createPPLLintFixApprovalNonce,
   getPPLLintFixOutcome,
   getPPLLintFixSession,
   isPPLLintFixFlowActive,
   markPPLLintFixApplied,
   markPPLLintFixDismissed,
+  resolveRequestIdByApprovalNonce,
   storePPLLintFixSession,
   subscribePPLLintFixOutcome,
 } from './ppl_lint_fix_session';
@@ -72,6 +74,36 @@ describe('PPL lint fix session', () => {
       })
     ).toThrow('context store unavailable');
     expect(getPPLLintFixSession()).toBeUndefined();
+  });
+
+  it('resolves an issued approval nonce back to its request id', () => {
+    const nonce = createPPLLintFixApprovalNonce('request-a');
+
+    expect(typeof nonce).toBe('string');
+    expect(nonce).not.toBe('request-a');
+    expect(resolveRequestIdByApprovalNonce(nonce)).toBe('request-a');
+  });
+
+  it('reuses the same nonce for a request rather than minting a second', () => {
+    const first = createPPLLintFixApprovalNonce('request-a');
+    const second = createPPLLintFixApprovalNonce('request-a');
+
+    expect(second).toBe(first);
+  });
+
+  it('does not resolve a nonce that was never issued', () => {
+    createPPLLintFixApprovalNonce('request-a');
+
+    expect(resolveRequestIdByApprovalNonce('made-up-nonce')).toBeUndefined();
+  });
+
+  it('forgets the nonce once its request is cleaned up', () => {
+    const nonce = createPPLLintFixApprovalNonce('request-a');
+    storePPLLintFixSession(createSession('request-a'));
+
+    cleanupPPLLintFixRequest('request-a', PREFIX, jest.fn());
+
+    expect(resolveRequestIdByApprovalNonce(nonce)).toBeUndefined();
   });
 
   it('keeps outcomes scoped to their originating request', () => {

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_session.ts
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_session.ts
@@ -6,6 +6,7 @@
 import type { AskPPLLintFixRequest, PPLLintContext } from '@osd/monaco';
 import type { Query } from '../../common';
 import type { PPLLintFixHost } from './ppl_lint_fix_host';
+import { PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX } from '../../common/chat_tools/ppl_lint_fix_protocol';
 
 export type { AskPPLLintFixRequest } from '@osd/monaco';
 
@@ -151,6 +152,7 @@ export function cleanupPPLLintFixRequest(
 ): void {
   try {
     removeContextById?.(contextIdPrefix + requestId);
+    removeContextById?.(contextIdPrefix + requestId + PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX);
   } finally {
     // Disarm on every exit path.
     if (armedRequests.delete(requestId)) {

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_session.ts
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_session.ts
@@ -3,10 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { v4 as uuidv4 } from 'uuid';
 import type { AskPPLLintFixRequest, PPLLintContext } from '@osd/monaco';
 import type { Query } from '../../common';
 import type { PPLLintFixHost } from './ppl_lint_fix_host';
-import { PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX } from '../../common/chat_tools/ppl_lint_fix_protocol';
+import { PPL_LINT_FIX_APPROVAL_NONCE_CONTEXT_SUFFIX } from '../../common/chat_tools/ppl_lint_fix_protocol';
 
 export type { AskPPLLintFixRequest } from '@osd/monaco';
 
@@ -34,6 +35,54 @@ let activeSession: PPLLintFixSession | undefined;
 // Requests in an active AI lint-fix flow, armed in onAskAiFix before the chat send
 // (chat snapshots tools at send time); disarmed by cleanupPPLLintFixRequest.
 const armedRequests = new Set<string>();
+
+const MAX_RETAINED_APPROVAL_NONCES = 100;
+const nonceByRequestId = new Map<string, string>();
+const requestIdByNonce = new Map<string, string>();
+
+/**
+ * Mint (or reuse) the secret nonce that authorizes a cross-window apply of this
+ * request. Callers publish it only under the request category that agent payloads
+ * strip; it never reaches the model, so a caller that holds it (not the model)
+ * stands in for the user's Approve click.
+ */
+export function createPPLLintFixApprovalNonce(requestId: string): string {
+  const existing = nonceByRequestId.get(requestId);
+  if (existing) {
+    return existing;
+  }
+  const nonce = uuidv4();
+  nonceByRequestId.set(requestId, nonce);
+  requestIdByNonce.set(nonce, requestId);
+  if (requestIdByNonce.size > MAX_RETAINED_APPROVAL_NONCES) {
+    const oldestNonce = requestIdByNonce.keys().next().value;
+    if (oldestNonce !== undefined) {
+      const oldestRequestId = requestIdByNonce.get(oldestNonce);
+      requestIdByNonce.delete(oldestNonce);
+      if (oldestRequestId !== undefined && nonceByRequestId.get(oldestRequestId) === oldestNonce) {
+        nonceByRequestId.delete(oldestRequestId);
+      }
+    }
+  }
+  return nonce;
+}
+
+/**
+ * Resolve an approval nonce back to the request id it was minted for. Liveness of
+ * that request is enforced downstream by getPPLLintFixSession; this only refuses
+ * a nonce that was never issued.
+ */
+export function resolveRequestIdByApprovalNonce(nonce: string): string | undefined {
+  return requestIdByNonce.get(nonce);
+}
+
+function deletePPLLintFixApprovalNonce(requestId: string): void {
+  const nonce = nonceByRequestId.get(requestId);
+  if (nonce !== undefined) {
+    requestIdByNonce.delete(nonce);
+  }
+  nonceByRequestId.delete(requestId);
+}
 
 /**
  * Terminal outcome of a request, driven directly by the card's Apply/Dismiss click
@@ -152,8 +201,9 @@ export function cleanupPPLLintFixRequest(
 ): void {
   try {
     removeContextById?.(contextIdPrefix + requestId);
-    removeContextById?.(contextIdPrefix + requestId + PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX);
+    removeContextById?.(contextIdPrefix + requestId + PPL_LINT_FIX_APPROVAL_NONCE_CONTEXT_SUFFIX);
   } finally {
+    deletePPLLintFixApprovalNonce(requestId);
     // Disarm on every exit path.
     if (armedRequests.delete(requestId)) {
       notifyOutcomeSubscribers();

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.test.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.test.tsx
@@ -22,6 +22,7 @@ import {
 import {
   cleanupPPLLintFixRequest,
   clearPPLLintFixSession,
+  createPPLLintFixApprovalNonce,
   getPPLLintFixOutcome,
   getPPLLintFixSession,
   storePPLLintFixSession,
@@ -1034,6 +1035,44 @@ describe('PPLLintFixToolRegistration', () => {
 
     expect(result?.success).toBe(true);
     expect(queryString.setQuery).toHaveBeenCalled();
+  });
+
+  it('applies a cross-window fix authorized by a valid approval nonce', async () => {
+    storeSession();
+    mockValidate.mockReturnValue({ accepted: true });
+    const config = renderRegistration();
+    const nonce = createPPLLintFixApprovalNonce(request.requestId);
+
+    let result: any;
+    await act(async () => {
+      result = await config.handler({
+        fixedQuery: 'source=logs | where status_code = 500',
+        __approvedNonce: nonce,
+        confirmed: true,
+      });
+    });
+
+    expect(result?.success).toBe(true);
+    expect(queryString.setQuery).toHaveBeenCalled();
+  });
+
+  it('fails closed when a cross-window apply carries an unissued nonce', async () => {
+    storeSession();
+    mockValidate.mockReturnValue({ accepted: true });
+    const config = renderRegistration();
+
+    let result: any;
+    await act(async () => {
+      result = await config.handler({
+        fixedQuery: 'source=logs | where status_code = 500',
+        __approvedNonce: 'nonce-the-model-invented',
+        confirmed: true,
+      });
+    });
+
+    expect(result?.success).toBe(false);
+    expect(result?.reason).toBe('missing-request');
+    expect(queryString.setQuery).not.toHaveBeenCalled();
   });
 
   it('cleans an abandoned request when its chat card unmounts', () => {

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.tsx
@@ -25,8 +25,8 @@ import {
   runPPLLintFixTestTool,
 } from './evaluate_ppl_lint_fix_candidate';
 import type { PPLLintFixTestToolResult } from './evaluate_ppl_lint_fix_candidate';
-import { PPLLintFixCard, PPL_LINT_FIX_UI_BINDING } from './ppl_lint_fix_card';
-import type { BoundPPLLintFixToolArgs, PPLLintFixToolArgs } from './ppl_lint_fix_card';
+import { PPLLintFixCard, resolveApprovedRequestId } from './ppl_lint_fix_card';
+import type { PPLLintFixToolArgs } from './ppl_lint_fix_card';
 
 export type { PPLLintFixToolArgs } from './ppl_lint_fix_card';
 
@@ -98,7 +98,7 @@ export function createPPLLintFixApplyAction({
       // Confirmation clones the model args before invoking this handler. Bind that
       // clone back to the request captured by the card's Approve click, rather
       // than trusting a model-provided request id or object identity.
-      const capturedRequestId = (args as BoundPPLLintFixToolArgs)[PPL_LINT_FIX_UI_BINDING];
+      const capturedRequestId = resolveApprovedRequestId(args);
       if (!capturedRequestId) {
         return failure(
           'missing-request',

--- a/src/plugins/data/public/index.ts
+++ b/src/plugins/data/public/index.ts
@@ -722,12 +722,20 @@ export type {
   PPLLintFixCandidateEvaluation,
   PPLLintFixTestToolResult,
 } from './chat_tools/evaluate_ppl_lint_fix_candidate';
-export { PPLLintFixCard, PPL_LINT_FIX_UI_BINDING } from './chat_tools/ppl_lint_fix_card';
+export {
+  PPLLintFixCard,
+  PPL_LINT_FIX_UI_BINDING,
+  resolveApprovedRequestId,
+} from './chat_tools/ppl_lint_fix_card';
 export type {
   BoundPPLLintFixToolArgs,
   PPLLintFixCardProps,
   PPLLintFixToolArgs,
 } from './chat_tools/ppl_lint_fix_card';
+export type {
+  PPLLintFixApprovalArgs,
+  PPLLintFixRequestCategory,
+} from '../common/chat_tools/ppl_lint_fix_protocol';
 // Host-parameterized launch lifecycle: supersession of a prior request, a TTL
 // that expires an abandoned request, and serialized chat launches. Shared by
 // both editor hosts so Explore reuses it rather than reimplementing addContext

--- a/src/plugins/data/public/ui/query_editor/ppl_lint_fix_lifecycle.ts
+++ b/src/plugins/data/public/ui/query_editor/ppl_lint_fix_lifecycle.ts
@@ -5,10 +5,13 @@
 
 import { withTimeout } from '@osd/std';
 import type { AssistantContextStore } from '../../../../context_provider/public';
-import { cleanupPPLLintFixRequest } from '../../chat_tools/ppl_lint_fix_session';
+import {
+  cleanupPPLLintFixRequest,
+  createPPLLintFixApprovalNonce,
+} from '../../chat_tools/ppl_lint_fix_session';
 import {
   PPL_LINT_FIX_REQUEST_CATEGORY,
-  PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX,
+  PPL_LINT_FIX_APPROVAL_NONCE_CONTEXT_SUFFIX,
 } from '../../../common/chat_tools/ppl_lint_fix_protocol';
 import type { PPLLintFixHost } from '../../chat_tools/ppl_lint_fix_host';
 import type {
@@ -48,10 +51,10 @@ export function addPPLLintFixAssistantContext(
   });
 
   contextStore.addContext({
-    id: host.contextIdPrefix + request.requestId + PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX,
-    description: 'PPL lint quick-fix request id',
-    value: request.requestId,
-    label: 'PPL lint fix request id',
+    id: host.contextIdPrefix + request.requestId + PPL_LINT_FIX_APPROVAL_NONCE_CONTEXT_SUFFIX,
+    description: 'PPL lint quick-fix approval nonce',
+    value: createPPLLintFixApprovalNonce(request.requestId),
+    label: 'PPL lint fix approval nonce',
     categories: ['page', PPL_LINT_FIX_REQUEST_CATEGORY],
   });
 }

--- a/src/plugins/data/public/ui/query_editor/ppl_lint_fix_lifecycle.ts
+++ b/src/plugins/data/public/ui/query_editor/ppl_lint_fix_lifecycle.ts
@@ -6,6 +6,10 @@
 import { withTimeout } from '@osd/std';
 import type { AssistantContextStore } from '../../../../context_provider/public';
 import { cleanupPPLLintFixRequest } from '../../chat_tools/ppl_lint_fix_session';
+import {
+  PPL_LINT_FIX_REQUEST_CATEGORY,
+  PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX,
+} from '../../../common/chat_tools/ppl_lint_fix_protocol';
 import type { PPLLintFixHost } from '../../chat_tools/ppl_lint_fix_host';
 import type {
   AskPPLLintFixRequest,
@@ -41,6 +45,14 @@ export function addPPLLintFixAssistantContext(
     // clearConversation removes non-page contexts before sending the message.
     // Explicit request cleanup still removes this entry on every exit path.
     categories: ['page', 'chat', 'ppl-lint-fix'],
+  });
+
+  contextStore.addContext({
+    id: host.contextIdPrefix + request.requestId + PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX,
+    description: 'PPL lint quick-fix request id',
+    value: request.requestId,
+    label: 'PPL lint fix request id',
+    categories: ['page', PPL_LINT_FIX_REQUEST_CATEGORY],
   });
 }
 

--- a/src/plugins/explore/public/application/pages/logs/logs_query_panel.test.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_query_panel.test.tsx
@@ -95,6 +95,12 @@ jest.mock('../../../components/query_panel/query_panel_generated_query', () => (
 jest.mock('../../../components/query_panel/actions/ppl_execute_query_action', () => ({
   usePPLExecuteQueryAction: jest.fn(),
 }));
+// The action module builds PPL-lint-fix tool definitions from the data plugin at
+// load time and registers/cleans up assistant actions on mount/unmount; neither
+// is exercised here, so stub the hook.
+jest.mock('../../../components/query_panel/actions/ppl_lint_fix_action', () => ({
+  usePPLLintFixAction: jest.fn(),
+}));
 // Stubbed to a no-op thunk; the real action pulls in createHistogramConfigs
 // (data plugin) at module load.
 jest.mock('../../utils/state_management/actions/query_editor', () => ({

--- a/src/plugins/explore/public/application/pages/logs/logs_query_panel.tsx
+++ b/src/plugins/explore/public/application/pages/logs/logs_query_panel.tsx
@@ -13,6 +13,7 @@ import { QueryPanelWidgets } from '../../../components/query_panel/query_panel_w
 import { ExploreQueryPanelEditor } from '../../../components/query_panel/query_panel_editor';
 import { QueryPanelGeneratedQuery } from '../../../components/query_panel/query_panel_generated_query';
 import { usePPLExecuteQueryAction } from '../../../components/query_panel/actions/ppl_execute_query_action';
+import { usePPLLintFixAction } from '../../../components/query_panel/actions/ppl_lint_fix_action';
 import { useEditorRef, useEditorText, useSetEditorTextWithQuery } from '../../../application/hooks';
 import { useSetEditorText } from '../../../application/hooks/editor_hooks/use_set_editor_text/use_set_editor_text';
 import {
@@ -74,6 +75,7 @@ export const LogsQueryPanel: React.FC<LogsQueryPanelProps> = ({
   const setEditorTextWithQuery = useSetEditorTextWithQuery();
   const setEditorText = useSetEditorText();
   usePPLExecuteQueryAction(setEditorTextWithQuery);
+  usePPLLintFixAction(setEditorTextWithQuery);
 
   const { queryString } = services.data.query;
 

--- a/src/plugins/explore/public/components/query_panel/actions/ppl_lint_fix_action.tsx
+++ b/src/plugins/explore/public/components/query_panel/actions/ppl_lint_fix_action.tsx
@@ -15,20 +15,18 @@ import {
   PPLLintFixCard,
   PPL_LINT_FIX_APPLY_PARAMETERS,
   PPL_LINT_FIX_TEST_PARAMETERS,
-  PPL_LINT_FIX_UI_BINDING,
+  resolveApprovedRequestId,
   runPPLLintFixTestTool,
 } from '../../../../../data/public';
-import type {
-  BoundPPLLintFixToolArgs,
-  PPLLintFixCardProps,
-  RemovePPLLintFixContextById,
-} from '../../../../../data/public';
+import type { PPLLintFixCardProps, RemovePPLLintFixContextById } from '../../../../../data/public';
 import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { ExploreServices } from '../../../types';
 import { useSetEditorTextWithQuery } from '../../../application/hooks';
 import { PPL_LINT_FIX_EXPLORE_HOST } from './ppl_lint_fix_host';
 
 const HOST = PPL_LINT_FIX_EXPLORE_HOST;
+
+let enabledActionMounts = 0;
 
 interface ApplyPPLLintFixArgs {
   requestId?: string;
@@ -140,6 +138,7 @@ export function usePPLLintFixAction(
 
   useMount(() => {
     if (!registerAction) return;
+    enabledActionMounts += 1;
 
     registerAction({
       ...TEST_PPL_LINT_FIX_EXPLORE_TOOL_DEFINITION,
@@ -173,7 +172,7 @@ export function usePPLLintFixAction(
           // frequently filled those with the wrong values (e.g. the rule name or
           // the query text), which tripped a false stale-request and, because a
           // failure result prompts a retry, sent the model into a tool-call loop.
-          const capturedRequestId = (args as BoundPPLLintFixToolArgs)[PPL_LINT_FIX_UI_BINDING];
+          const capturedRequestId = resolveApprovedRequestId(args);
           // Fail closed: a confirmed call with no card-approval binding must
           // refuse rather than apply against whatever session happens to be
           // active. getPPLLintFixSession(undefined) returns the active session,
@@ -244,8 +243,11 @@ export function usePPLLintFixAction(
 
   useUnmount(() => {
     if (registerAction) {
-      registerDisabledPPLLintFixTestAction(registerAction);
-      registerDisabledPPLLintFixAction(registerAction);
+      enabledActionMounts = Math.max(0, enabledActionMounts - 1);
+      if (enabledActionMounts === 0) {
+        registerDisabledPPLLintFixTestAction(registerAction);
+        registerDisabledPPLLintFixAction(registerAction);
+      }
     }
     const requestId = getPPLLintFixSession()?.request.requestId;
     if (requestId) {

--- a/src/plugins/explore/public/components/query_panel/actions/ppl_lint_fix_action.tsx
+++ b/src/plugins/explore/public/components/query_panel/actions/ppl_lint_fix_action.tsx
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { useRef } from 'react';
 import { useMount, useUnmount } from 'react-use';
 import {
   buildApplyToolDescription,
@@ -136,8 +137,11 @@ export function usePPLLintFixAction(
     store?.removeContextById?.(contextId);
   };
 
+  const didRegister = useRef(false);
+
   useMount(() => {
     if (!registerAction) return;
+    didRegister.current = true;
     enabledActionMounts += 1;
 
     registerAction({
@@ -242,9 +246,10 @@ export function usePPLLintFixAction(
   });
 
   useUnmount(() => {
-    if (registerAction) {
+    if (didRegister.current) {
+      didRegister.current = false;
       enabledActionMounts = Math.max(0, enabledActionMounts - 1);
-      if (enabledActionMounts === 0) {
+      if (enabledActionMounts === 0 && registerAction) {
         registerDisabledPPLLintFixTestAction(registerAction);
         registerDisabledPPLLintFixAction(registerAction);
       }


### PR DESCRIPTION
### Description

This PR enables PPL lint quick-fixes to be applied by the chat assistant across window boundaries, without coupling the data/explore plugins to core chat internals, and exposes the chat plugin's configured agent IDs so other plugins can consume them.

Cross-window PPL fix apply

- context_provider — Extends the ContextProviderStart.actions contract with getToolDefinitions(), hasAction(name), and executeAction(name, args), so consumers can discover and invoke registered assistant actions by name instead of holding direct references. The no-op stub (used when the service is unavailable) implements the same three methods.
- data (PPL lint fix) — Adds a dedicated request-id context entry (PPL_LINT_FIX_REQUEST_ID_CONTEXT_SUFFIX) under a new PPL_LINT_FIX_REQUEST_CATEGORY so the approved request id travels with the assistant context and can be recovered in another window. cleanupPPLLintFixRequest now removes this extra entry on every exit path. The tool handler falls back to an __approvedRequestId arg when the in-window UI binding (PPL_LINT_FIX_UI_BINDING) is absent, so a fix approved in one window still binds to the correct request. Both the data tool registration and the explore action apply this same fallback.
- explore — Wires usePPLLintFixAction into the Logs query panel. The enabled/disabled action registration is now reference-counted (enabledActionMounts) so the disabled stubs are only re-registered when the last mounted action unmounts, preventing a still-mounted panel from having its action disabled out from under it.
- core/public — Re-exports UserMessage and InputContent chat types.

Expose configured agent IDs

- chat — ChatPlugin.setup() now returns mlCommonsAgentId and observabilityAgentId (from config) instead of an empty object, and ChatPluginSetup declares these optional fields, letting other plugins consume the configured agent IDs from the setup contract.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
