### PR TITLE
[PPL Linter] Scope PPL lint AI-fix tools to an active fix flow

### DIFF
--- a/changelogs/fragments/12650.yml
+++ b/changelogs/fragments/12650.yml
@@ -1,0 +1,2 @@
+fix:
+- Scope PPL lint AI-fix assistant tools to an active fix flow ([#12650](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12650))

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_session.test.ts
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_session.test.ts
@@ -4,13 +4,16 @@
  */
 
 import {
+  armPPLLintFixRequest,
   cleanupPPLLintFixRequest,
   clearPPLLintFixSession,
   getPPLLintFixOutcome,
   getPPLLintFixSession,
+  isPPLLintFixFlowActive,
   markPPLLintFixApplied,
   markPPLLintFixDismissed,
   storePPLLintFixSession,
+  subscribePPLLintFixOutcome,
 } from './ppl_lint_fix_session';
 import { PPL_LINT_FIX_DATA_HOST } from './ppl_lint_fix_tool_registration';
 
@@ -82,5 +85,71 @@ describe('PPL lint fix session', () => {
 
     expect(getPPLLintFixOutcome('request-a')).toEqual({ kind: 'dismissed' });
     expect(getPPLLintFixOutcome('request-b')).toEqual({ kind: 'applied' });
+  });
+});
+
+describe('PPL lint fix flow-active gate', () => {
+  const REQ = 'flow-req';
+
+  // No public "disarm all"; reset the id these tests use, then the session.
+  const reset = () => {
+    cleanupPPLLintFixRequest(REQ, PREFIX);
+    clearPPLLintFixSession();
+  };
+  beforeEach(reset);
+  afterEach(reset);
+
+  it('is inactive when nothing is armed and no session exists', () => {
+    expect(isPPLLintFixFlowActive()).toBe(false);
+  });
+
+  it('becomes active once a request is armed, before any session is stored', () => {
+    armPPLLintFixRequest(REQ);
+    expect(isPPLLintFixFlowActive()).toBe(true);
+    expect(getPPLLintFixSession()).toBeUndefined();
+  });
+
+  it('stays active after the session is stored', () => {
+    armPPLLintFixRequest(REQ);
+    storePPLLintFixSession(createSession(REQ));
+    expect(isPPLLintFixFlowActive()).toBe(true);
+  });
+
+  it('is active from a stored session even without an explicit arm', () => {
+    storePPLLintFixSession(createSession(REQ));
+    expect(isPPLLintFixFlowActive()).toBe(true);
+  });
+
+  it('goes inactive after cleanup disarms and clears the request', () => {
+    armPPLLintFixRequest(REQ);
+    storePPLLintFixSession(createSession(REQ));
+    cleanupPPLLintFixRequest(REQ, PREFIX);
+    expect(isPPLLintFixFlowActive()).toBe(false);
+  });
+
+  it('disarms even when the request never reached a stored session', () => {
+    armPPLLintFixRequest(REQ);
+    expect(isPPLLintFixFlowActive()).toBe(true);
+    cleanupPPLLintFixRequest(REQ, PREFIX);
+    expect(isPPLLintFixFlowActive()).toBe(false);
+  });
+
+  it('notifies subscribers on arm and on cleanup', () => {
+    const callback = jest.fn();
+    const unsubscribe = subscribePPLLintFixOutcome(callback);
+    armPPLLintFixRequest(REQ);
+    expect(callback).toHaveBeenCalledTimes(1);
+    cleanupPPLLintFixRequest(REQ, PREFIX);
+    expect(callback).toHaveBeenCalledTimes(2);
+    unsubscribe();
+  });
+
+  it('arming the same request twice notifies only once', () => {
+    const callback = jest.fn();
+    const unsubscribe = subscribePPLLintFixOutcome(callback);
+    armPPLLintFixRequest(REQ);
+    armPPLLintFixRequest(REQ);
+    expect(callback).toHaveBeenCalledTimes(1);
+    unsubscribe();
   });
 });

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_session.ts
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_session.ts
@@ -30,6 +30,10 @@ export interface PPLLintFixSession {
 
 let activeSession: PPLLintFixSession | undefined;
 
+// Requests in an active AI lint-fix flow, armed in onAskAiFix before the chat send
+// (chat snapshots tools at send time); disarmed by cleanupPPLLintFixRequest.
+const armedRequests = new Set<string>();
+
 /**
  * Terminal outcome of a request, driven directly by the card's Apply/Dismiss click
  * and the apply handler — NOT by the framework's tool-call status. The framework
@@ -103,6 +107,18 @@ export function subscribePPLLintFixOutcome(callback: () => void): () => void {
   return () => outcomeSubscribers.delete(callback);
 }
 
+export function armPPLLintFixRequest(requestId: string): void {
+  if (!armedRequests.has(requestId)) {
+    armedRequests.add(requestId);
+    notifyOutcomeSubscribers();
+  }
+}
+
+// True while a lint-fix flow is active; gates the tool registration, not lint itself.
+export function isPPLLintFixFlowActive(): boolean {
+  return armedRequests.size > 0 || activeSession !== undefined;
+}
+
 export function getPPLLintFixSession(requestId?: string): PPLLintFixSession | undefined {
   // With no requestId, return the single active session. Callers no longer key on
   // a model-provided requestId (weak models fill it with wrong values); the active
@@ -136,6 +152,10 @@ export function cleanupPPLLintFixRequest(
   try {
     removeContextById?.(contextIdPrefix + requestId);
   } finally {
+    // Disarm on every exit path.
+    if (armedRequests.delete(requestId)) {
+      notifyOutcomeSubscribers();
+    }
     clearPPLLintFixSession(requestId);
   }
 }

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.test.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.test.tsx
@@ -9,6 +9,8 @@ import { hasExplainOutcome } from '@osd/monaco/target/ppl/lint/explain/explain_o
 import { explainCache } from '@osd/monaco/target/ppl/lint/explain/explain_cache';
 import { buildPerformanceFixProbeQueries } from '../ppl_lint/performance_fix_revalidation';
 import {
+  createPPLLintFixApplyAction,
+  createPPLLintFixTestAction,
   PPLLintFixToolArgs,
   PPLLintFixToolRegistration,
   PPLLintFixTestToolRegistration,
@@ -18,12 +20,14 @@ import {
   PPL_LINT_FIX_TEST_DATA_TOOL_NAME,
 } from './ppl_lint_fix_tool_registration';
 import {
+  cleanupPPLLintFixRequest,
   clearPPLLintFixSession,
   getPPLLintFixOutcome,
   getPPLLintFixSession,
   storePPLLintFixSession,
 } from './ppl_lint_fix_session';
 import { PPL_LINT_FIX_UI_BINDING } from './ppl_lint_fix_card';
+import { AssistantActionService } from '../../../context_provider/public/services/assistant_action_service';
 
 jest.mock('@osd/monaco', () => ({
   validatePPLLintFixCandidate: jest.fn(),
@@ -161,6 +165,42 @@ describe('PPLLintFixToolRegistration', () => {
     const config = renderRegistration(false);
 
     expect(config.enabled).toBe(false);
+  });
+
+  it('stays recoverable when cleanup clears the session while an Apply confirmation is pending', async () => {
+    // Reviewer concern (CR): TTL expiry or editor unmount can fire cleanup while an Apply
+    // confirmation is pending. Confirm the request still reaches a terminal, recoverable
+    // outcome instead of leaving the card stuck.
+    const config = renderRegistration();
+    storeSession();
+
+    const args = { fixedQuery: 'source=logs | head 10' } as PPLLintFixToolArgs;
+    const card = render(
+      <>{config.render({ status: 'executing', args, onApprove: jest.fn(), onReject: jest.fn() })}</>
+    );
+    // The user clicks Apply (binding the captured request id onto the tool args)...
+    fireEvent.click(card.getByText('Apply to editor'));
+    // ...but cleanup races in and clears the session before the handler runs.
+    act(() =>
+      cleanupPPLLintFixRequest(
+        request.requestId,
+        PPL_LINT_FIX_DATA_CONTEXT_ID_PREFIX,
+        removeContextById
+      )
+    );
+    expect(getPPLLintFixSession()).toBeUndefined();
+
+    let result: unknown;
+    await act(async () => {
+      result = await config.handler(args);
+    });
+
+    // Recovery: a terminal missing-request failure is returned and recorded as the outcome,
+    // so the card resolves rather than hanging on the vanished session.
+    expect(result).toEqual(expect.objectContaining({ success: false, reason: 'missing-request' }));
+    expect(getPPLLintFixOutcome(request.requestId)).toEqual(
+      expect.objectContaining({ kind: 'failed' })
+    );
   });
 
   it('rejects a missing active request', async () => {
@@ -1142,5 +1182,25 @@ describe('PPLLintFixToolRegistration', () => {
 
       expect(result).toEqual(expect.objectContaining({ ok: false, reason: 'missing-request' }));
     });
+  });
+});
+
+describe('synchronous imperative registration', () => {
+  // Reviewer concern (CR): arming registers the tools in a post-commit effect, which can
+  // land after the chat send snapshots the tool list. onAskAiFix instead registers them
+  // synchronously via the same action service; confirm they are visible immediately.
+  it('exposes both fix tools in the tool list as soon as they are registered', () => {
+    const service = AssistantActionService.getInstance();
+    const queryString = { getQuery: jest.fn(), setQuery: jest.fn() } as any;
+
+    service.registerAction(createPPLLintFixApplyAction({ queryString }));
+    service.registerAction(createPPLLintFixTestAction());
+
+    const toolNames = service.getToolDefinitions().map((tool) => tool.name);
+    expect(toolNames).toContain(PPL_LINT_FIX_DATA_TOOL_NAME);
+    expect(toolNames).toContain(PPL_LINT_FIX_TEST_DATA_TOOL_NAME);
+
+    service.unregisterAction(PPL_LINT_FIX_DATA_TOOL_NAME);
+    service.unregisterAction(PPL_LINT_FIX_TEST_DATA_TOOL_NAME);
   });
 });

--- a/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.tsx
+++ b/src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import type { ContextProviderStart } from '../../../context_provider/public';
+import type { AssistantAction, ContextProviderStart } from '../../../context_provider/public';
 import type { QueryStringContract } from '../query/query_string';
 import {
   cleanupPPLLintFixRequest,
@@ -76,17 +76,20 @@ const failure = (
   ...extra,
 });
 
-export const PPLLintFixToolRegistration: React.FC<PPLLintFixToolRegistrationProps> = ({
+/**
+ * Build the apply-tool action. Extracted from the component so it can also be registered
+ * imperatively (synchronously, before a chat send) — see `onAskAiFix` — which avoids
+ * depending on the search bar's post-commit registration effect.
+ */
+export function createPPLLintFixApplyAction({
   queryString,
-  useAssistantAction,
   removeContextById,
-  enabled = true,
-}) => {
-  const useAssistantActionHook = useAssistantAction || noopUseAssistantAction;
-
-  useAssistantActionHook<PPLLintFixToolArgs>({
+}: {
+  queryString: QueryStringContract;
+  removeContextById?: RemovePPLLintFixContextById;
+}): AssistantAction<PPLLintFixToolArgs> {
+  return {
     name: PPL_LINT_FIX_DATA_HOST.applyToolName,
-    enabled,
     description: buildApplyToolDescription(PPL_LINT_FIX_DATA_HOST),
     parameters: PPL_LINT_FIX_APPLY_PARAMETERS,
     requiresConfirmation: true,
@@ -181,6 +184,20 @@ export const PPLLintFixToolRegistration: React.FC<PPLLintFixToolRegistrationProp
         testSubjPrefix="pplLintFix"
       />
     ),
+  };
+}
+
+export const PPLLintFixToolRegistration: React.FC<PPLLintFixToolRegistrationProps> = ({
+  queryString,
+  useAssistantAction,
+  removeContextById,
+  enabled = true,
+}) => {
+  const useAssistantActionHook = useAssistantAction || noopUseAssistantAction;
+
+  useAssistantActionHook<PPLLintFixToolArgs>({
+    ...createPPLLintFixApplyAction({ queryString, removeContextById }),
+    enabled,
   });
 
   return null;
@@ -198,16 +215,13 @@ export interface PPLLintFixTestToolArgs {
  * best of several candidate fixes — and to decide, when none clear, that it should
  * tell the user it cannot fix the query rather than propose one that would be
  * summarily rejected.
+ *
+ * Extracted as a factory (alongside {@link createPPLLintFixApplyAction}) so it can also be
+ * registered synchronously before a chat send.
  */
-export const PPLLintFixTestToolRegistration: React.FC<PPLLintFixToolRegistrationProps> = ({
-  useAssistantAction,
-  enabled = true,
-}) => {
-  const useAssistantActionHook = useAssistantAction || noopUseAssistantAction;
-
-  useAssistantActionHook<PPLLintFixTestToolArgs>({
+export function createPPLLintFixTestAction(): AssistantAction<PPLLintFixTestToolArgs> {
+  return {
     name: PPL_LINT_FIX_DATA_HOST.testToolName,
-    enabled,
     description: buildTestToolDescription(PPL_LINT_FIX_DATA_HOST),
     parameters: PPL_LINT_FIX_TEST_PARAMETERS,
     // No confirmation and no custom renderer: this tool must run silently and
@@ -215,6 +229,18 @@ export const PPLLintFixTestToolRegistration: React.FC<PPLLintFixToolRegistration
     requiresConfirmation: false,
     handler: async (args): Promise<PPLLintFixTestToolResult> =>
       runPPLLintFixTestTool(args.fixedQuery),
+  };
+}
+
+export const PPLLintFixTestToolRegistration: React.FC<PPLLintFixToolRegistrationProps> = ({
+  useAssistantAction,
+  enabled = true,
+}) => {
+  const useAssistantActionHook = useAssistantAction || noopUseAssistantAction;
+
+  useAssistantActionHook<PPLLintFixTestToolArgs>({
+    ...createPPLLintFixTestAction(),
+    enabled,
   });
 
   return null;

--- a/src/plugins/data/public/chat_tools/use_ppl_lint_fix_flow_active.ts
+++ b/src/plugins/data/public/chat_tools/use_ppl_lint_fix_flow_active.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import { isPPLLintFixFlowActive, subscribePPLLintFixOutcome } from './ppl_lint_fix_session';
+
+// Re-renders when a lint-fix flow arms/clears, gating the tool registration to an active
+// fix. Timing to verify at runtime: tools register via useEffect (post-commit) but chat
+// snapshots tools at send time; onAskAiFix arms before sending.
+export function useIsPPLLintFixFlowActive(): boolean {
+  const [active, setActive] = useState<boolean>(() => isPPLLintFixFlowActive());
+
+  useEffect(() => {
+    const sync = () => setActive(isPPLLintFixFlowActive());
+    sync();
+    return subscribePPLLintFixOutcome(sync);
+  }, []);
+
+  return active;
+}

--- a/src/plugins/data/public/ui/query_editor/query_editor.tsx
+++ b/src/plugins/data/public/ui/query_editor/query_editor.tsx
@@ -56,8 +56,15 @@ import {
 import { fetchDisabledObjectFields } from '../../ppl_lint/disabled_object_fields';
 import { fetchVisibleIndices } from '../../ppl_lint/visible_indices';
 import { getAiAgentAvailableForDataSource } from '../../ppl_lint/ai_agent_availability';
-import { storePPLLintFixSession } from '../../chat_tools/ppl_lint_fix_session';
-import { PPL_LINT_FIX_DATA_HOST } from '../../chat_tools/ppl_lint_fix_tool_registration';
+import {
+  armPPLLintFixRequest,
+  storePPLLintFixSession,
+} from '../../chat_tools/ppl_lint_fix_session';
+import {
+  createPPLLintFixApplyAction,
+  createPPLLintFixTestAction,
+  PPL_LINT_FIX_DATA_HOST,
+} from '../../chat_tools/ppl_lint_fix_tool_registration';
 import type { AskPPLLintFixRequest } from '../../chat_tools/ppl_lint_fix_session';
 import { addPPLLintFixAssistantContext, PPLLintFixLifecycle } from './ppl_lint_fix_lifecycle';
 
@@ -174,6 +181,8 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
 
   function onAskAiFix(request: AskPPLLintFixRequest): void {
     pplLintFixLifecycle.beginRequest(request.requestId);
+    // Arm before the chat send so the tools register for this fix turn.
+    armPPLLintFixRequest(request.requestId);
     const session = {
       host: PPL_LINT_FIX_DATA_HOST,
       request,
@@ -199,6 +208,20 @@ export const QueryEditorUI: React.FC<Props> = (props) => {
     // the short human message (request.chatMessage). Keyed by requestId.
     const contextStore = services.contextProvider?.getAssistantContextStore?.();
     addPPLLintFixAssistantContext(request, contextStore, PPL_LINT_FIX_DATA_HOST);
+
+    // Register the fix tools synchronously here, before the send below snapshots the
+    // available tools. Arming flips the search bar's flow-active flag, but that registers
+    // the tools in a post-commit effect, which can land after the send when the chat window
+    // is already open. Registering to the same action service (idempotent by name) closes
+    // that race; <PPLLintFixToolRegistration> still owns the reactive unregister on cleanup.
+    const contextProviderActions = services.contextProvider?.actions;
+    if (contextProviderActions) {
+      const removeContextById = (contextId: string) => contextStore?.removeContextById(contextId);
+      contextProviderActions.registerAssistantAction(
+        createPPLLintFixApplyAction({ queryString, removeContextById })
+      );
+      contextProviderActions.registerAssistantAction(createPPLLintFixTestAction());
+    }
 
     void pplLintFixLifecycle
       .waitForChatLaunch(request.requestId, () =>

--- a/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
+++ b/src/plugins/data/public/ui/search_bar/create_search_bar.tsx
@@ -46,6 +46,7 @@ import {
   PPLLintFixTestToolRegistration,
   PPL_LINT_FIX_DATA_TOOL_NAME,
 } from '../../chat_tools/ppl_lint_fix_tool_registration';
+import { useIsPPLLintFixFlowActive } from '../../chat_tools/use_ppl_lint_fix_flow_active';
 import { ContextProviderStart } from '../../../../../plugins/context_provider/public';
 
 interface StatefulSearchBarDeps {
@@ -151,6 +152,9 @@ export function createSearchBar({ core, storage, data, contextProvider }: Statef
     const pplLintFixEnabled = Boolean(
       contextProvider?.hooks?.useAssistantAction && props.showQueryInput !== false
     );
+    // Register the apply/test tools only during an active fix flow, so an unrelated agent
+    // turn can't call test_ppl_lint_fix_data with no session (missing-request).
+    const pplLintFixFlowActive = useIsPPLLintFixFlowActive();
 
     // Handle queries
     const onQuerySubmitRef = useRef(props.onQuerySubmit);
@@ -214,12 +218,12 @@ export function createSearchBar({ core, storage, data, contextProvider }: Statef
           queryString={data.query.queryString}
           useAssistantAction={contextProvider?.hooks?.useAssistantAction}
           removeContextById={removePPLLintFixContextById}
-          enabled={pplLintFixEnabled}
+          enabled={pplLintFixEnabled && pplLintFixFlowActive}
         />
         <PPLLintFixTestToolRegistration
           queryString={data.query.queryString}
           useAssistantAction={contextProvider?.hooks?.useAssistantAction}
-          enabled={pplLintFixEnabled}
+          enabled={pplLintFixEnabled && pplLintFixFlowActive}
         />
         <SearchBar
           showAutoRefreshOnly={props.showAutoRefreshOnly}


### PR DESCRIPTION
### Description

The `apply_ppl_lint_fix_data` / `test_ppl_lint_fix_data` assistant tools were registered whenever the Discover search bar and assistant context existed — decoupled from whether a lint fix was actually in progress. They were therefore advertised to the assistant on **every** turn, so any unrelated agent turn that called `test_ppl_lint_fix_data` with no active session received a `missing-request` result, polluting that feature's analysis.

This PR gates tool registration on an active lint-fix flow:

- `ppl_lint_fix_session.ts`: `armedRequests` set + `armPPLLintFixRequest` + `isPPLLintFixFlowActive`; disarm in `cleanupPPLLintFixRequest` (the universal terminal for every exit path).
- `use_ppl_lint_fix_flow_active.ts` (new): reactive hook exposing the flow-active signal.
- `query_editor.tsx`: arm the request in `onAskAiFix` and register the apply/test tools **synchronously** before the chat send, so the first fix never snapshots the tool list before registration lands (avoids relying on `useEffect` timing when the chat window is already open).
- `create_search_bar.tsx`: register the apply/test tools only when the feature is enabled **and** a fix flow is active.

The lint engine, lint markers/hover, and the "Ask AI" action stay feature-level and are unaffected.

### Issues Resolved

Follow-up hardening for the PPL lint AI-fix feature introduced in #12465.

## Screenshot

https://github.com/user-attachments/assets/4b427724-3108-4e3c-8b2e-9b5db7128b2d


## Testing the changes

- `yarn test:jest src/plugins/data/public/chat_tools/ppl_lint_fix_session.test.ts`
- `yarn test:jest src/plugins/data/public/chat_tools/ppl_lint_fix_tool_registration.test.tsx`
- Manual: open Discover, trigger a PPL lint error, click **Quick fix with AI** — the apply/test tools register only for that flow; unrelated assistant turns no longer see them and no longer produce `missing-request`.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
