### PR TITLE
[Dashboard] Collapsible dashboard sections behind a feature flag

### DIFF
--- a/src/plugins/dashboard/config.ts
+++ b/src/plugins/dashboard/config.ts
@@ -32,6 +32,11 @@ import { schema, TypeOf } from '@osd/config-schema';
 
 export const configSchema = schema.object({
   allowByValueEmbeddables: schema.boolean({ defaultValue: false }),
+  // Dashboard collapsible sections. Off by default; gates all
+  // section write paths (factory registration, "Add section" menu entry, and
+  // the move/change-section action). No saved-object migration is registered,
+  // so toggling this never mutates stored dashboards.
+  allowDashboardSections: schema.boolean({ defaultValue: false }),
   variables: schema.object({
     enabled: schema.boolean({ defaultValue: true }),
   }),

--- a/src/plugins/dashboard/public/application/actions/add_panel_to_section_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/add_panel_to_section_action.tsx
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Section support (Option 1): a section-only context-menu action that opens the
+// add-panel-to-section flyout (appears in the section container's kebab / More
+// menu). The same flyout is offered as an in-body call-to-action when an
+// expanded section is empty (see DashboardGrid/DashboardSectionGrid).
+
+import { i18n } from '@osd/i18n';
+import React from 'react';
+import { CoreStart } from 'src/core/public';
+import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
+import { IEmbeddable, ViewMode, EmbeddableStart } from '../../../../embeddable/public';
+import { ActionByType, IncompatibleActionError } from '../../../../ui_actions/public';
+import { DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '../embeddable';
+import { isSectionEmbeddable } from '../embeddable/section';
+import { openAddPanelToSectionFlyout } from './add_panel_to_section_flyout';
+
+export const ACTION_ADD_PANEL_TO_SECTION = 'addPanelToSection';
+
+export interface AddPanelToSectionActionContext {
+  embeddable: IEmbeddable;
+}
+
+export class AddPanelToSectionAction implements ActionByType<typeof ACTION_ADD_PANEL_TO_SECTION> {
+  public readonly type = ACTION_ADD_PANEL_TO_SECTION;
+  public readonly id = ACTION_ADD_PANEL_TO_SECTION;
+  // Sits just above "Move to section" (44) in the section's menu.
+  public order = 43;
+
+  constructor(
+    private core: CoreStart,
+    private savedObjectFinder: React.ComponentType<any>,
+    private getEmbeddableFactories: EmbeddableStart['getEmbeddableFactories']
+  ) {}
+
+  public getDisplayName() {
+    return i18n.translate('dashboard.section.addPanel.actionLabel', {
+      defaultMessage: 'Add existing visualization',
+    });
+  }
+
+  public getIconType(): EuiIconType {
+    return 'plusInCircle';
+  }
+
+  public async isCompatible({ embeddable }: AddPanelToSectionActionContext) {
+    // Only for a section container, in edit mode, inside a dashboard.
+    if (!isSectionEmbeddable(embeddable)) {
+      return false;
+    }
+    const root = embeddable.getRoot();
+    return Boolean(
+      root &&
+      root.isContainer &&
+      root.type === DASHBOARD_CONTAINER_TYPE &&
+      embeddable.getInput()?.viewMode !== ViewMode.VIEW
+    );
+  }
+
+  public async execute({ embeddable }: AddPanelToSectionActionContext) {
+    if (!isSectionEmbeddable(embeddable)) {
+      throw new IncompatibleActionError();
+    }
+    const container = embeddable.getRoot() as DashboardContainer;
+    openAddPanelToSectionFlyout({
+      overlays: this.core.overlays,
+      notifications: this.core.notifications,
+      container,
+      sectionId: embeddable.id,
+      savedObjectFinder: this.savedObjectFinder,
+      getEmbeddableFactories: this.getEmbeddableFactories,
+    });
+  }
+}

--- a/src/plugins/dashboard/public/application/actions/add_panel_to_section_flyout.tsx
+++ b/src/plugins/dashboard/public/application/actions/add_panel_to_section_flyout.tsx
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Section support (Option 1): a dashboard-scoped "add existing panel to a
+// section" flyout. The generic embeddable add-panel flyout adds panels at the
+// top level with no section awareness, so this small flyout reuses the same
+// SavedObjectFinder but, on choose, adds the embeddable and then relocates it
+// INTO the target section (relocatePanelToSection edits the section's
+// explicitInput.members). Modeled on ReplacePanelFlyout.
+
+import { i18n } from '@osd/i18n';
+import React from 'react';
+import { EuiFlyoutBody, EuiFlyoutHeader, EuiTitle } from '@elastic/eui';
+import { NotificationsStart, OverlayStart, Toast } from 'src/core/public';
+import { toMountPoint } from '../../../../opensearch_dashboards_react/public';
+import { DashboardContainer } from '../embeddable';
+import { EmbeddableStart, SavedObjectEmbeddableInput } from '../../../../embeddable/public';
+import { relocatePanelToSection } from './move_panel_to_section_action';
+
+interface Props {
+  container: DashboardContainer;
+  sectionId: string;
+  savedObjectsFinder: React.ComponentType<any>;
+  onClose: () => void;
+  notifications: NotificationsStart;
+  getEmbeddableFactories: EmbeddableStart['getEmbeddableFactories'];
+}
+
+class AddPanelToSectionFlyout extends React.Component<Props> {
+  private lastToast: Toast = { id: 'addPanelToSectionToast' };
+
+  private showToast = (name: string) => {
+    if (this.lastToast) {
+      this.props.notifications.toasts.remove(this.lastToast);
+    }
+    this.lastToast = this.props.notifications.toasts.addSuccess({
+      title: i18n.translate('dashboard.section.addPanel.addedToSectionSuccess', {
+        defaultMessage: '{name} was added to the section',
+        values: { name },
+      }),
+      'data-test-subj': 'addObjectToSectionSuccess',
+    });
+  };
+
+  private onAddPanel = async (savedObjectId: string, type: string, name: string) => {
+    const { container, sectionId } = this.props;
+    // The new panel is created at the top level, then relocated into the
+    // section (added to the section's explicitInput.members at an open
+    // section-relative slot). Its own gridData stays its absolute home.
+    const { id } = await container.addNewEmbeddable<SavedObjectEmbeddableInput>(type, {
+      savedObjectId,
+    });
+    const newPanels = relocatePanelToSection(id, sectionId, container.getInput().panels);
+    container.updateInput({ panels: newPanels });
+    this.showToast(name);
+    this.props.onClose();
+  };
+
+  public render() {
+    const SavedObjectFinder = this.props.savedObjectsFinder;
+    return (
+      <>
+        <EuiFlyoutHeader hasBorder>
+          <EuiTitle size="m">
+            <h2>
+              {i18n.translate('dashboard.section.addPanel.flyoutTitle', {
+                defaultMessage: 'Add panel to section',
+              })}
+            </h2>
+          </EuiTitle>
+        </EuiFlyoutHeader>
+        <EuiFlyoutBody>
+          <SavedObjectFinder
+            noItemsMessage={i18n.translate('dashboard.addPanel.noMatchingObjectsMessage', {
+              defaultMessage: 'No matching objects found.',
+            })}
+            savedObjectMetaData={[...this.props.getEmbeddableFactories()]
+              .filter(
+                (embeddableFactory) =>
+                  Boolean(embeddableFactory.savedObjectMetaData) &&
+                  !embeddableFactory.isContainerType
+              )
+              .map(({ savedObjectMetaData }) => savedObjectMetaData as any)}
+            showFilter={true}
+            onChoose={this.onAddPanel}
+          />
+        </EuiFlyoutBody>
+      </>
+    );
+  }
+}
+
+export function openAddPanelToSectionFlyout(options: {
+  overlays: OverlayStart;
+  notifications: NotificationsStart;
+  container: DashboardContainer;
+  sectionId: string;
+  savedObjectFinder: React.ComponentType<any>;
+  getEmbeddableFactories: EmbeddableStart['getEmbeddableFactories'];
+}) {
+  const {
+    overlays,
+    notifications,
+    container,
+    sectionId,
+    savedObjectFinder,
+    getEmbeddableFactories,
+  } = options;
+  const flyoutSession = overlays.openFlyout(
+    toMountPoint(
+      <AddPanelToSectionFlyout
+        container={container}
+        sectionId={sectionId}
+        savedObjectsFinder={savedObjectFinder}
+        notifications={notifications}
+        getEmbeddableFactories={getEmbeddableFactories}
+        onClose={() => flyoutSession.close()}
+      />
+    ),
+    { 'data-test-subj': 'dashboardAddPanelToSection', ownFocus: true }
+  );
+}

--- a/src/plugins/dashboard/public/application/actions/add_to_library_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/add_to_library_action.tsx
@@ -43,6 +43,7 @@ import {
   IEmbeddable,
 } from '../../../../embeddable/public';
 import { DashboardPanelState, DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '..';
+import { isSectionEmbeddable } from '../embeddable/section';
 
 export const ACTION_ADD_TO_LIBRARY = 'addToFromLibrary';
 
@@ -81,7 +82,10 @@ export class AddToLibraryAction implements ActionByType<typeof ACTION_ADD_TO_LIB
       embeddable.getRoot().isContainer &&
       embeddable.getRoot().type === DASHBOARD_CONTAINER_TYPE &&
       isReferenceOrValueEmbeddable(embeddable) &&
-      !embeddable.inputIsRefType(embeddable.getInput())
+      !embeddable.inputIsRefType(embeddable.getInput()) &&
+      // A section is not a library-backed content panel (defensive; a section
+      // is not a reference-or-value embeddable either).
+      !isSectionEmbeddable(embeddable)
     );
   }
 

--- a/src/plugins/dashboard/public/application/actions/clone_panel_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/clone_panel_action.test.tsx
@@ -42,6 +42,7 @@ import { getSampleDashboardInput, getSampleDashboardPanel } from '../test_helper
 import { coreMock } from '../../../../../core/public/mocks';
 import { CoreStart } from 'opensearch-dashboards/public';
 import { ClonePanelAction } from '.';
+import { DASHBOARD_SECTION_EMBEDDABLE } from '../embeddable/section';
 
 const { setup, doStart } = embeddablePluginMock.createInstance();
 setup.registerEmbeddableFactory(
@@ -107,6 +108,16 @@ test('Clone is incompatible with Error Embeddables', async () => {
     embeddable.getRoot() as IContainer
   );
   expect(await action.isCompatible({ embeddable: errorEmbeddable })).toBe(false);
+});
+
+test('Clone is incompatible with a section embeddable', async () => {
+  const action = new ClonePanelAction(coreStart);
+  const sectionEmbeddable = Object.assign(
+    Object.create(Object.getPrototypeOf(embeddable)),
+    embeddable,
+    { type: DASHBOARD_SECTION_EMBEDDABLE }
+  );
+  expect(await action.isCompatible({ embeddable: sectionEmbeddable })).toBe(false);
 });
 
 test('Clone adds a new embeddable', async () => {

--- a/src/plugins/dashboard/public/application/actions/clone_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/clone_panel_action.tsx
@@ -49,6 +49,7 @@ import {
   IPanelPlacementBesideArgs,
 } from '../embeddable/panel/dashboard_panel_placement';
 import { DashboardPanelState, DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '..';
+import { isSectionEmbeddable } from '../embeddable/section';
 
 export const ACTION_CLONE_PANEL = 'clonePanel';
 
@@ -85,7 +86,10 @@ export class ClonePanelAction implements ActionByType<typeof ACTION_CLONE_PANEL>
       embeddable.getInput()?.viewMode !== ViewMode.VIEW &&
       embeddable.getRoot() &&
       embeddable.getRoot().isContainer &&
-      embeddable.getRoot().type === DASHBOARD_CONTAINER_TYPE
+      embeddable.getRoot().type === DASHBOARD_CONTAINER_TYPE &&
+      // Cloning a section container would only duplicate an empty shell (its
+      // members live in the flat panels map, not inside it) -- excluded.
+      !isSectionEmbeddable(embeddable)
     );
   }
 

--- a/src/plugins/dashboard/public/application/actions/expand_panel_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/expand_panel_action.test.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../../embeddable/public/lib/test_samples';
 import { embeddablePluginMock } from '../../../../embeddable/public/mocks';
 import { ExpandPanelAction } from './expand_panel_action';
+import { DASHBOARD_SECTION_EMBEDDABLE } from '../embeddable/section';
 import { DashboardContainer } from '../embeddable';
 import { getSampleDashboardInput, getSampleDashboardPanel } from '../test_helpers';
 
@@ -118,6 +119,18 @@ test('Execute throws an error when called with an embeddable not in a parent', a
     await action.execute({ embeddable: container });
   }
   await expect(check()).rejects.toThrow(Error);
+});
+
+test('Is not compatible with a section embeddable', async () => {
+  const action = new ExpandPanelAction();
+  // Preserve the instance prototype (methods like getInput) while overriding
+  // the type so the action sees a section container inside the dashboard.
+  const sectionEmbeddable = Object.assign(
+    Object.create(Object.getPrototypeOf(embeddable)),
+    embeddable,
+    { type: DASHBOARD_SECTION_EMBEDDABLE }
+  );
+  expect(await action.isCompatible({ embeddable: sectionEmbeddable })).toBe(false);
 });
 
 test('Returns title', async () => {

--- a/src/plugins/dashboard/public/application/actions/expand_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/expand_panel_action.tsx
@@ -33,6 +33,7 @@ import { i18n } from '@osd/i18n';
 import { IEmbeddable } from '../../../../embeddable/public';
 import { ActionByType, IncompatibleActionError } from '../../../../ui_actions/public';
 import { DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '../embeddable';
+import { isSectionEmbeddable } from '../embeddable/section';
 
 export const ACTION_EXPAND_PANEL = 'togglePanel';
 
@@ -82,7 +83,10 @@ export class ExpandPanelAction implements ActionByType<typeof ACTION_EXPAND_PANE
   }
 
   public async isCompatible({ embeddable }: ExpandPanelActionContext) {
-    return Boolean(embeddable.parent && isDashboard(embeddable.parent));
+    // Sections are structural containers, not maximizable content panels.
+    return Boolean(
+      embeddable.parent && isDashboard(embeddable.parent) && !isSectionEmbeddable(embeddable)
+    );
   }
 
   public async execute({ embeddable }: ExpandPanelActionContext) {

--- a/src/plugins/dashboard/public/application/actions/index.ts
+++ b/src/plugins/dashboard/public/application/actions/index.ts
@@ -58,3 +58,19 @@ export {
   LibraryNotificationAction,
   ACTION_LIBRARY_NOTIFICATION,
 } from './library_notification_action';
+export {
+  MovePanelToSectionAction,
+  MovePanelToSectionActionContext,
+  ACTION_MOVE_PANEL_TO_SECTION,
+} from './move_panel_to_section_action';
+export {
+  AddPanelToSectionAction,
+  AddPanelToSectionActionContext,
+  ACTION_ADD_PANEL_TO_SECTION,
+} from './add_panel_to_section_action';
+export { openAddPanelToSectionFlyout } from './add_panel_to_section_flyout';
+export {
+  UngroupSectionAction,
+  UngroupSectionActionContext,
+  ACTION_UNGROUP_SECTION,
+} from './ungroup_section_action';

--- a/src/plugins/dashboard/public/application/actions/move_panel_to_section_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/move_panel_to_section_action.test.tsx
@@ -1,0 +1,276 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Dashboard collapsible sections.
+// Exercises MovePanelToSectionAction against a real DashboardContainer.
+
+import {
+  isErrorEmbeddable,
+  IContainer,
+  ErrorEmbeddable,
+  ViewMode,
+} from '../../../../embeddable/public';
+import {
+  CONTACT_CARD_EMBEDDABLE,
+  ContactCardEmbeddableFactory,
+  ContactCardEmbeddable,
+  ContactCardEmbeddableInput,
+  ContactCardEmbeddableOutput,
+} from '../../../../embeddable/public/lib/test_samples';
+import { embeddablePluginMock } from '../../../../embeddable/public/mocks';
+import { DashboardContainer, DashboardPanelState } from '../embeddable';
+import { DASHBOARD_SECTION_EMBEDDABLE, SectionMember } from '../embeddable/section';
+import { getSampleDashboardInput, getSampleDashboardPanel } from '../test_helpers';
+import { coreMock } from '../../../../../core/public/mocks';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { MovePanelToSectionAction } from '.';
+import { relocatePanelToSection } from './move_panel_to_section_action';
+
+const { setup, doStart } = embeddablePluginMock.createInstance();
+setup.registerEmbeddableFactory(
+  CONTACT_CARD_EMBEDDABLE,
+  new ContactCardEmbeddableFactory((() => null) as any, {} as any)
+);
+const start = doStart();
+
+let container: DashboardContainer;
+let embeddable: ContactCardEmbeddable;
+let coreStart: CoreStart;
+
+beforeEach(async () => {
+  coreStart = coreMock.createStart();
+
+  const options = {
+    ExitFullScreenButton: () => null,
+    SavedObjectFinder: () => null,
+    application: {} as any,
+    embeddable: start,
+    chrome: {} as any,
+    inspector: {} as any,
+    notifications: {} as any,
+    overlays: coreStart.overlays,
+    savedObjectMetaData: {} as any,
+    uiActions: {} as any,
+  };
+  const input = getSampleDashboardInput({
+    panels: {
+      '123': getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'opensearchDashboards', id: '123' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+      section1: {
+        gridData: { x: 0, y: 20, w: 48, h: 4, i: 'section1' },
+        type: DASHBOARD_SECTION_EMBEDDABLE,
+        explicitInput: { id: 'section1', title: 'Section 1', collapsed: false },
+      } as unknown as DashboardPanelState,
+    },
+  });
+  container = new DashboardContainer(input, options);
+
+  const contactCardEmbeddable = await container.addNewEmbeddable<
+    ContactCardEmbeddableInput,
+    ContactCardEmbeddableOutput,
+    ContactCardEmbeddable
+  >(CONTACT_CARD_EMBEDDABLE, {
+    firstName: 'opensearchDashboards',
+  });
+
+  if (isErrorEmbeddable(contactCardEmbeddable)) {
+    throw new Error('Failed to create embeddable');
+  } else {
+    embeddable = contactCardEmbeddable;
+  }
+});
+
+test('Move to section is incompatible with Error Embeddables', async () => {
+  const action = new MovePanelToSectionAction(coreStart);
+  const errorEmbeddable = new ErrorEmbeddable(
+    'Wow what an awful error',
+    { id: '404' },
+    embeddable.getRoot() as IContainer
+  );
+  expect(await action.isCompatible({ embeddable: errorEmbeddable })).toBe(false);
+});
+
+test('Move to section is compatible with an ordinary dashboard panel in edit mode', async () => {
+  const action = new MovePanelToSectionAction(coreStart);
+  embeddable.updateInput({ viewMode: ViewMode.EDIT });
+  expect(await action.isCompatible({ embeddable })).toBe(true);
+});
+
+test('Move to section is NOT compatible with an ordinary dashboard panel in view mode', async () => {
+  const action = new MovePanelToSectionAction(coreStart);
+  embeddable.updateInput({ viewMode: ViewMode.VIEW });
+  expect(await action.isCompatible({ embeddable })).toBe(false);
+});
+
+test('Move to section is NOT compatible with a section panel itself (no nesting)', async () => {
+  const action = new MovePanelToSectionAction(coreStart);
+  const dashboard = embeddable.getRoot() as DashboardContainer;
+  const sectionEmbeddable = dashboard.getChild('section1');
+  expect(await action.isCompatible({ embeddable: sectionEmbeddable })).toBe(false);
+});
+
+test('execute() opens a modal listing the current section as a move target', async () => {
+  const action = new MovePanelToSectionAction(coreStart);
+  const dashboard = embeddable.getRoot() as DashboardContainer;
+  embeddable.updateInput({ viewMode: ViewMode.EDIT });
+
+  await action.execute({ embeddable });
+
+  expect(coreStart.overlays.openModal).toHaveBeenCalledTimes(1);
+  // coreMock's openModal does not actually render children -- it just
+  // records the call. Verifying the mount-point argument was constructed
+  // (not undefined/thrown) is what's checkable here without deeper
+  // enzyme-around-MountPoint test infrastructure this plugin doesn't
+  // otherwise use for modals; isCompatible + gridData mutation logic itself
+  // is covered directly in the other tests in this file.
+  const mountPointArg = (coreStart.overlays.openModal as jest.Mock).mock.calls[0][0];
+  expect(mountPointArg).toBeDefined();
+});
+
+test('getDisplayName is "Move to section" when ungrouped and "Change section" when in a section', async () => {
+  const action = new MovePanelToSectionAction(coreStart);
+  const dashboard = embeddable.getRoot() as DashboardContainer;
+
+  // Ungrouped panel -> "Move to section".
+  expect(action.getDisplayName({ embeddable })).toBe('Move to section');
+
+  // Once it belongs to a section (Option 1: listed in section1's members) ->
+  // "Change section".
+  const panels = dashboard.getInput().panels;
+  dashboard.updateInput({
+    panels: {
+      ...panels,
+      section1: {
+        ...panels.section1,
+        explicitInput: {
+          ...panels.section1.explicitInput,
+          members: [{ id: embeddable.id, gridData: { x: 0, y: 0, w: 6, h: 6 } }],
+        },
+      },
+    },
+  });
+  expect(action.getDisplayName({ embeddable })).toBe('Change section');
+});
+
+// Option 1 (section-owned members): relocatePanelToSection now
+// edits the section panels' explicitInput.members (membership + section-relative
+// layout). Member panels' own absolute gridData is NEVER changed by a move, so
+// they stay valid standalone panels. These tests exercise that pure function.
+describe('relocatePanelToSection (Option 1: section owns its members)', () => {
+  function panel(gridData: {
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    i: string;
+  }): DashboardPanelState {
+    return {
+      gridData,
+      type: 'visualization',
+      explicitInput: { id: gridData.i },
+    } as unknown as DashboardPanelState;
+  }
+
+  function section(
+    id: string,
+    members: SectionMember[] = [],
+    collapsed = false
+  ): DashboardPanelState {
+    return {
+      gridData: { x: 0, y: 0, w: 48, h: 4, i: id },
+      type: DASHBOARD_SECTION_EMBEDDABLE,
+      explicitInput: { id, title: id, collapsed, members },
+    } as unknown as DashboardPanelState;
+  }
+
+  const membersOf = (p: DashboardPanelState): SectionMember[] =>
+    (p.explicitInput as { members: SectionMember[] }).members;
+
+  test('moving a panel INTO an empty section adds it to members at section-relative 0,0; panel gridData untouched', () => {
+    const panels = {
+      section1: section('section1'),
+      moved: panel({ x: 10, y: 50, w: 24, h: 15, i: 'moved' }),
+    };
+    const result = relocatePanelToSection('moved', 'section1', panels);
+    expect(membersOf(result.section1)).toEqual([
+      { id: 'moved', gridData: { x: 0, y: 0, w: 24, h: 15 } },
+    ]);
+    // The panel's own absolute gridData (its standalone home) is preserved.
+    expect(result.moved.gridData).toEqual(panels.moved.gridData);
+  });
+
+  test('moving a panel INTO a section with an existing member places it beside without overlap', () => {
+    const panels = {
+      section1: section('section1', [{ id: 'existing', gridData: { x: 0, y: 0, w: 24, h: 15 } }]),
+      moved: panel({ x: 40, y: 99, w: 24, h: 15, i: 'moved' }),
+    };
+    const result = relocatePanelToSection('moved', 'section1', panels);
+    const members = membersOf(result.section1);
+    const movedLayout = members.find((m) => m.id === 'moved')!;
+    expect(movedLayout).toBeDefined();
+    const overlaps =
+      movedLayout.gridData.x < 24 &&
+      movedLayout.gridData.x + movedLayout.gridData.w > 0 &&
+      movedLayout.gridData.y < 15 &&
+      movedLayout.gridData.y + movedLayout.gridData.h > 0;
+    expect(overlaps).toBe(false);
+    // The existing member's layout is untouched.
+    expect(members.find((m) => m.id === 'existing')).toEqual({
+      id: 'existing',
+      gridData: { x: 0, y: 0, w: 24, h: 15 },
+    });
+    expect(result.moved.gridData).toEqual(panels.moved.gridData);
+  });
+
+  test('moving a panel INTO a full section appends it below existing members (section-relative)', () => {
+    const panels = {
+      section1: section('section1', [{ id: 'fullRow', gridData: { x: 0, y: 0, w: 48, h: 15 } }]),
+      moved: panel({ x: 0, y: 200, w: 24, h: 15, i: 'moved' }),
+    };
+    const result = relocatePanelToSection('moved', 'section1', panels);
+    const movedLayout = membersOf(result.section1).find((m) => m.id === 'moved')!;
+    // No open column beside the full row -> appended directly below it (y=15).
+    expect(movedLayout.gridData.y).toBe(15);
+  });
+
+  test('moving a panel OUT removes it from its section members; panel gridData untouched', () => {
+    const panels = {
+      section1: section('section1', [{ id: 'moved', gridData: { x: 0, y: 0, w: 24, h: 15 } }]),
+      moved: panel({ x: 3, y: 7, w: 24, h: 15, i: 'moved' }),
+    };
+    const result = relocatePanelToSection('moved', undefined, panels);
+    expect(membersOf(result.section1).find((m) => m.id === 'moved')).toBeUndefined();
+    expect(result.moved.gridData).toEqual(panels.moved.gridData);
+  });
+
+  test('moving between sections removes from the old section and adds to the new', () => {
+    const panels = {
+      section1: section('section1', [{ id: 'moved', gridData: { x: 0, y: 0, w: 24, h: 15 } }]),
+      section2: section('section2'),
+      moved: panel({ x: 0, y: 0, w: 24, h: 15, i: 'moved' }),
+    };
+    const result = relocatePanelToSection('moved', 'section2', panels);
+    expect(membersOf(result.section1).find((m) => m.id === 'moved')).toBeUndefined();
+    expect(membersOf(result.section2).find((m) => m.id === 'moved')).toBeDefined();
+  });
+
+  test('moving INTO a collapsed section auto-expands it', () => {
+    const panels = {
+      section2: section('section2', [], true),
+      moved: panel({ x: 0, y: 50, w: 24, h: 15, i: 'moved' }),
+    };
+    const result = relocatePanelToSection('moved', 'section2', panels);
+    expect((result.section2.explicitInput as { collapsed?: boolean }).collapsed).toBe(false);
+    expect(membersOf(result.section2).find((m) => m.id === 'moved')).toBeDefined();
+  });
+});

--- a/src/plugins/dashboard/public/application/actions/move_panel_to_section_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/move_panel_to_section_action.tsx
@@ -1,0 +1,363 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Dashboard collapsible sections.
+// "Move to section" panel action. Mirrors ReplacePanelAction's shape (a single
+// ActionByType whose execute() opens a small overlay to gather a choice) --
+// uiActions registers actions statically at plugin setup, before any sections
+// exist, so a real dynamic submenu-per-target isn't expressible as separate
+// registered actions; the overlay is where the current section list is read.
+
+import React from 'react';
+import { i18n } from '@osd/i18n';
+import { CoreStart } from 'src/core/public';
+import {
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiRadioGroup,
+  EuiRadioGroupOption,
+} from '@elastic/eui';
+import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
+import { IEmbeddable, ViewMode, isErrorEmbeddable } from '../../../../embeddable/public';
+import { ActionByType, IncompatibleActionError } from '../../../../ui_actions/public';
+import { DASHBOARD_CONTAINER_TYPE, DashboardContainer, DashboardPanelState } from '..';
+import { findTopLeftMostOpenSpace } from '../embeddable/panel/dashboard_panel_placement';
+import {
+  DASHBOARD_SECTION_EMBEDDABLE,
+  buildSectionMemberMap,
+  SectionMember,
+  DashboardSectionEmbeddableInput,
+} from '../embeddable/section';
+import { toMountPoint } from '../../../../opensearch_dashboards_react/public';
+
+export const ACTION_MOVE_PANEL_TO_SECTION = 'movePanelToSection';
+
+export interface MovePanelToSectionActionContext {
+  embeddable: IEmbeddable;
+}
+
+const OUTER_TARGET_ID = '__outer__';
+
+/**
+ * "Move to section" updates section membership: it adds the panel's id to the
+ * target section's `members` list with a section-relative layout (or removes
+ * that entry when moving the panel out). The panel's own entry in the flat
+ * panels map is left untouched.
+ *
+ * A member's layout (stored in the section's `members` list) is
+ * SECTION-RELATIVE -- coordinates within the target section's own inner
+ * react-grid-layout -- whereas an ungrouped panel's gridData is absolute
+ * outer-dashboard coordinates. Moving between the two is therefore a
+ * coordinate-SPACE change, and the panel must be re-placed into open space in
+ * the destination space. We reuse the existing, unmodified
+ * findTopLeftMostOpenSpace() placement algorithm -- just fed a `currentPanels`
+ * set PRE-FILTERED to the destination space (the target section's members, or
+ * the ungrouped/outer panels). No hand-rolled cross-space push-down logic:
+ * each grid's own compactType='vertical' resolves any residual overlap
+ * natively, and members of OTHER sections are never touched because they are
+ * simply never in the filtered set.
+ */
+
+/** Synthetic {id: {gridData}} map from a section's member layouts, so the
+ * shared findTopLeftMostOpenSpace() can pick an open SECTION-RELATIVE slot. */
+function sectionMembersAsPanels(members: SectionMember[]): {
+  [key: string]: DashboardPanelState;
+} {
+  const out: { [key: string]: DashboardPanelState } = {};
+  members.forEach((m) => {
+    // Only gridData is read by findTopLeftMostOpenSpace; a minimal synthetic
+    // panel keyed by the member id is enough to reserve its section-relative
+    // slot when placing a new member.
+    out[m.id] = { gridData: { ...m.gridData, i: m.id } } as unknown as DashboardPanelState;
+  });
+  return out;
+}
+
+/**
+ * Compute the updated panels map after moving `panelToMove` to
+ * `nextSectionId` (undefined = remove from any section, back to the outer
+ * dashboard space). Pure -- returns a new map, mutates nothing.
+ *
+ * Exported for direct unit testing -- the coordinate-space placement is the
+ * load-bearing behavior and is not observable through the modal-driven tests.
+ */
+export function relocatePanelToSection(
+  panelToMoveId: string,
+  nextSectionId: string | undefined,
+  panels: { [key: string]: DashboardPanelState }
+): { [key: string]: DashboardPanelState } {
+  const panelToMove = panels[panelToMoveId];
+  if (!panelToMove) return panels;
+  const { w, h } = panelToMove.gridData;
+
+  // Option 1: membership lives in each section's explicitInput.members. Moving
+  // a panel means editing section member-lists ONLY -- the panel's own
+  // (absolute) gridData is never touched, so it stays a valid standalone panel.
+  const memberMap = buildSectionMemberMap(panels);
+  const currentSectionId = memberMap.get(panelToMoveId)?.sectionId;
+
+  const getMembers = (sectionId: string): SectionMember[] =>
+    (
+      (panels[sectionId]?.explicitInput as Partial<DashboardSectionEmbeddableInput>)?.members ?? []
+    ).slice();
+
+  const withMembers = (
+    map: { [key: string]: DashboardPanelState },
+    sectionId: string,
+    members: SectionMember[]
+  ): { [key: string]: DashboardPanelState } => {
+    const sectionPanel = map[sectionId];
+    if (!sectionPanel) return map;
+    return {
+      ...map,
+      [sectionId]: {
+        ...sectionPanel,
+        explicitInput: { ...sectionPanel.explicitInput, members },
+      },
+    };
+  };
+
+  let next = { ...panels };
+
+  // Remove from the current section (if any), so a move never leaves the panel
+  // listed in two sections.
+  if (currentSectionId && currentSectionId !== nextSectionId) {
+    next = withMembers(
+      next,
+      currentSectionId,
+      getMembers(currentSectionId).filter((m) => m.id !== panelToMoveId)
+    );
+  }
+
+  // Moving OUT (no target): nothing else to do -- the panel already has its
+  // absolute gridData and will render in the outer grid.
+  if (nextSectionId === undefined) {
+    return next;
+  }
+
+  // Moving IN: pick an open SECTION-RELATIVE slot among the target section's
+  // existing members (excluding this panel if it was already there), then add
+  // (or update) its layout entry. Auto-expand a collapsed target so the move
+  // is visible.
+  const targetMembers = getMembers(nextSectionId).filter((m) => m.id !== panelToMoveId);
+  const placement = findTopLeftMostOpenSpace({
+    width: w,
+    height: h,
+    currentPanels: sectionMembersAsPanels(targetMembers),
+  });
+  const newLayout: SectionMember = {
+    id: panelToMoveId,
+    gridData: {
+      x: placement.x,
+      y: placement.y,
+      w,
+      h,
+    },
+  };
+  next = withMembers(next, nextSectionId, [...targetMembers, newLayout]);
+
+  const targetSection = next[nextSectionId];
+  if (targetSection && (targetSection.explicitInput as { collapsed?: boolean }).collapsed) {
+    next = {
+      ...next,
+      [nextSectionId]: {
+        ...targetSection,
+        explicitInput: { ...targetSection.explicitInput, collapsed: false },
+      },
+    };
+  }
+
+  return next;
+}
+
+export class MovePanelToSectionAction implements ActionByType<typeof ACTION_MOVE_PANEL_TO_SECTION> {
+  public readonly type = ACTION_MOVE_PANEL_TO_SECTION;
+  public readonly id = ACTION_MOVE_PANEL_TO_SECTION;
+  public order = 44;
+
+  constructor(private core: CoreStart) {}
+
+  public getDisplayName({ embeddable }: MovePanelToSectionActionContext) {
+    if (!this.isDashboardChild(embeddable)) {
+      throw new IncompatibleActionError();
+    }
+    // Context-aware label: a panel already inside a section is "changing" its
+    // section (which includes removing it), whereas an ungrouped panel is
+    // "moving into" one. Same modal either way.
+    return this.isInSection(embeddable)
+      ? i18n.translate('dashboard.panel.movePanelToSection.changeSection', {
+          defaultMessage: 'Change section',
+        })
+      : i18n.translate('dashboard.panel.movePanelToSection', {
+          defaultMessage: 'Move to section',
+        });
+  }
+
+  public getIconType(): EuiIconType {
+    return 'folderOpen';
+  }
+
+  public async isCompatible({ embeddable }: MovePanelToSectionActionContext) {
+    if (!this.isDashboardChild(embeddable)) {
+      return false;
+    }
+    if (embeddable.type === DASHBOARD_SECTION_EMBEDDABLE) {
+      // a section itself is not movable into another section (no nesting)
+      return false;
+    }
+    return Boolean(
+      !isErrorEmbeddable(embeddable) && embeddable.getInput()?.viewMode !== ViewMode.VIEW
+    );
+  }
+
+  private isDashboardChild(embeddable: IEmbeddable): boolean {
+    return Boolean(
+      embeddable.getRoot() &&
+      embeddable.getRoot().isContainer &&
+      embeddable.getRoot().type === DASHBOARD_CONTAINER_TYPE
+    );
+  }
+
+  /** True when this panel currently belongs to a section (has a sectionId). */
+  /** True when this panel currently belongs to a section (Option 1: listed in
+   * some section's explicitInput.members). */
+  private isInSection(embeddable: IEmbeddable): boolean {
+    const root = embeddable.getRoot() as DashboardContainer;
+    const panels = root?.getInput?.().panels;
+    if (!panels) return false;
+    return buildSectionMemberMap(panels).has(embeddable.id);
+  }
+
+  public async execute({ embeddable }: MovePanelToSectionActionContext) {
+    if (!this.isDashboardChild(embeddable)) {
+      throw new IncompatibleActionError();
+    }
+    const dashboard = embeddable.getRoot() as DashboardContainer;
+    const panels = dashboard.getInput().panels;
+    // Option 1: current membership comes from the section member-lists, not a
+    // sectionId on the panel.
+    const currentSectionId = buildSectionMemberMap(panels).get(embeddable.id)?.sectionId;
+
+    const sortedSections = Object.values(panels)
+      .filter((p) => p.type === DASHBOARD_SECTION_EMBEDDABLE)
+      // List sections in their real top-to-bottom dashboard order (by y, then
+      // x) rather than panels-map insertion order, so the list matches what the
+      // user sees on the dashboard.
+      .sort((a, b) => {
+        if (a.gridData.y !== b.gridData.y) return a.gridData.y - b.gridData.y;
+        return a.gridData.x - b.gridData.x;
+      });
+
+    // Selection is tracked by section id (EuiRadioGroup `idSelected`), NOT by
+    // label -- so section titles may safely repeat. (EuiSelectable was avoided
+    // here because it resolves its highlighted option by `label === clicked
+    // .label`, which mis-highlights duplicate-named sections.)
+    const sectionOptions: EuiRadioGroupOption[] = sortedSections.map((p) => ({
+      id: p.gridData.i,
+      label: (p.explicitInput as { title?: string }).title || p.gridData.i,
+    }));
+
+    const outerOption: EuiRadioGroupOption = {
+      id: OUTER_TARGET_ID,
+      label: i18n.translate('dashboard.panel.movePanelToSection.outerOption', {
+        defaultMessage: 'No section (move to dashboard)',
+      }),
+    };
+
+    const options: EuiRadioGroupOption[] = [outerOption, ...sectionOptions];
+    const initialSelectedId = currentSectionId ?? OUTER_TARGET_ID;
+
+    const modalSession = this.core.overlays.openModal(
+      toMountPoint(
+        <MoveToSectionModal
+          options={options}
+          hasNoSections={sectionOptions.length === 0}
+          inSection={Boolean(currentSectionId)}
+          initialSelectedId={initialSelectedId}
+          onClose={() => modalSession.close()}
+          onSelect={(targetId) => {
+            const nextSectionId = targetId === OUTER_TARGET_ID ? undefined : targetId;
+            const newPanels = relocatePanelToSection(embeddable.id, nextSectionId, panels);
+            dashboard.updateInput({ panels: newPanels });
+            modalSession.close();
+          }}
+        />
+      ),
+      { className: 'dshMovePanelToSectionModal' }
+    );
+  }
+}
+
+function MoveToSectionModal({
+  options,
+  hasNoSections,
+  inSection,
+  initialSelectedId,
+  onClose,
+  onSelect,
+}: {
+  options: EuiRadioGroupOption[];
+  hasNoSections: boolean;
+  inSection: boolean;
+  initialSelectedId: string;
+  onClose: () => void;
+  onSelect: (targetId: string) => void;
+}) {
+  const [selectedId, setSelectedId] = React.useState(initialSelectedId);
+
+  return (
+    <>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {inSection
+            ? i18n.translate('dashboard.panel.movePanelToSection.changeSectionModalTitle', {
+                defaultMessage: 'Change section',
+              })
+            : i18n.translate('dashboard.panel.movePanelToSection.modalTitle', {
+                defaultMessage: 'Move to section',
+              })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+      <EuiModalBody>
+        {hasNoSections && (
+          <p>
+            {i18n.translate('dashboard.panel.movePanelToSection.noSections', {
+              defaultMessage: 'No sections exist yet on this dashboard.',
+            })}
+          </p>
+        )}
+        {/* Radio group selects by id, so duplicate section titles are fine and
+            never mis-highlight (unlike EuiSelectable's label-based matching). */}
+        <EuiRadioGroup
+          options={options}
+          idSelected={selectedId}
+          onChange={(id) => setSelectedId(id)}
+        />
+      </EuiModalBody>
+      <EuiModalFooter>
+        <EuiButtonEmpty onClick={onClose}>
+          {i18n.translate('dashboard.panel.movePanelToSection.cancel', {
+            defaultMessage: 'Cancel',
+          })}
+        </EuiButtonEmpty>
+        <EuiButton fill onClick={() => onSelect(selectedId)}>
+          {i18n.translate('dashboard.panel.movePanelToSection.move', {
+            defaultMessage: 'Move',
+          })}
+        </EuiButton>
+      </EuiModalFooter>
+    </>
+  );
+}

--- a/src/plugins/dashboard/public/application/actions/replace_panel_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/replace_panel_action.test.tsx
@@ -38,6 +38,7 @@ import {
 } from '../../../../embeddable/public/lib/test_samples';
 import { embeddablePluginMock } from '../../../../embeddable/public/mocks';
 import { ReplacePanelAction } from './replace_panel_action';
+import { DASHBOARD_SECTION_EMBEDDABLE } from '../embeddable/section';
 import { DashboardContainer } from '../embeddable';
 import { getSampleDashboardInput, getSampleDashboardPanel } from '../test_helpers';
 import { coreMock } from '../../../../../core/public/mocks';
@@ -136,6 +137,24 @@ test('Execute throws an error when called with an embeddable not in a parent', a
     await action.execute({ embeddable: container });
   }
   await expect(check()).rejects.toThrow(Error);
+});
+
+test('Is not compatible with a section embeddable', async () => {
+  let SavedObjectFinder: any;
+  let notifications: any;
+  const action = new ReplacePanelAction(
+    coreStart,
+    SavedObjectFinder,
+    notifications,
+    start.getEmbeddableFactories
+  );
+  // Preserve the instance prototype (getInput, etc.) while overriding type.
+  const sectionEmbeddable = Object.assign(
+    Object.create(Object.getPrototypeOf(embeddable)),
+    embeddable,
+    { type: DASHBOARD_SECTION_EMBEDDABLE }
+  );
+  expect(await action.isCompatible({ embeddable: sectionEmbeddable })).toBe(false);
 });
 
 test('Returns title', async () => {

--- a/src/plugins/dashboard/public/application/actions/replace_panel_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/replace_panel_action.tsx
@@ -33,6 +33,7 @@ import { CoreStart } from 'src/core/public';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
 import { IEmbeddable, ViewMode, EmbeddableStart } from '../../../../embeddable/public';
 import { DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '../embeddable';
+import { isSectionEmbeddable } from '../embeddable/section';
 import { ActionByType, IncompatibleActionError } from '../../../../ui_actions/public';
 import { openReplacePanelFlyout } from './open_replace_panel_flyout';
 
@@ -79,6 +80,11 @@ export class ReplacePanelAction implements ActionByType<typeof ACTION_REPLACE_PA
       if (embeddable.getInput().viewMode === ViewMode.VIEW) {
         return false;
       }
+    }
+
+    // A section has no single underlying saved object to swap out.
+    if (isSectionEmbeddable(embeddable)) {
+      return false;
     }
 
     return Boolean(embeddable.parent && isDashboard(embeddable.parent));

--- a/src/plugins/dashboard/public/application/actions/ungroup_section_action.test.tsx
+++ b/src/plugins/dashboard/public/application/actions/ungroup_section_action.test.tsx
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Section support (Option 1): UngroupSectionAction removes a section (releasing
+// its members to absolute space, same as "Delete from dashboard") behind a
+// confirmation dialog.
+
+import { ErrorEmbeddable, IContainer, ViewMode } from '../../../../embeddable/public';
+import {
+  CONTACT_CARD_EMBEDDABLE,
+  ContactCardEmbeddableFactory,
+  ContactCardEmbeddableInput,
+} from '../../../../embeddable/public/lib/test_samples';
+import { embeddablePluginMock } from '../../../../embeddable/public/mocks';
+import { DashboardContainer, DashboardPanelState } from '../embeddable';
+import { DASHBOARD_SECTION_EMBEDDABLE, SectionEmbeddable } from '../embeddable/section';
+import { getSampleDashboardInput, getSampleDashboardPanel } from '../test_helpers';
+import { coreMock } from '../../../../../core/public/mocks';
+import { CoreStart } from 'opensearch-dashboards/public';
+import { UngroupSectionAction } from '.';
+
+const { setup, doStart } = embeddablePluginMock.createInstance();
+setup.registerEmbeddableFactory(
+  CONTACT_CARD_EMBEDDABLE,
+  new ContactCardEmbeddableFactory((() => null) as any, {} as any)
+);
+const start = doStart();
+
+let container: DashboardContainer;
+let coreStart: CoreStart;
+
+beforeEach(() => {
+  coreStart = coreMock.createStart();
+  const options = {
+    ExitFullScreenButton: () => null,
+    SavedObjectFinder: () => null,
+    application: {} as any,
+    embeddable: start,
+    chrome: {} as any,
+    inspector: {} as any,
+    notifications: {} as any,
+    overlays: coreStart.overlays,
+    savedObjectMetaData: {} as any,
+    uiActions: {} as any,
+  };
+  const input = getSampleDashboardInput({
+    panels: {
+      '123': getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'opensearchDashboards', id: '123' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+      section1: {
+        gridData: { x: 0, y: 20, w: 48, h: 12, i: 'section1' },
+        type: DASHBOARD_SECTION_EMBEDDABLE,
+        explicitInput: {
+          id: 'section1',
+          title: 'Section 1',
+          collapsed: false,
+          // Section OWNS member '123' at section-relative (0,0).
+          members: [{ id: '123', gridData: { x: 0, y: 0, w: 24, h: 8 } }],
+        },
+      } as unknown as DashboardPanelState,
+    },
+  });
+  container = new DashboardContainer(input, options);
+  container.updateInput({ viewMode: ViewMode.EDIT });
+});
+
+const makeSection = () =>
+  new SectionEmbeddable(
+    { id: 'section1', title: 'Section 1', collapsed: false, members: [] },
+    container
+  );
+
+test('Ungroup section is incompatible with Error Embeddables', async () => {
+  const action = new UngroupSectionAction(coreStart);
+  const errorEmbeddable = new ErrorEmbeddable('an error', { id: '404' }, container as IContainer);
+  expect(await action.isCompatible({ embeddable: errorEmbeddable })).toBe(false);
+});
+
+test('Ungroup section is compatible with a section panel in edit mode', async () => {
+  const action = new UngroupSectionAction(coreStart);
+  // container is in EDIT mode (beforeEach); the section inherits it.
+  expect(await action.isCompatible({ embeddable: makeSection() })).toBe(true);
+});
+
+test('Ungroup section is NOT compatible with a section panel in view mode', async () => {
+  const action = new UngroupSectionAction(coreStart);
+  container.updateInput({ viewMode: ViewMode.VIEW });
+  expect(await action.isCompatible({ embeddable: makeSection() })).toBe(false);
+});
+
+test('execute does nothing when the confirm dialog is cancelled', async () => {
+  (coreStart.overlays.openConfirm as jest.Mock).mockResolvedValue(false);
+  const action = new UngroupSectionAction(coreStart);
+
+  await action.execute({ embeddable: makeSection() });
+
+  expect(coreStart.overlays.openConfirm).toHaveBeenCalledTimes(1);
+  // Section still present, member untouched.
+  expect(container.getInput().panels.section1).toBeDefined();
+});
+
+test('execute removes the section and releases its member to absolute space when confirmed', async () => {
+  (coreStart.overlays.openConfirm as jest.Mock).mockResolvedValue(true);
+  const action = new UngroupSectionAction(coreStart);
+
+  await action.execute({ embeddable: makeSection() });
+
+  const panels = container.getInput().panels;
+  // Section gone.
+  expect(panels.section1).toBeUndefined();
+  // Member survives, repositioned to ABSOLUTE at the section's location:
+  // sectionY(20) + SECTION_HEADER_ROWS(2) + memberY(0) = 22.
+  expect(panels['123']).toBeDefined();
+  expect(panels['123'].gridData).toMatchObject({ x: 0, y: 22, w: 24, h: 8 });
+});

--- a/src/plugins/dashboard/public/application/actions/ungroup_section_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/ungroup_section_action.tsx
@@ -1,0 +1,99 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Section support (Option 1): a section-only "Ungroup section" context-menu
+// action. It removes the section via DashboardContainer.ungroupSection, which
+// releases the members back into absolute dashboard space at the section's
+// location (the members stay on the dashboard) -- behind a confirmation dialog
+// so the (irreversible) ungrouping is intentional. Contrast with the generic
+// "Delete from dashboard", which removes the section AND its member panels.
+
+import { i18n } from '@osd/i18n';
+import { EUI_MODAL_CONFIRM_BUTTON } from '@elastic/eui';
+import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
+import { CoreStart } from 'src/core/public';
+import { IEmbeddable, ViewMode } from '../../../../embeddable/public';
+import { ActionByType, IncompatibleActionError } from '../../../../ui_actions/public';
+import { DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '../embeddable';
+import { isSectionEmbeddable } from '../embeddable/section';
+
+export const ACTION_UNGROUP_SECTION = 'ungroupSection';
+
+export interface UngroupSectionActionContext {
+  embeddable: IEmbeddable;
+}
+
+export class UngroupSectionAction implements ActionByType<typeof ACTION_UNGROUP_SECTION> {
+  public readonly type = ACTION_UNGROUP_SECTION;
+  public readonly id = ACTION_UNGROUP_SECTION;
+  // Sits just below "Add existing visualization" (43) / "Move to section" (44).
+  public order = 42;
+
+  constructor(private core: CoreStart) {}
+
+  public getDisplayName() {
+    return i18n.translate('dashboard.section.ungroup.actionLabel', {
+      defaultMessage: 'Ungroup section',
+    });
+  }
+
+  public getIconType(): EuiIconType {
+    return 'exit';
+  }
+
+  public async isCompatible({ embeddable }: UngroupSectionActionContext) {
+    // Only for a section container, in edit mode, inside a dashboard.
+    if (!isSectionEmbeddable(embeddable)) {
+      return false;
+    }
+    const root = embeddable.getRoot();
+    return Boolean(
+      root &&
+      root.isContainer &&
+      root.type === DASHBOARD_CONTAINER_TYPE &&
+      embeddable.getInput()?.viewMode !== ViewMode.VIEW
+    );
+  }
+
+  public async execute({ embeddable }: UngroupSectionActionContext) {
+    if (!isSectionEmbeddable(embeddable)) {
+      throw new IncompatibleActionError();
+    }
+    const container = embeddable.getRoot() as DashboardContainer;
+
+    const confirmed = await this.core.overlays.openConfirm(
+      i18n.translate('dashboard.section.ungroup.confirmDescription', {
+        defaultMessage:
+          'The section will be removed. Its panels stay on the dashboard and keep their positions.',
+      }),
+      {
+        title: i18n.translate('dashboard.section.ungroup.confirmTitle', {
+          defaultMessage: 'Ungroup this section?',
+        }),
+        confirmButtonText: i18n.translate('dashboard.section.ungroup.confirmButtonLabel', {
+          defaultMessage: 'Ungroup',
+        }),
+        cancelButtonText: i18n.translate('dashboard.section.ungroup.cancelButtonLabel', {
+          defaultMessage: 'Cancel',
+        }),
+        defaultFocusedButton: EUI_MODAL_CONFIRM_BUTTON,
+      }
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    // Keep the panels: DashboardContainer.ungroupSection releases the members
+    // to absolute space at the section's location, then drops the section.
+    container.ungroupSection(embeddable.id);
+  }
+}

--- a/src/plugins/dashboard/public/application/actions/unlink_from_library_action.tsx
+++ b/src/plugins/dashboard/public/application/actions/unlink_from_library_action.tsx
@@ -43,6 +43,7 @@ import {
   IEmbeddable,
 } from '../../../../embeddable/public';
 import { DashboardPanelState, DASHBOARD_CONTAINER_TYPE, DashboardContainer } from '..';
+import { isSectionEmbeddable } from '../embeddable/section';
 
 export const ACTION_UNLINK_FROM_LIBRARY = 'unlinkFromLibrary';
 
@@ -81,7 +82,10 @@ export class UnlinkFromLibraryAction implements ActionByType<typeof ACTION_UNLIN
       embeddable.getRoot().isContainer &&
       embeddable.getRoot().type === DASHBOARD_CONTAINER_TYPE &&
       isReferenceOrValueEmbeddable(embeddable) &&
-      embeddable.inputIsRefType(embeddable.getInput())
+      embeddable.inputIsRefType(embeddable.getInput()) &&
+      // A section is not a library-backed content panel (defensive; a section
+      // is not a reference-or-value embeddable either).
+      !isSectionEmbeddable(embeddable)
     );
   }
 

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -90,6 +90,7 @@ exports[`Dashboard top nav render in embed mode 1`] = `
       <Provider
         services={
           Object {
+            "allowDashboardSections": false,
             "application": Object {
               "applications$": BehaviorSubject {
                 "_isScalar": false,
@@ -1298,6 +1299,7 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
       <Provider
         services={
           Object {
+            "allowDashboardSections": false,
             "application": Object {
               "applications$": BehaviorSubject {
                 "_isScalar": false,
@@ -2506,6 +2508,7 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
       <Provider
         services={
           Object {
+            "allowDashboardSections": false,
             "application": Object {
               "applications$": BehaviorSubject {
                 "_isScalar": false,
@@ -3714,6 +3717,7 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
       <Provider
         services={
           Object {
+            "allowDashboardSections": false,
             "application": Object {
               "applications$": BehaviorSubject {
                 "_isScalar": false,
@@ -4922,6 +4926,7 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
       <Provider
         services={
           Object {
+            "allowDashboardSections": false,
             "application": Object {
               "applications$": BehaviorSubject {
                 "_isScalar": false,
@@ -6130,6 +6135,7 @@ exports[`Dashboard top nav render with all components 1`] = `
       <Provider
         services={
           Object {
+            "allowDashboardSections": false,
             "application": Object {
               "applications$": BehaviorSubject {
                 "_isScalar": false,

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.ts
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.ts
@@ -346,6 +346,9 @@ function getAddConfig(action: NavAction): TopNavMenuIconData {
   };
 }
 
+/**
+ * Dashboard collapsible sections.
+ */
 function getShareConfig(action: NavAction | undefined): TopNavMenuIconData {
   return {
     tooltip: i18n.translate('dashboard.topNav.shareButtonTooltip', {

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/show_add_panel_popover.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/show_add_panel_popover.tsx
@@ -34,12 +34,14 @@ const PanelPopover = ({
   onClose,
   button,
   onAddExistingPanelFlyout,
+  onAddSection,
   uiActions,
   containerInfo,
 }: {
   onClose: () => void;
   button: HTMLElement;
   onAddExistingPanelFlyout: () => void;
+  onAddSection?: () => void;
   uiActions: UiActionsStart;
   containerInfo?: ContainerInfo;
 }) => {
@@ -50,12 +52,47 @@ const PanelPopover = ({
   const actionsRef = useRef(uiActions.getTriggerActions(DASHBOARD_ADD_PANEL_TRIGGER));
 
   const panels = useAsync(() => {
-    return buildContextMenuForActions({
-      actions: actionsRef.current.map((action) => ({
-        action,
+    const actions = actionsRef.current.map((action) => ({
+      action,
+      context: triggerContext,
+      trigger: DASHBOARD_ADD_PANEL_TRIGGER as any,
+    }));
+
+    // Dashboard collapsible sections: inject an "Add section"
+    // entry into the same "Create new" menu as the visualization types, placed
+    // immediately AFTER the Metrics visualization entry. We derive the order
+    // from the live Metrics action's own order (order-1 -> renders right after
+    // it) rather than a hard-coded constant, so the position stays correct
+    // regardless of which visualization types are installed/registered.
+    if (onAddSection) {
+      const metricsAction = actionsRef.current.find(
+        (a) => a.id === 'add_vis_action_MetricsVisualization'
+      );
+      const sectionOrder = (metricsAction?.order ?? 0) - 1;
+      const addSectionAction = {
+        id: 'addDashboardSection',
+        order: sectionOrder,
+        type: 'addDashboardSection',
+        getDisplayName: () =>
+          i18n.translate('dashboard.addPanel.addSectionMenuItem', {
+            defaultMessage: 'Section',
+          }),
+        getIconType: () => 'list',
+        isCompatible: async () => true,
+        execute: async () => {
+          onAddSection();
+          onClose();
+        },
+      };
+      actions.push({
+        action: addSectionAction as any,
         context: triggerContext,
         trigger: DASHBOARD_ADD_PANEL_TRIGGER as any,
-      })),
+      });
+    }
+
+    return buildContextMenuForActions({
+      actions,
       closeMenu: onClose,
       title: '',
       autoWrapItems: false,
@@ -92,11 +129,13 @@ const PanelPopover = ({
 export function showAddPanelPopover({
   anchorElement,
   onAddExistingPanelFlyout,
+  onAddSection,
   uiActions,
   containerInfo,
 }: {
   anchorElement: HTMLElement;
   onAddExistingPanelFlyout: () => void;
+  onAddSection?: () => void;
   uiActions: UiActionsStart;
   containerInfo?: ContainerInfo;
 }) {
@@ -112,6 +151,7 @@ export function showAddPanelPopover({
   root.render(
     <PanelPopover
       onAddExistingPanelFlyout={onAddExistingPanelFlyout}
+      onAddSection={onAddSection}
       button={anchorElement}
       onClose={unmount}
       uiActions={uiActions}

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/top_nav_ids.ts
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/top_nav_ids.ts
@@ -38,4 +38,6 @@ export const TopNavIds = {
   FULL_SCREEN: 'fullScreenMode',
   VISUALIZE: 'visualize',
   ADD_EXISTING: 'addExisting',
+  // Dashboard collapsible sections.
+  ADD_SECTION: 'addSection',
 };

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_constants.ts
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_constants.ts
@@ -32,4 +32,24 @@ export const DASHBOARD_GRID_COLUMN_COUNT = 48;
 export const DASHBOARD_GRID_HEIGHT = 20;
 export const DEFAULT_PANEL_WIDTH = DASHBOARD_GRID_COLUMN_COUNT / 2;
 export const DEFAULT_PANEL_HEIGHT = 15;
+
+/**
+ * Outer-grid rows reserved for a collapsible section's header strip
+ * (chevron/title/chrome) above its inner members grid. A section's
+ * outer height = SECTION_HEADER_ROWS + its inner grid content rows, and its
+ * members' section-relative y are offset by SECTION_HEADER_ROWS when released
+ * to absolute coordinates (ungroup). The header is forced to a single line via
+ * `.dshDashboardGrid__sectionHeader .embPanel__title { flex-wrap: nowrap }`
+ * (see _dashboard_grid.scss); its rendered height (~26px incl. padding/border)
+ * is a little over one outer row's ~20px, so 1 row clips the last member by a
+ * few px and 2 rows clears it with a small (~half-row) residual gap. We accept
+ * that tiny gap rather than clip a member. Larger values only add empty space
+ * at the bottom (the inner grid is content-height and top-anchored, so surplus
+ * rows are never filled).
+ *
+ * Single source of truth -- imported by DashboardGrid (height/render),
+ * DashboardContainer (ungroup repositioning) and get_nav_actions (new-section
+ * placement) so the three cannot drift.
+ */
+export const SECTION_HEADER_ROWS = 2;
 export const DASHBOARD_CONTAINER_TYPE = 'dashboard';

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.test.tsx
@@ -270,3 +270,125 @@ test('DashboardContainer in edit mode shows edit mode actions', async () => {
   // const action = findTestSubject(component, `embeddablePanelAction-${editModeAction.id}`);
   // expect(action.length).toBe(1);
 });
+
+test('ungroupSection repositions members to the section location, then removes only the section', () => {
+  const initialInput = getSampleDashboardInput({
+    panels: {
+      section1: {
+        gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+        type: 'dashboard_section',
+        // Option 1: the section owns its members via explicitInput.members.
+        explicitInput: {
+          id: 'section1',
+          title: 'Section 1',
+          collapsed: false,
+          members: [
+            { id: 'm1', gridData: { x: 0, y: 0, w: 6, h: 6 } },
+            { id: 'm2', gridData: { x: 6, y: 0, w: 6, h: 6 } },
+          ],
+        },
+      } as any,
+      m1: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'a', id: 'm1' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+      m2: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'b', id: 'm2' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+    },
+  });
+  // Member panels start at some absolute home; ungroup must reposition them to
+  // the section's rendered location (sectionY + HEADER_ROWS + memberY).
+  initialInput.panels.m1.gridData = { x: 0, y: 40, w: 6, h: 6, i: 'm1' };
+  initialInput.panels.m2.gridData = { x: 6, y: 40, w: 6, h: 6, i: 'm2' };
+
+  const container = new DashboardContainer(initialInput, options);
+  // Ungrouping a section converts its members' section-relative layout to
+  // absolute at the section's location, then removes the section panel (only).
+  container.ungroupSection('section1');
+
+  const panels = container.getInput().panels;
+  expect(panels.section1).toBeUndefined();
+  expect(panels.m1).toBeDefined();
+  expect(panels.m2).toBeDefined();
+  // section1 is at y:0, SECTION_HEADER_ROWS=2, so members land at y = 2 + memberY.
+  expect(panels.m1.gridData).toEqual({ x: 0, y: 2, w: 6, h: 6, i: 'm1' });
+  expect(panels.m2.gridData).toEqual({ x: 6, y: 2, w: 6, h: 6, i: 'm2' });
+});
+
+test('removeEmbeddable on a section confirms, then deletes the section AND its members', async () => {
+  const openConfirm = jest.fn().mockResolvedValue(true);
+  const deleteOptions = { ...options, overlays: { openConfirm } as any };
+  const initialInput = getSampleDashboardInput({
+    panels: {
+      section1: {
+        gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+        type: 'dashboard_section',
+        explicitInput: {
+          id: 'section1',
+          title: 'Section 1',
+          collapsed: false,
+          members: [
+            { id: 'm1', gridData: { x: 0, y: 0, w: 6, h: 6 } },
+            { id: 'm2', gridData: { x: 6, y: 0, w: 6, h: 6 } },
+          ],
+        },
+      } as any,
+      m1: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'a', id: 'm1' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+      m2: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'b', id: 'm2' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+    },
+  });
+
+  const container = new DashboardContainer(initialInput, deleteOptions);
+  container.removeEmbeddable('section1');
+  // openConfirm is async (fire-and-forget from the sync removeEmbeddable);
+  // let the microtasks settle before asserting.
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(openConfirm).toHaveBeenCalledTimes(1);
+  const panels = container.getInput().panels;
+  // Section AND both members are gone.
+  expect(panels.section1).toBeUndefined();
+  expect(panels.m1).toBeUndefined();
+  expect(panels.m2).toBeUndefined();
+});
+
+test('removeEmbeddable on a section does nothing when the delete confirm is cancelled', async () => {
+  const openConfirm = jest.fn().mockResolvedValue(false);
+  const deleteOptions = { ...options, overlays: { openConfirm } as any };
+  const initialInput = getSampleDashboardInput({
+    panels: {
+      section1: {
+        gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+        type: 'dashboard_section',
+        explicitInput: {
+          id: 'section1',
+          title: 'Section 1',
+          collapsed: false,
+          members: [{ id: 'm1', gridData: { x: 0, y: 0, w: 6, h: 6 } }],
+        },
+      } as any,
+      m1: getSampleDashboardPanel<ContactCardEmbeddableInput>({
+        explicitInput: { firstName: 'a', id: 'm1' },
+        type: CONTACT_CARD_EMBEDDABLE,
+      }),
+    },
+  });
+
+  const container = new DashboardContainer(initialInput, deleteOptions);
+  container.removeEmbeddable('section1');
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  expect(openConfirm).toHaveBeenCalledTimes(1);
+  const panels = container.getInput().panels;
+  // Nothing removed.
+  expect(panels.section1).toBeDefined();
+  expect(panels.m1).toBeDefined();
+});

--- a/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/dashboard_container.tsx
@@ -34,6 +34,8 @@ import { isEqual } from 'lodash';
 import { Subscription } from 'rxjs';
 import React from 'react';
 import { createRoot, Root } from 'react-dom/client';
+import { i18n } from '@osd/i18n';
+import { EUI_MODAL_CONFIRM_BUTTON } from '@elastic/eui';
 import { I18nProvider } from '@osd/i18n/react';
 import { RefreshInterval, TimeRange, Query, Filter } from 'src/plugins/data/public';
 import { CoreStart, Logos } from 'src/core/public';
@@ -53,7 +55,7 @@ import {
 } from '../../../../embeddable/public';
 import { UiActionsStart } from '../../../../ui_actions/public';
 import { DataPublicPluginStart } from '../../../../data/public';
-import { DASHBOARD_CONTAINER_TYPE } from './dashboard_constants';
+import { DASHBOARD_CONTAINER_TYPE, SECTION_HEADER_ROWS } from './dashboard_constants';
 import { VariableService } from '../../variables/variable_service';
 import { Variable } from '../../variables/types';
 import {
@@ -70,6 +72,7 @@ import {
 } from '../../../../opensearch_dashboards_react/public';
 import { PLACEHOLDER_EMBEDDABLE } from './placeholder';
 import { PanelPlacementMethod, IPanelPlacementArgs } from './panel/dashboard_panel_placement';
+import { DASHBOARD_SECTION_EMBEDDABLE, DashboardSectionEmbeddableInput } from './section';
 
 export interface DashboardContainerInput extends ContainerInput {
   viewMode: ViewMode;
@@ -230,6 +233,127 @@ export class DashboardContainer extends Container<InheritedChildInput, Dashboard
         }
       })
     );
+  }
+
+  /**
+   * Section support (Option 1): "Delete from dashboard" on a section is the
+   * generic embeddable remove action; it has no section awareness and no
+   * confirmation. We intercept it here (the dashboard-scoped layer) so that
+   * removing a section removes the SECTION AND ITS MEMBER PANELS together,
+   * behind a confirmation dialog. Removing any non-section panel delegates to
+   * the base implementation unchanged.
+   *
+   * (Contrast with `ungroupSection`, wired to the "Ungroup section" action,
+   * which removes only the section and keeps the members on the dashboard.)
+   *
+   * The confirm is async while the base `removeEmbeddable` contract is sync +
+   * void, so we fire-and-forget: the only callers that remove a section are
+   * user-initiated actions (the generic delete + the ungroup action, which
+   * calls `ungroupSection` directly), so there is no programmatic path that
+   * would surface an unexpected dialog.
+   */
+  public removeEmbeddable(embeddableId: string) {
+    const panelToRemove = this.input.panels[embeddableId];
+    if (!panelToRemove || panelToRemove.type !== DASHBOARD_SECTION_EMBEDDABLE) {
+      super.removeEmbeddable(embeddableId);
+      return;
+    }
+    this.confirmAndDeleteSection(embeddableId);
+  }
+
+  /**
+   * Confirm, then delete the section AND all of its member panels from the
+   * dashboard. Used by the generic "Delete from dashboard" action on a section.
+   */
+  private async confirmAndDeleteSection(embeddableId: string) {
+    const panelToRemove = this.input.panels[embeddableId];
+    if (!panelToRemove || panelToRemove.type !== DASHBOARD_SECTION_EMBEDDABLE) {
+      return;
+    }
+    const members =
+      (panelToRemove.explicitInput as Partial<DashboardSectionEmbeddableInput>).members ?? [];
+    const memberCount = members.filter((m) => Boolean(this.input.panels[m.id])).length;
+
+    const confirmed = await this.options.overlays.openConfirm(
+      i18n.translate('dashboard.section.delete.confirmDescription', {
+        defaultMessage:
+          'This removes the section and its {memberCount, plural, one {# panel} other {# panels}}. This cannot be undone.',
+        values: { memberCount },
+      }),
+      {
+        title: i18n.translate('dashboard.section.delete.confirmTitle', {
+          defaultMessage: 'Delete section and its panels?',
+        }),
+        confirmButtonText: i18n.translate('dashboard.section.delete.confirmButtonLabel', {
+          defaultMessage: 'Delete',
+        }),
+        cancelButtonText: i18n.translate('dashboard.section.delete.cancelButtonLabel', {
+          defaultMessage: 'Cancel',
+        }),
+        buttonColor: 'danger',
+        defaultFocusedButton: EUI_MODAL_CONFIRM_BUTTON,
+      }
+    );
+
+    if (!confirmed) {
+      return;
+    }
+
+    const panels = { ...this.input.panels };
+    // Remove every member panel, then the section itself.
+    members.forEach((m) => {
+      delete panels[m.id];
+    });
+    delete panels[embeddableId];
+    this.updateInput({ panels });
+  }
+
+  /**
+   * Section support (Option 1): "Ungroup section" removes the section but LEAVES
+   * its members on the dashboard, where they visually were -- not teleported.
+   *
+   * Under Option 1 a member's own gridData is its ABSOLUTE "home" (its position
+   * before it joined the section) -- its in-section position lives in the
+   * section's explicitInput.members (SECTION-RELATIVE). If we just dropped the
+   * section panel, each member would fall back to its stale home and jump away
+   * from where it was rendered. So on ungroup we CONVERT each member's
+   * section-relative layout to an absolute position at the section's own
+   * location (sectionY + header rows + memberY) and write it into the member's
+   * gridData, then remove the section -- the members stay put and the outer
+   * grid's vertical compaction closes the vacated header gap.
+   */
+  public ungroupSection(embeddableId: string) {
+    const panelToRemove = this.input.panels[embeddableId];
+    if (!panelToRemove || panelToRemove.type !== DASHBOARD_SECTION_EMBEDDABLE) {
+      return;
+    }
+
+    // Section-relative member layout -> absolute at the section's rendered
+    // location. SECTION_HEADER_ROWS (shared constant) offsets past the header
+    // strip so released members land where they visually sat.
+    const sectionY = panelToRemove.gridData.y;
+    const members =
+      (panelToRemove.explicitInput as Partial<DashboardSectionEmbeddableInput>).members ?? [];
+
+    const panels = { ...this.input.panels };
+    members.forEach((m) => {
+      const memberPanel = panels[m.id];
+      if (!memberPanel) return;
+      panels[m.id] = {
+        ...memberPanel,
+        gridData: {
+          ...memberPanel.gridData,
+          // Section-relative -> absolute at the section's rendered location.
+          x: m.gridData.x,
+          y: sectionY + SECTION_HEADER_ROWS + m.gridData.y,
+          w: m.gridData.w,
+          h: m.gridData.h,
+        },
+      };
+    });
+
+    delete panels[embeddableId];
+    this.updateInput({ panels });
   }
 
   protected createNewPanelState<

--- a/src/plugins/dashboard/public/application/embeddable/grid/_dashboard_grid.scss
+++ b/src/plugins/dashboard/public/application/embeddable/grid/_dashboard_grid.scss
@@ -61,6 +61,132 @@
   // Altered panel styles can be found in ../panel
 }
 
+/**
+ * Rendering architecture: nested grids.
+ * A section is one outer grid item containing its header (EmbeddablePanel
+ * chrome) stacked above its own inner react-grid-layout of member panels.
+ * The inner grid's wrapper carries the `dshDashboardSectionGrid` marker class
+ * that the OUTER grid targets via draggableCancel for disjoint-drag isolation.
+ */
+.dshDashboardGrid__item--section {
+  display: flex;
+  flex-direction: column;
+  border: $euiBorderThin;
+  border-radius: $euiBorderRadius;
+  background-color: transparentize($euiColorLightestShade, 0.5);
+  overflow: hidden;
+}
+
+/**
+ * A hidden section must stay hidden (e.g. every non-owning section while a
+ * panel is maximized). `.dshDashboardGrid__item--hidden { display: none }` is
+ * declared earlier than `.dshDashboardGrid__item--section { display: flex }`
+ * above, and both are single-class selectors -- so on a section that carries
+ * BOTH classes, source order makes `display: flex` win and the section would
+ * stay visible, overlapping the maximized panel. This compound selector
+ * (specificity 0,2,0) restores display:none for that case.
+ */
+.dshDashboardGrid__item--section.dshDashboardGrid__item--hidden {
+  display: none;
+}
+
+/**
+ * The section's OWN header panel only (title + collapse chevron + kebab). It
+ * must stay header-height and never grow. Scoped to this wrapper -- NOT
+ * `.dshDashboardGrid__item--section .embPanel`, which would also match every
+ * MEMBER panel's .embPanel inside the inner grid and collapse their charts to
+ * ~1px (they have no intrinsic height). Member panels keep the default
+ * height:100% that fills their inner-grid item.
+ */
+.dshDashboardGrid__sectionHeader {
+  flex: 0 0 auto;
+
+  .embPanel {
+    height: auto;
+  }
+
+  // Keep the section header on a single row AND fix its height here, on the
+  // title row. .embPanel__title is a single element (unlike .embPanel, which is
+  // nested twice -- outer EmbeddableChildPanel wrapper + inner EuiPanel -- and
+  // would double any rule). The title text already truncates (euiTextTruncate on
+  // .embPanel__titleText), but .embPanel__title is flex-wrap:wrap by default,
+  // which would let the chevron + title + kebab wrap to a second line; nowrap
+  // (with min-width:0 so the title can shrink to its ellipsis) keeps it one row.
+
+  // Fixed height sizes the header to what the section reserves: at
+  // SECTION_HEADER_ROWS=2 the outer section item is a CONSTANT 38px taller than
+  // its inner grid (both grids share rowHeight/margin, so the per-row terms
+  // cancel: item - grid = 28*2 - 8 - 2*border = 38, independent of member count).
+  // The header card is the title row + ~2px card border, so a 36px title makes
+  // the card 38px -> header + inner grid == item content, and the grid fills the
+  // section exactly (no trailing gap, no clip). The card already renders the
+  // #FCFEFF (euiPanel--plain) background. Coupled to SECTION_HEADER_ROWS=2; if
+  // that changes, retune (item - grid = 38).
+  .embPanel__title {
+    flex-wrap: nowrap;
+    min-width: 0;
+    height: 36px;
+  }
+
+  // Empty section-embeddable body -- no visual footprint.
+  .dshSectionEmbeddable {
+    display: none;
+  }
+}
+
+.dshDashboardSectionGrid {
+  flex: 1 1 auto;
+  min-height: 0;
+
+  // Nested grid needs its own positioning context; inner react-grid-layout
+  // items are absolutely positioned relative to this wrapper.
+  position: relative;
+  width: 100%;
+}
+
+// The actual nested react-grid-layout. Hidden when collapsed, but kept mounted
+// (see DashboardSectionGrid `collapsed` prop -- unmounting would destroy the
+// member embeddables via EmbeddablePanel.componentWillUnmount).
+.dshDashboardSectionGrid__inner--collapsed {
+  display: none;
+}
+
+// Shown in place of the grid when the section is collapsed. Fills the section
+// body and centers the hint text both horizontally and vertically.
+.dshDashboardSectionGrid__collapsedHint {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: $euiSizeS $euiSize;
+  color: $euiColorDarkShade;
+  font-size: $euiFontSizeXS;
+  font-style: italic;
+  text-align: center;
+}
+
+// Call-to-action shown inside an empty, expanded section to add a first panel.
+// Fills the section body so the widget is centered horizontally + vertically.
+.dshDashboardSectionGrid__emptyCta {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: $euiSize;
+}
+
+// Mirrors the empty-dashboard start screen (.dshEmptyWidget): a dashed,
+// centered box with a prompt + "Add existing visualization" button. Uses
+// lighter padding than the full-dashboard widget so it fits a section's area.
+.dshDashboardSectionGrid__emptyWidget {
+  border: $euiBorderThin;
+  border-style: dashed;
+  border-radius: $euiBorderRadius;
+  padding: $euiSize $euiSizeXL;
+  text-align: center;
+  max-width: 400px;
+}
+
 // REACT-GRID
 
 .react-grid-item {
@@ -83,6 +209,20 @@
     &:focus {
       background-color: $embEditingModeHoverColor;
     }
+  }
+
+  /**
+   * hide the resize handle on non-resizable items (the section
+   * container passes isResizable:false -- see DashboardGrid.buildLayoutFromPanels).
+   * When an item is not resizable, react-grid-layout keeps rendering the handle
+   * and instead tags the item with `.react-resizable-hide`, expecting its OWN
+   * stylesheet (react-grid-layout/css/styles.css) to `display:none` it. This
+   * project doesn't import that stylesheet -- it only pulls in
+   * react-resizable/css/styles.css (the handle image) and manages handle
+   * visibility itself here -- so we must supply the hide rule ourselves.
+   */
+  &.react-resizable-hide > .react-resizable-handle {
+    display: none;
   }
 
   /**

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.test.tsx
@@ -44,15 +44,22 @@ import {
 } from '../../../../../embeddable/public/lib/test_samples';
 import { embeddablePluginMock } from '../../../../../embeddable/public/mocks';
 import { OpenSearchDashboardsContextProvider } from '../../../../../opensearch_dashboards_react/public';
+import { SectionEmbeddableFactory } from '../section';
+import { SECTION_HEADER_ROWS } from '../dashboard_constants';
 
 let dashboardContainer: DashboardContainer | undefined;
 
-function prepare(props?: Partial<DashboardGridProps>) {
+function prepare(props?: Partial<DashboardGridProps>, { withSections = true } = {}) {
   const { setup, doStart } = embeddablePluginMock.createInstance();
   setup.registerEmbeddableFactory(
     CONTACT_CARD_EMBEDDABLE,
     new ContactCardEmbeddableFactory((() => null) as any, {} as any)
   );
+  // Option 1: sections are "enabled" iff the section embeddable factory is
+  // registered (mirrors the allowDashboardSections flag gating in plugin.tsx).
+  if (withSections) {
+    setup.registerEmbeddableFactory('dashboard_section', new SectionEmbeddableFactory() as any);
+  }
   const start = doStart();
 
   const getEmbeddableFactory = start.getEmbeddableFactory;
@@ -225,4 +232,428 @@ test('DashboardGrid unmount unsubscribes', (done) => {
     });
 
   props.container.updateInput({ expandedPanelId: '1' });
+});
+
+// Dashboard collapsible sections.
+// Exercises the real DashboardGrid lockstep renderPanels()/buildLayoutFromPanels()
+// filtering against the section-as-panel data model -- not a standalone mock.
+describe('collapsible sections', () => {
+  const DASHBOARD_SECTION_EMBEDDABLE = 'dashboard_section';
+
+  function prepareWithSection() {
+    const { props, options } = prepare();
+    return { props, options };
+  }
+
+  test('member panels of an expanded section render normally', async () => {
+    const { props, options } = prepareWithSection();
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+
+    await act(async () => {
+      props.container.updateInput({
+        panels: {
+          section1: {
+            gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+            type: DASHBOARD_SECTION_EMBEDDABLE,
+            explicitInput: {
+              id: 'section1',
+              title: 'Section 1',
+              collapsed: false,
+              members: [{ id: '1', gridData: { x: 0, y: 0, w: 6, h: 6 } }],
+            },
+          },
+          '1': {
+            gridData: { x: 0, y: 0, w: 6, h: 6, i: '1' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: '1' },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      component.update();
+      // section panel itself + its one member both render/mount.
+      expect(component.find('EmbeddableChildPanel').length).toBe(2);
+    });
+  });
+
+  test('maximizing a section MEMBER expands its owning section and the member, hiding siblings', async () => {
+    const { props, options } = prepareWithSection();
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+
+    await act(async () => {
+      props.container.updateInput({
+        panels: {
+          section1: {
+            gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+            type: DASHBOARD_SECTION_EMBEDDABLE,
+            explicitInput: {
+              id: 'section1',
+              title: 'Section 1',
+              collapsed: false,
+              members: [
+                { id: '1', gridData: { x: 0, y: 0, w: 6, h: 6 } },
+                { id: '2', gridData: { x: 6, y: 0, w: 6, h: 6 } },
+              ],
+            },
+          },
+          '1': {
+            gridData: { x: 0, y: 0, w: 6, h: 6, i: '1' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: '1' },
+          },
+          '2': {
+            gridData: { x: 6, y: 0, w: 6, h: 6, i: '2' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: '2' },
+          },
+        },
+      });
+    });
+
+    // Maximize member '1' (as ExpandPanelAction does: sets container-level
+    // expandedPanelId to the member's id).
+    await act(async () => {
+      props.container.updateInput({ expandedPanelId: '1' });
+    });
+
+    await waitFor(() => {
+      component.update();
+      // Owning section item + the maximized member both carry --expanded.
+      expect(component.find('.dshDashboardGrid__item--expanded').length).toBeGreaterThanOrEqual(1);
+      // The sibling member '2' is hidden.
+      expect(component.find('.dshDashboardGrid__item--hidden').length).toBeGreaterThanOrEqual(1);
+      // All panels remain mounted (maximize must not destroy anything).
+      expect(component.find('EmbeddableChildPanel').length).toBe(3);
+    });
+
+    // Minimize -- everything returns to normal, nothing hidden.
+    await act(async () => {
+      props.container.updateInput({ expandedPanelId: undefined });
+    });
+
+    await waitFor(() => {
+      component.update();
+      expect(component.find('.dshDashboardGrid__item--hidden').length).toBe(0);
+      expect(component.find('EmbeddableChildPanel').length).toBe(3);
+    });
+  });
+
+  test('member panels stay mounted but are hidden when their section is collapsed', async () => {
+    const { props, options } = prepareWithSection();
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+
+    await act(async () => {
+      props.container.updateInput({
+        panels: {
+          section1: {
+            gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+            type: DASHBOARD_SECTION_EMBEDDABLE,
+            explicitInput: {
+              id: 'section1',
+              title: 'Section 1',
+              collapsed: false,
+              members: [
+                { id: '1', gridData: { x: 0, y: 0, w: 6, h: 6 } },
+                { id: '2', gridData: { x: 6, y: 0, w: 6, h: 6 } },
+              ],
+            },
+          },
+          '1': {
+            gridData: { x: 0, y: 0, w: 6, h: 6, i: '1' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: '1' },
+          },
+          '2': {
+            gridData: { x: 6, y: 0, w: 6, h: 6, i: '2' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: '2' },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      component.update();
+      // section header + 2 members = 3 mounted EmbeddableChildPanel entries.
+      expect(component.find('EmbeddableChildPanel').length).toBe(3);
+    });
+
+    // Collapse the section -- this is a real container.updateInput on the
+    // section's OWN explicitInput, exactly the primitive Phase 3's toggle
+    // action would call (container.updateInputForChild equivalent).
+    await act(async () => {
+      const panels = props.container.getInput().panels;
+      props.container.updateInput({
+        panels: {
+          ...panels,
+          section1: {
+            ...panels.section1,
+            explicitInput: { ...panels.section1.explicitInput, collapsed: true },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      component.update();
+      // CORRECTED behavior (see DashboardSectionGrid `collapsed` prop): a
+      // collapsed section's members stay MOUNTED -- all 3 EmbeddableChildPanel
+      // entries (header + 2 members) remain -- because unmounting would call
+      // EmbeddablePanel.componentWillUnmount -> embeddable.destroy() and the
+      // members would come back blank on expand. Collapse hides the inner grid
+      // via the --collapsed CSS modifier instead.
+      expect(component.find('EmbeddableChildPanel').length).toBe(3);
+      expect(component.find('.dshDashboardSectionGrid__inner--collapsed').length).toBeGreaterThan(
+        0
+      );
+    });
+
+    // Expand again -- members remount.
+    await act(async () => {
+      const panels = props.container.getInput().panels;
+      props.container.updateInput({
+        panels: {
+          ...panels,
+          section1: {
+            ...panels.section1,
+            explicitInput: { ...panels.section1.explicitInput, collapsed: false },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      component.update();
+      expect(component.find('EmbeddableChildPanel').length).toBe(3);
+    });
+  });
+
+  test('ungrouped panels (no sectionId) are unaffected by any section collapse state', async () => {
+    const { props, options } = prepareWithSection();
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+
+    await act(async () => {
+      props.container.updateInput({
+        panels: {
+          section1: {
+            gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+            type: DASHBOARD_SECTION_EMBEDDABLE,
+            explicitInput: {
+              id: 'section1',
+              title: 'Section 1',
+              collapsed: true,
+              members: [{ id: 'member1', gridData: { x: 0, y: 0, w: 6, h: 6 } }],
+            },
+          },
+          member1: {
+            gridData: { x: 0, y: 0, w: 6, h: 6, i: 'member1' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: 'member1' },
+          },
+          ungrouped1: {
+            gridData: { x: 0, y: 20, w: 6, h: 6, i: 'ungrouped1' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: 'ungrouped1' },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      component.update();
+      // section header + ungrouped1 + member1 (mounted-but-hidden under the
+      // collapsed section) = 3. The point of THIS test is that the ungrouped
+      // panel is present and unaffected by section1's collapsed state.
+      expect(component.find('EmbeddableChildPanel').length).toBe(3);
+      expect(component.find('[data-test-subj="dashboardPanel"]').length).toBeGreaterThan(0);
+    });
+  });
+
+  test('with sections disabled, section panels are dropped and members render ungrouped', async () => {
+    const { props, options } = prepare(undefined, { withSections: false });
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+
+    await act(async () => {
+      props.container.updateInput({
+        panels: {
+          section1: {
+            gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+            type: DASHBOARD_SECTION_EMBEDDABLE,
+            explicitInput: {
+              id: 'section1',
+              title: 'Section 1',
+              collapsed: false,
+              members: [{ id: '1', gridData: { x: 0, y: 0, w: 6, h: 6 } }],
+            },
+          },
+          '1': {
+            gridData: { x: 0, y: 10, w: 6, h: 6, i: '1' },
+            type: CONTACT_CARD_EMBEDDABLE,
+            explicitInput: { id: '1' },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      component.update();
+      // Section factory unregistered (feature off): the section panel is
+      // filtered out entirely (no inner section grid), and the former member
+      // renders as an ordinary standalone panel at its absolute gridData.
+      expect(component.find('[data-test-subj="dashboardSectionGrid-section1"]').length).toBe(0);
+      expect(component.find('EmbeddableChildPanel').length).toBe(1);
+    });
+  });
+});
+
+// Directly exercises the outer-grid layout math for sections
+// (buildLayoutFromPanels -> computeSectionOuterHeight): the section item's
+// reserved height and the exclusion of member panels from the outer grid.
+// jsdom can't lay out pixels, but the computed row `h` is a pure function of
+// the section's member list, so we assert it via the component instance.
+describe('collapsible sections: outer-grid height', () => {
+  const DASHBOARD_SECTION_EMBEDDABLE = 'dashboard_section';
+  // Mirrors EMPTY_SECTION_CTA_ROWS in dashboard_grid.tsx (rows reserved for the
+  // "add visualization" call-to-action shown in an empty, expanded section).
+  const EMPTY_SECTION_CTA_ROWS = 5;
+
+  interface OuterItem {
+    i: string;
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+    isResizable?: boolean;
+  }
+
+  const sectionPanel = (
+    collapsed: boolean,
+    members: Array<{ id: string; gridData: { x: number; y: number; w: number; h: number } }>
+  ) => ({
+    gridData: { x: 0, y: 0, w: 48, h: 4, i: 'section1' },
+    type: DASHBOARD_SECTION_EMBEDDABLE,
+    explicitInput: { id: 'section1', title: 'Section 1', collapsed, members },
+  });
+
+  const memberPanel = (id: string, gridData: { x: number; y: number; w: number; h: number }) => ({
+    gridData: { ...gridData, i: id },
+    type: CONTACT_CARD_EMBEDDABLE,
+    explicitInput: { id },
+  });
+
+  async function outerLayoutFor(panels: Record<string, unknown>): Promise<OuterItem[]> {
+    const { props, options } = prepare();
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+    await act(async () => {
+      props.container.updateInput({ panels: panels as any });
+    });
+    component.update();
+    const instance = component.find('DashboardGridUi').instance() as any;
+    return instance.buildLayoutFromPanels() as OuterItem[];
+  }
+
+  test('a collapsed section reserves exactly SECTION_HEADER_ROWS, full width, not resizable', async () => {
+    const layout = await outerLayoutFor({
+      section1: sectionPanel(true, [{ id: '1', gridData: { x: 0, y: 0, w: 24, h: 15 } }]),
+      '1': memberPanel('1', { x: 0, y: 0, w: 24, h: 15 }),
+    });
+    const section = layout.find((l) => l.i === 'section1');
+    expect(section?.h).toBe(SECTION_HEADER_ROWS);
+    expect(section?.w).toBe(48);
+    expect(section?.isResizable).toBe(false);
+  });
+
+  test('an expanded EMPTY section reserves header rows + CTA rows', async () => {
+    const layout = await outerLayoutFor({ section1: sectionPanel(false, []) });
+    const section = layout.find((l) => l.i === 'section1');
+    expect(section?.h).toBe(SECTION_HEADER_ROWS + EMPTY_SECTION_CTA_ROWS);
+  });
+
+  test('an expanded section height = header rows + tallest member bottom (max y + h)', async () => {
+    const members = [
+      { id: '1', gridData: { x: 0, y: 0, w: 24, h: 10 } }, // bottom 10
+      { id: '2', gridData: { x: 24, y: 0, w: 24, h: 15 } }, // bottom 15
+      { id: '3', gridData: { x: 0, y: 10, w: 24, h: 8 } }, // bottom 18 (tallest)
+    ];
+    const layout = await outerLayoutFor({
+      section1: sectionPanel(false, members),
+      '1': memberPanel('1', { x: 0, y: 0, w: 24, h: 10 }),
+      '2': memberPanel('2', { x: 24, y: 0, w: 24, h: 15 }),
+      '3': memberPanel('3', { x: 0, y: 10, w: 24, h: 8 }),
+    });
+    const section = layout.find((l) => l.i === 'section1');
+    expect(section?.h).toBe(SECTION_HEADER_ROWS + 18);
+  });
+
+  test('member panels are excluded from the outer layout (rendered by the inner grid)', async () => {
+    const layout = await outerLayoutFor({
+      section1: sectionPanel(false, [
+        { id: '1', gridData: { x: 0, y: 0, w: 24, h: 15 } },
+        { id: '2', gridData: { x: 24, y: 0, w: 24, h: 15 } },
+      ]),
+      '1': memberPanel('1', { x: 0, y: 0, w: 24, h: 15 }),
+      '2': memberPanel('2', { x: 24, y: 0, w: 24, h: 15 }),
+      free: memberPanel('free', { x: 0, y: 30, w: 12, h: 6 }), // ungrouped panel
+    });
+    const ids = layout.map((l) => l.i).sort();
+    // Only the section item and the ungrouped panel appear at the outer level;
+    // members '1' and '2' are owned by the inner grid.
+    expect(ids).toEqual(['free', 'section1']);
+  });
+
+  test('with sections disabled, the section panel is dropped and members fall through as ungrouped', async () => {
+    const { props, options } = prepare(undefined, { withSections: false });
+    const component = mountWithIntl(
+      <OpenSearchDashboardsContextProvider services={options}>
+        <DashboardGrid {...props} />
+      </OpenSearchDashboardsContextProvider>
+    );
+    await act(async () => {
+      props.container.updateInput({
+        panels: {
+          section1: sectionPanel(false, [
+            { id: '1', gridData: { x: 0, y: 0, w: 24, h: 15 } },
+          ]) as any,
+          '1': memberPanel('1', { x: 3, y: 7, w: 24, h: 15 }) as any,
+        },
+      });
+    });
+    component.update();
+    const instance = component.find('DashboardGridUi').instance() as any;
+    const layout = instance.buildLayoutFromPanels() as OuterItem[];
+    // Flag off: the dashboard_section panel is filtered out (factory absent) and
+    // the former member falls through as an ordinary panel at the outer level.
+    // (Its y may be vertically compacted by react-grid-layout, so assert only
+    // presence and the stable dimensions, not the exact y.)
+    expect(layout.find((l) => l.i === 'section1')).toBeUndefined();
+    const member = layout.find((l) => l.i === '1');
+    expect(member).toBeDefined();
+    expect(member).toMatchObject({ x: 3, w: 24, h: 15 });
+  });
 });

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_grid.tsx
@@ -28,101 +28,38 @@
  * under the License.
  */
 
-import 'react-resizable/css/styles.css';
-
-// @ts-ignore
-import sizeMe from 'react-sizeme';
-
 import { injectI18n } from '@osd/i18n/react';
 import classNames from 'classnames';
 import _ from 'lodash';
 import React from 'react';
 import { Subscription } from 'rxjs';
-import ReactGridLayout, { Layout, ReactGridLayoutProps } from 'react-grid-layout';
+import { Layout } from 'react-grid-layout';
 import { ViewMode, EmbeddableChildPanel, EmbeddableStart } from '../../../../../embeddable/public';
 import { GridData } from '../../../../common';
-import { DASHBOARD_GRID_COLUMN_COUNT, DASHBOARD_GRID_HEIGHT } from '../dashboard_constants';
 import { DashboardPanelState } from '../types';
+import { DASHBOARD_SECTION_EMBEDDABLE } from '../section';
+import {
+  buildSectionMemberMap,
+  SectionMember,
+  DashboardSectionEmbeddableInput,
+} from '../section/section_embeddable';
 import { withOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
 import { DashboardContainerInput } from '../dashboard_container';
 import { DashboardContainer, DashboardReactContextValue } from '../dashboard_container';
-
-let lastValidGridSize = 0;
+import { ResponsiveSizedGrid, SECTION_INNER_GRID_CANCEL } from './dashboard_responsive_grid';
+import { DashboardSectionGrid } from './dashboard_section_grid';
+import { SECTION_HEADER_ROWS } from '../dashboard_constants';
+import { openAddPanelToSectionFlyout } from '../../actions/add_panel_to_section_flyout';
 
 /**
- * This is a fix for a bug that stopped the browser window from automatically scrolling down when panels were made
- * taller than the current grid.
- * see https://github.com/elastic/kibana/issues/14710.
+ * SECTION_HEADER_ROWS (the outer-grid
+ * rows reserved for a section's header strip) now lives in dashboard_constants
+ * as the single source of truth -- see the constant there for the rendering
+ * rationale (single-line header, 1-row-clips / 2-rows-clears trade-off).
  */
-function ensureWindowScrollsToBottom(event: { clientY: number; pageY: number }) {
-  // The buffer is to handle the case where the browser is maximized and it's impossible for the mouse to move below
-  // the screen, out of the window.  see https://github.com/elastic/kibana/issues/14737
-  const WINDOW_BUFFER = 10;
-  if (event.clientY > window.innerHeight - WINDOW_BUFFER) {
-    window.scrollTo(0, event.pageY + WINDOW_BUFFER - window.innerHeight);
-  }
-}
 
-function ResponsiveGrid({
-  size,
-  isViewMode,
-  layout,
-  onLayoutChange,
-  children,
-  maximizedPanelId,
-  useMargins,
-}: {
-  size: { width: number };
-  isViewMode: boolean;
-  layout: Layout[];
-  onLayoutChange: ReactGridLayoutProps['onLayoutChange'];
-  children: JSX.Element[];
-  maximizedPanelId?: string;
-  useMargins: boolean;
-}) {
-  // This is to prevent a bug where view mode changes when the panel is expanded.  View mode changes will trigger
-  // the grid to re-render, but when a panel is expanded, the size will be 0. Minimizing the panel won't cause the
-  // grid to re-render so it'll show a grid with a width of 0.
-  lastValidGridSize = size.width > 0 ? size.width : lastValidGridSize;
-  const classes = classNames({
-    'dshLayout--viewing': isViewMode,
-    'dshLayout--editing': !isViewMode,
-    'dshLayout-isMaximizedPanel': maximizedPanelId !== undefined,
-    'dshLayout-withoutMargins': !useMargins,
-  });
-
-  const MARGINS = useMargins ? 8 : 0;
-  // We can't take advantage of isDraggable or isResizable due to performance concerns:
-  // https://github.com/STRML/react-grid-layout/issues/240
-  return (
-    // @ts-expect-error TS2769 TODO(ts-error): fixme
-    <ReactGridLayout
-      width={lastValidGridSize}
-      className={classes}
-      isDraggable={true}
-      isResizable={true}
-      // There is a bug with d3 + firefox + elements using transforms.
-      // See https://github.com/elastic/kibana/issues/16870 for more context.
-      useCSSTransforms={false}
-      margin={[MARGINS, MARGINS]}
-      cols={DASHBOARD_GRID_COLUMN_COUNT}
-      rowHeight={DASHBOARD_GRID_HEIGHT}
-      // Pass the named classes of what should get the dragging handle
-      // (.doesnt-exist literally doesnt exist)
-      draggableHandle={isViewMode ? '.doesnt-exist' : '.embPanel__dragger'}
-      layout={layout}
-      onLayoutChange={onLayoutChange}
-      onResize={({}, {}, {}, {}, event) => ensureWindowScrollsToBottom(event)}
-    >
-      {children}
-    </ReactGridLayout>
-  );
-}
-
-// Using sizeMe sets up the grid to be re-rendered automatically not only when the window size changes, but also
-// when the container size changes, so it works for Full Screen mode switches.
-const config = { monitorWidth: true };
-const ResponsiveSizedGrid = sizeMe(config)(ResponsiveGrid);
+/** Extra inner rows reserved for an empty, expanded section's add-panel CTA. */
+const EMPTY_SECTION_CTA_ROWS = 5;
 
 export interface DashboardGridProps extends ReactIntl.InjectedIntlProps {
   opensearchDashboards: DashboardReactContextValue;
@@ -210,25 +147,179 @@ class DashboardGridUi extends React.Component<DashboardGridProps, State> {
     }
   }
 
-  public buildLayoutFromPanels = (): GridData[] => {
-    return _.map(this.state.panels, (panel) => {
-      return panel.gridData;
+  // ---------------------------------------------------------------------------
+  // Option 1 (section-owned member list). Membership + the
+  // section-relative layout of members live in each section panel's
+  // `explicitInput.members`. Member panels stay in the flat `panels` map with
+  // their own ABSOLUTE gridData and NO sectionId. The flat map therefore
+  // contains only two kinds of OUTER entry from the grid's perspective:
+  //   1. Section panels    (type === DASHBOARD_SECTION_EMBEDDABLE)
+  //   2. Ungrouped panels  (not listed in any section's `members`)
+  // A panel listed in some section's `members` is rendered by that section's
+  // inner DashboardSectionGrid (at its section-relative layout), never by the
+  // outer grid.
+  // ---------------------------------------------------------------------------
+
+  private isSectionPanel = (panel: DashboardPanelState): boolean =>
+    panel.type === DASHBOARD_SECTION_EMBEDDABLE;
+
+  /**
+   * Whether the collapsible-sections feature is active. When the
+   * allowDashboardSections flag is off, plugin.tsx never registers the section
+   * embeddable factory, so getEmbeddableFactory returns undefined. In that case
+   * the grid filters section panels out entirely and renders every other panel
+   * (including former members) at its own ABSOLUTE gridData -- former members
+   * are valid standalone panels under Option 1, so no error and no relayout.
+   */
+  private sectionsEnabled = (): boolean =>
+    Boolean(
+      this.props.opensearchDashboards?.services?.embeddable?.getEmbeddableFactory?.(
+        DASHBOARD_SECTION_EMBEDDABLE
+      )
+    );
+
+  /** Section member map, or an empty map when the feature is disabled. */
+  private getMemberMap = (panels: { [key: string]: DashboardPanelState }) =>
+    this.sectionsEnabled()
+      ? buildSectionMemberMap(panels)
+      : new Map<string, { sectionId: string; member: SectionMember }>();
+
+  /**
+   * Open the "add existing visualization to section" flyout for a section.
+   * Shared by the section's kebab action and the empty-section call-to-action.
+   */
+  private openAddPanelToSection = (sectionId: string) => {
+    const services = this.props.opensearchDashboards?.services;
+    if (!services?.overlays) return;
+    openAddPanelToSectionFlyout({
+      overlays: services.overlays,
+      notifications: services.notifications,
+      container: this.props.container,
+      sectionId,
+      savedObjectFinder: services.SavedObjectFinder,
+      getEmbeddableFactories: services.embeddable.getEmbeddableFactories,
     });
   };
 
+  private isSectionCollapsed = (sectionPanel: DashboardPanelState): boolean =>
+    Boolean((sectionPanel.explicitInput as { collapsed?: boolean }).collapsed);
+
+  /** The section's own authoritative member list (section-relative layout). */
+  private getSectionMemberLayouts = (sectionPanel: DashboardPanelState): SectionMember[] =>
+    (
+      (sectionPanel.explicitInput as Partial<DashboardSectionEmbeddableInput>).members ?? []
+    ).slice();
+
+  /**
+   * Resolve a section's members to { panel, member } pairs for rendering, in
+   * layout order. Entries whose panel no longer exists in the flat map
+   * (stale reference) are skipped.
+   */
+  private getSectionMembers = (
+    sectionPanel: DashboardPanelState,
+    panels: { [key: string]: DashboardPanelState }
+  ): Array<{ panel: DashboardPanelState; member: SectionMember }> =>
+    this.getSectionMemberLayouts(sectionPanel)
+      .map((member) => ({ panel: panels[member.id], member }))
+      .filter((m) => Boolean(m.panel));
+
+  /**
+   * Outer-grid height (in outer rows) for a section item: the header strip
+   * plus, when expanded, enough rows to contain the inner grid's content.
+   * Inner and outer grids share rowHeight/margin/columns, so an inner content
+   * span of N rows occupies N outer rows too (no scaling).
+   */
+  private computeSectionOuterHeight = (
+    sectionPanel: DashboardPanelState,
+    collapsed: boolean
+  ): number => {
+    if (collapsed) return SECTION_HEADER_ROWS;
+    const innerContentRows = this.getSectionMemberLayouts(sectionPanel).reduce(
+      (max, m) => Math.max(max, m.gridData.y + m.gridData.h),
+      0
+    );
+    // An empty, expanded section reserves a few rows so its "add visualization"
+    // call-to-action has room to render.
+    if (innerContentRows === 0) return SECTION_HEADER_ROWS + EMPTY_SECTION_CTA_ROWS;
+    return SECTION_HEADER_ROWS + innerContentRows;
+  };
+
+  /**
+   * The OUTER grid's layout: ungrouped panels + section panels only. Panels
+   * listed in a section's `members` are excluded (rendered by inner grids).
+   * Each section panel's `h` is overridden with the computed header+content
+   * height so the outer item is exactly tall enough for its inner grid.
+   */
+  public buildLayoutFromPanels = (): Array<GridData & { isResizable?: boolean }> => {
+    const { panels } = this.state;
+    const sectionsEnabled = this.sectionsEnabled();
+    const memberMap = this.getMemberMap(panels);
+    return Object.values(panels)
+      .filter((panel) => {
+        // When the feature is off, drop section panels entirely (their factory
+        // is unregistered -> they'd render as errors). Members are not in the
+        // (empty) member map, so they fall through and render at absolute coords.
+        if (this.isSectionPanel(panel)) return sectionsEnabled;
+        return !memberMap.has(panel.explicitInput.id);
+      })
+      .map((panel) => {
+        if (sectionsEnabled && this.isSectionPanel(panel)) {
+          const collapsed = this.isSectionCollapsed(panel);
+          return {
+            ...panel.gridData,
+            h: this.computeSectionOuterHeight(panel, collapsed),
+            // The section container is NOT user-resizable -- its outer height is
+            // derived each render from its members, so a manual resize would be
+            // overwritten. Per-item RGL override; ordinary panels keep resize.
+            isResizable: false,
+          };
+        }
+        return panel.gridData;
+      });
+  };
+
+  /**
+   * OUTER grid layout-change handler. `layout` only contains outer items
+   * (ungrouped panels + section panels). Section members are NOT in it and are
+   * preserved untouched -- merge the reported outer updates over the full map.
+   */
   public onLayoutChange = (layout: PanelLayout[]) => {
-    const panels = this.state.panels;
-    const updatedPanels: { [key: string]: DashboardPanelState } = layout.reduce(
-      (updatedPanelsAcc, panelLayout) => {
-        updatedPanelsAcc[panelLayout.i] = {
-          ...panels[panelLayout.i],
+    const { panels } = this.state;
+    const updatedOuter: { [key: string]: DashboardPanelState } = layout.reduce(
+      (acc, panelLayout) => {
+        const existing = panels[panelLayout.i];
+        if (!existing) return acc;
+        acc[panelLayout.i] = {
+          ...existing,
           gridData: _.pick(panelLayout, ['x', 'y', 'w', 'h', 'i']),
         };
-        return updatedPanelsAcc;
+        return acc;
       },
       {} as { [key: string]: DashboardPanelState }
     );
-    this.onPanelsUpdated(updatedPanels);
+    this.onPanelsUpdated({ ...panels, ...updatedOuter });
+  };
+
+  /**
+   * INNER grid layout-change handler, one section at a time. The section OWNS
+   * its members' layout, so we write the updated section-relative layout back
+   * into that section panel's `explicitInput.members` -- member panels' own
+   * gridData is never touched here.
+   */
+  public onSectionMembersLayoutChange = (sectionId: string, updatedLayouts: SectionMember[]) => {
+    const { panels } = this.state;
+    const sectionPanel = panels[sectionId];
+    if (!sectionPanel) return;
+    this.onPanelsUpdated({
+      ...panels,
+      [sectionId]: {
+        ...sectionPanel,
+        explicitInput: {
+          ...sectionPanel.explicitInput,
+          members: updatedLayouts,
+        },
+      },
+    });
   };
 
   public onPanelsUpdated = (panels: { [key: string]: DashboardPanelState }) => {
@@ -248,41 +339,102 @@ class DashboardGridUi extends React.Component<DashboardGridProps, State> {
   };
 
   public renderPanels() {
-    const { focusedPanelIndex, panels, expandedPanelId } = this.state;
+    const { focusedPanelIndex, panels, expandedPanelId, viewMode, useMargins } = this.state;
+    const isViewMode = viewMode === ViewMode.VIEW;
 
-    // Part of our unofficial API - need to render in a consistent order for plugins.
-    const panelsInOrder = Object.keys(panels).map(
-      (key: string) => panels[key] as DashboardPanelState
-    );
-    panelsInOrder.sort((panelA, panelB) => {
+    // When the maximized panel is a section MEMBER it lives in that section's
+    // inner grid, not the outer grid. Maximizing it is therefore a two-level
+    // operation: the OWNING SECTION's outer item is expanded (and every other
+    // outer item hidden) while that section's inner grid expands the member
+    // itself (see DashboardSectionGrid). Resolve the owning section here.
+    const memberMap = this.getMemberMap(panels);
+    const sectionsEnabled = this.sectionsEnabled();
+    // If the maximized panel is a section MEMBER, resolve its owning section so
+    // the two-level maximize can expand that section at the outer level.
+    const expandedOwnerSectionId = expandedPanelId
+      ? memberMap.get(expandedPanelId)?.sectionId
+      : undefined;
+
+    // Outer children: section panels (only when enabled) + ungrouped panels
+    // (anything NOT listed as a member of some section), in consistent order.
+    const outerPanels = Object.values(panels).filter((panel) => {
+      if (this.isSectionPanel(panel)) return sectionsEnabled;
+      return !memberMap.has(panel.explicitInput.id);
+    });
+    outerPanels.sort((panelA, panelB) => {
       if (panelA.gridData.y === panelB.gridData.y) {
         return panelA.gridData.x - panelB.gridData.x;
-      } else {
-        return panelA.gridData.y - panelB.gridData.y;
       }
+      return panelA.gridData.y - panelB.gridData.y;
     });
 
-    return _.map(panelsInOrder, (panel) => {
+    return _.map(outerPanels, (panel) => {
+      const id = panel.explicitInput.id;
+      // A section item is "expanded" when the section itself is maximized OR
+      // when it owns the maximized member; any other outer item is hidden.
       const expandPanel =
-        expandedPanelId !== undefined && expandedPanelId === panel.explicitInput.id;
-      const hidePanel = expandedPanelId !== undefined && expandedPanelId !== panel.explicitInput.id;
+        expandedPanelId !== undefined && (expandedPanelId === id || id === expandedOwnerSectionId);
+      const hidePanel = expandedPanelId !== undefined && !expandPanel;
+      const isSection = this.isSectionPanel(panel);
       const classes = classNames({
         'dshDashboardGrid__item--expanded': expandPanel,
         'dshDashboardGrid__item--hidden': hidePanel,
+        'dshDashboardGrid__item--section': isSection,
       });
+
+      // Section item: header (via EmbeddableChildPanel chrome, so it keeps its
+      // own kebab actions) + an inner grid of its members when expanded.
+      if (isSection) {
+        const collapsed = this.isSectionCollapsed(panel);
+        const members = this.getSectionMembers(panel, panels);
+        return (
+          <div
+            style={{ zIndex: focusedPanelIndex === id ? 2 : 'auto' }}
+            className={classes}
+            key={id}
+            data-test-subj="dashboardPanel"
+            ref={(reactGridItem) => {
+              this.gridItems[id] = reactGridItem;
+            }}
+          >
+            <div className="dshDashboardGrid__sectionHeader">
+              <EmbeddableChildPanel
+                key={panel.type}
+                embeddableId={id}
+                container={this.props.container}
+                PanelComponent={this.props.PanelComponent}
+              />
+            </div>
+            <DashboardSectionGrid
+              container={this.props.container}
+              PanelComponent={this.props.PanelComponent}
+              sectionId={id}
+              members={members}
+              isViewMode={isViewMode}
+              useMargins={useMargins}
+              collapsed={collapsed}
+              expandedPanelId={expandedPanelId}
+              onMembersLayoutChange={this.onSectionMembersLayoutChange}
+              onAddPanel={() => this.openAddPanelToSection(id)}
+            />
+          </div>
+        );
+      }
+
+      // Ordinary (ungrouped) panel -- unchanged from the pre-sections behavior.
       return (
         <div
-          style={{ zIndex: focusedPanelIndex === panel.explicitInput.id ? 2 : 'auto' }}
+          style={{ zIndex: focusedPanelIndex === id ? 2 : 'auto' }}
           className={classes}
-          key={panel.explicitInput.id}
+          key={id}
           data-test-subj="dashboardPanel"
           ref={(reactGridItem) => {
-            this.gridItems[panel.explicitInput.id] = reactGridItem;
+            this.gridItems[id] = reactGridItem;
           }}
         >
           <EmbeddableChildPanel
             key={panel.type}
-            embeddableId={panel.explicitInput.id}
+            embeddableId={id}
             container={this.props.container}
             PanelComponent={this.props.PanelComponent}
           />
@@ -296,7 +448,7 @@ class DashboardGridUi extends React.Component<DashboardGridProps, State> {
       return null;
     }
 
-    const { viewMode } = this.state;
+    const { viewMode, useMargins } = this.state;
     const isViewMode = viewMode === ViewMode.VIEW;
     return (
       <ResponsiveSizedGrid
@@ -304,7 +456,12 @@ class DashboardGridUi extends React.Component<DashboardGridProps, State> {
         layout={this.buildLayoutFromPanels()}
         onLayoutChange={this.onLayoutChange}
         maximizedPanelId={this.state.expandedPanelId!}
-        useMargins={this.state.useMargins}
+        useMargins={useMargins}
+        // a mousedown inside any section's inner grid must NOT
+        // start a drag of the section (outer) item -- the inner grid handles
+        // its own members. This is the disjoint-drag isolation from the
+        // nested-grid prototype (see dashboard_responsive_grid).
+        draggableCancel={SECTION_INNER_GRID_CANCEL}
       >
         {this.renderPanels()}
       </ResponsiveSizedGrid>

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_responsive_grid.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_responsive_grid.tsx
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Dashboard collapsible sections
+// "Rendering architecture: nested grids".
+//
+// This is the shared, reusable `react-grid-layout` primitive used by BOTH
+// the outer dashboard grid (DashboardGrid) and each section's inner grid
+// (DashboardSectionGrid). It was extracted from DashboardGrid so the exact
+// same drag/resize/collision behavior is available at both nesting levels.
+//
+// Two changes versus the original inline ResponsiveGrid in dashboard_grid.tsx:
+//   1. `draggableHandle`/`draggableCancel` are props (not hard-coded), so the
+//      outer grid can EXCLUDE inner-grid drags via draggableCancel while the
+//      inner grid uses the standard panel dragger -- this is the disjoint-drag
+//      isolation the nested-grid prototype proved necessary.
+//   2. The "last valid measured width" is a PER-INSTANCE ref, not a module
+//      global. The original code kept `lastValidGridSize` as a module-level
+//      variable; with nested grids that is actively wrong -- the inner grid's
+//      width differs from the outer grid's, and a shared global would let
+//      whichever rendered last clobber the other's width. A per-instance ref
+//      keeps each grid's width independent.
+
+import 'react-resizable/css/styles.css';
+
+// @ts-ignore
+import sizeMe from 'react-sizeme';
+
+import classNames from 'classnames';
+import React from 'react';
+import ReactGridLayout, { Layout, ReactGridLayoutProps } from 'react-grid-layout';
+import { DASHBOARD_GRID_COLUMN_COUNT, DASHBOARD_GRID_HEIGHT } from '../dashboard_constants';
+
+/** Standard panel drag handle class rendered by EmbeddablePanel chrome. */
+export const PANEL_DRAG_HANDLE = '.embPanel__dragger';
+
+/**
+ * Class applied to a section's inner-grid wrapper. The OUTER grid passes this
+ * as `draggableCancel` so a mousedown inside a section's inner grid never
+ * starts a drag of the section (outer) item -- the inner member's own grid
+ * handles it instead. Disjoint-drag isolation, verified in the prototype.
+ */
+export const SECTION_INNER_GRID_CANCEL = '.dshDashboardSectionGrid';
+
+/**
+ * This is a fix for a bug that stopped the browser window from automatically scrolling down when panels were made
+ * taller than the current grid.
+ * see https://github.com/elastic/kibana/issues/14710.
+ */
+function ensureWindowScrollsToBottom(event: { clientY: number; pageY: number }) {
+  // The buffer is to handle the case where the browser is maximized and it's impossible for the mouse to move below
+  // the screen, out of the window.  see https://github.com/elastic/kibana/issues/14737
+  const WINDOW_BUFFER = 10;
+  if (event.clientY > window.innerHeight - WINDOW_BUFFER) {
+    window.scrollTo(0, event.pageY + WINDOW_BUFFER - window.innerHeight);
+  }
+}
+
+export interface ResponsiveGridProps {
+  size: { width: number };
+  isViewMode: boolean;
+  layout: Layout[];
+  onLayoutChange: ReactGridLayoutProps['onLayoutChange'];
+  children: JSX.Element[];
+  maximizedPanelId?: string;
+  useMargins: boolean;
+  /** Extra class(es) on the ReactGridLayout root, e.g. the section inner-grid marker. */
+  className?: string;
+  /** Defaults to the standard panel dragger. */
+  draggableHandle?: string;
+  /** In edit mode, mousedowns matching this selector never start a drag on THIS grid. */
+  draggableCancel?: string;
+}
+
+function ResponsiveGrid({
+  size,
+  isViewMode,
+  layout,
+  onLayoutChange,
+  children,
+  maximizedPanelId,
+  useMargins,
+  className,
+  draggableHandle,
+  draggableCancel,
+}: ResponsiveGridProps) {
+  // Per-instance "last valid width". sizeMe reports width 0 in some transient
+  // states (e.g. while a panel is expanded); we keep the last non-zero width
+  // so the grid doesn't collapse to width 0. Instance-local (useRef) so nested
+  // grids never clobber each other's width -- see file header note.
+  const lastValidWidthRef = React.useRef(0);
+  if (size.width > 0) {
+    lastValidWidthRef.current = size.width;
+  }
+  const width = lastValidWidthRef.current;
+
+  const classes = classNames(className, {
+    'dshLayout--viewing': isViewMode,
+    'dshLayout--editing': !isViewMode,
+    'dshLayout-isMaximizedPanel': maximizedPanelId !== undefined,
+    'dshLayout-withoutMargins': !useMargins,
+  });
+
+  const MARGINS = useMargins ? 8 : 0;
+  // We can't take advantage of isDraggable or isResizable due to performance concerns:
+  // https://github.com/STRML/react-grid-layout/issues/240
+  return (
+    // @ts-expect-error TS2769 TODO(ts-error): fixme
+    <ReactGridLayout
+      width={width}
+      className={classes}
+      isDraggable={true}
+      isResizable={true}
+      // There is a bug with d3 + firefox + elements using transforms.
+      // See https://github.com/elastic/kibana/issues/16870 for more context.
+      useCSSTransforms={false}
+      margin={[MARGINS, MARGINS]}
+      cols={DASHBOARD_GRID_COLUMN_COUNT}
+      rowHeight={DASHBOARD_GRID_HEIGHT}
+      // Pass the named classes of what should get the dragging handle
+      // (.doesnt-exist literally doesnt exist -> nothing draggable in view mode)
+      draggableHandle={isViewMode ? '.doesnt-exist' : (draggableHandle ?? PANEL_DRAG_HANDLE)}
+      draggableCancel={draggableCancel}
+      layout={layout}
+      onLayoutChange={onLayoutChange}
+      onResize={({}, {}, {}, {}, event) => ensureWindowScrollsToBottom(event)}
+    >
+      {children}
+    </ReactGridLayout>
+  );
+}
+
+// Using sizeMe sets up the grid to be re-rendered automatically not only when the window size changes, but also
+// when the container size changes, so it works for Full Screen mode switches.
+const config = { monitorWidth: true };
+export const ResponsiveSizedGrid = sizeMe(config)(ResponsiveGrid);

--- a/src/plugins/dashboard/public/application/embeddable/grid/dashboard_section_grid.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/grid/dashboard_section_grid.tsx
@@ -1,0 +1,227 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Dashboard collapsible sections
+// "Rendering architecture: nested grids with section-relative coordinates".
+//
+// One instance of this component is rendered per EXPANDED section, inside that
+// section's outer grid item (below its header). It owns a real, independent
+// `react-grid-layout` instance containing ONLY that section's member panels.
+// react-grid-layout provides drag/resize/collision natively for this inner
+// grid, exactly as it does for the outer dashboard grid -- no hand-rolled
+// placement/collision logic (that was the flat-overlay Path-1 approach that
+// was removed).
+//
+// Coordinate model: a member's gridData.x/y are
+// SECTION-RELATIVE -- coordinates within THIS inner grid (0-based rows), NOT
+// the outer dashboard grid. They are never compared against outer-grid or
+// other-section coordinates.
+
+import _ from 'lodash';
+import React from 'react';
+import classNames from 'classnames';
+import { i18n } from '@osd/i18n';
+import { EuiButton, EuiText, EuiSpacer } from '@elastic/eui';
+import { Layout } from 'react-grid-layout';
+import { EmbeddableChildPanel, EmbeddableStart } from '../../../../../embeddable/public';
+import { DashboardContainer } from '../dashboard_container';
+import { DashboardPanelState } from '../types';
+import { SectionMember } from '../section/section_embeddable';
+import {
+  ResponsiveSizedGrid,
+  PANEL_DRAG_HANDLE,
+  SECTION_INNER_GRID_CANCEL,
+} from './dashboard_responsive_grid';
+
+interface PanelLayout extends Layout {
+  i: string;
+}
+
+export interface DashboardSectionGridProps {
+  container: DashboardContainer;
+  PanelComponent: EmbeddableStart['EmbeddablePanel'];
+  /** Section panel id these members belong to. */
+  sectionId: string;
+  /**
+   * This section's members as { panel, layout } pairs, where `panel` is the
+   * member's entry in the flat dashboard map and `layout` is its
+   * SECTION-RELATIVE position owned by the section (explicitInput.members).
+   */
+  members: Array<{ panel: DashboardPanelState; member: SectionMember }>;
+  isViewMode: boolean;
+  useMargins: boolean;
+  /**
+   * When true the section is collapsed: the inner grid is CSS-hidden
+   * (display:none) but its member panels stay MOUNTED. We deliberately do NOT
+   * unmount them -- OSD's EmbeddablePanel.componentWillUnmount() calls
+   * embeddable.destroy(), so unmounting a collapsed section's members would
+   * tear them down and they'd re-mount blank/white on expand. Hiding (the same
+   * mechanism OSD's "expand one panel" uses for the other panels via
+   * dshDashboardGrid__item--hidden) keeps each member alive so expand restores
+   * it intact.
+   */
+  collapsed: boolean;
+  /**
+   * The dashboard's currently maximized panel id (container.expandedPanelId).
+   * When it matches one of THIS section's members, that member is expanded to
+   * fill the section (and its siblings hidden) -- the inner half of the
+   * two-level maximize. Undefined / non-member id => normal grid.
+   */
+  expandedPanelId?: string;
+  /**
+   * Called when the inner grid reports a layout change (drag/resize/collision
+   * within the section). Receives the section's NEW section-relative member
+   * layout list; the caller writes it back into the section panel's
+   * explicitInput.members (member panels' own gridData is never touched).
+   */
+  onMembersLayoutChange: (sectionId: string, updatedLayouts: SectionMember[]) => void;
+  /**
+   * Opens the "add existing visualization to section" flyout. Used by the
+   * call-to-action shown when the (expanded) section has no members yet.
+   */
+  onAddPanel?: () => void;
+}
+
+export class DashboardSectionGrid extends React.Component<DashboardSectionGridProps> {
+  public onLayoutChange = (layout: PanelLayout[]) => {
+    const { members, sectionId, onMembersLayoutChange } = this.props;
+    const validIds = new Set(members.map((m) => m.panel.explicitInput.id));
+    const updatedLayouts: SectionMember[] = layout
+      .filter((panelLayout) => validIds.has(panelLayout.i))
+      .map((panelLayout) => ({
+        id: panelLayout.i,
+        gridData: _.pick(panelLayout, ['x', 'y', 'w', 'h']),
+      }));
+    onMembersLayoutChange(sectionId, updatedLayouts);
+  };
+
+  public render() {
+    const {
+      members,
+      container,
+      PanelComponent,
+      isViewMode,
+      useMargins,
+      sectionId,
+      collapsed,
+      expandedPanelId,
+      onAddPanel,
+    } = this.props;
+
+    const membersInOrder = [...members].sort((a, b) => {
+      if (a.member.gridData.y === b.member.gridData.y)
+        return a.member.gridData.x - b.member.gridData.x;
+      return a.member.gridData.y - b.member.gridData.y;
+    });
+
+    const layout: PanelLayout[] = membersInOrder.map((m) => ({
+      ..._.pick(m.member.gridData, ['x', 'y', 'w', 'h']),
+      i: m.panel.explicitInput.id,
+    }));
+
+    // Inner half of the two-level maximize: when the dashboard's maximized
+    // panel is one of THIS section's members, that member fills the section
+    // and its siblings are hidden -- reusing the outer grid's own expand/hide
+    // classes so the CSS (position/height/width overrides) is shared.
+    const hasMaximizedMember =
+      expandedPanelId !== undefined &&
+      membersInOrder.some((m) => m.panel.explicitInput.id === expandedPanelId);
+
+    const children = membersInOrder.map(({ panel }) => {
+      const memberId = panel.explicitInput.id;
+      const expandPanel = hasMaximizedMember && expandedPanelId === memberId;
+      const hidePanel = hasMaximizedMember && expandedPanelId !== memberId;
+      const itemClassName = classNames({
+        'dshDashboardGrid__item--expanded': expandPanel,
+        'dshDashboardGrid__item--hidden': hidePanel,
+      });
+      return (
+        <div key={memberId} className={itemClassName} data-test-subj="dashboardPanel">
+          <EmbeddableChildPanel
+            key={panel.type}
+            embeddableId={memberId}
+            container={container}
+            PanelComponent={PanelComponent}
+          />
+        </div>
+      );
+    });
+
+    const innerClassName = collapsed
+      ? 'dshDashboardSectionGrid__inner dshDashboardSectionGrid__inner--collapsed'
+      : 'dshDashboardSectionGrid__inner';
+
+    return (
+      <div className="dshDashboardSectionGrid" data-test-subj={`dashboardSectionGrid-${sectionId}`}>
+        {collapsed ? (
+          <div
+            className="dshDashboardSectionGrid__collapsedHint"
+            data-test-subj={`dashboardSectionCollapsedHint-${sectionId}`}
+          >
+            {i18n.translate('dashboard.section.collapsedHint', {
+              defaultMessage:
+                'This section is collapsed. Click the expand arrow in the header to show its panels.',
+            })}
+          </div>
+        ) : null}
+        {!collapsed && members.length === 0 && onAddPanel ? (
+          <div
+            className="dshDashboardSectionGrid__emptyCta"
+            data-test-subj={`dashboardSectionEmptyCta-${sectionId}`}
+          >
+            {/* Mirrors the empty-dashboard start screen (.dshEmptyWidget): a
+                dashed box prompting the user to add their first panel. */}
+            <div
+              className="dshDashboardSectionGrid__emptyWidget"
+              data-test-subj="emptySectionWidget"
+            >
+              <EuiText size="s" color="subdued">
+                <p>
+                  {i18n.translate('dashboard.section.addPanel.emptyPrompt', {
+                    defaultMessage: 'This section is empty.',
+                  })}
+                </p>
+              </EuiText>
+              <EuiSpacer size="s" />
+              <EuiButton
+                size="s"
+                iconType="plusInCircle"
+                onClick={onAddPanel}
+                data-test-subj="addExistingVisToSectionButton"
+              >
+                {i18n.translate('dashboard.section.addPanel.ctaLabel', {
+                  defaultMessage: 'Add existing visualization',
+                })}
+              </EuiButton>
+            </div>
+          </div>
+        ) : null}
+        <div className={innerClassName}>
+          <ResponsiveSizedGrid
+            className="dshDashboardSectionGrid__grid"
+            isViewMode={isViewMode}
+            layout={layout}
+            onLayoutChange={this.onLayoutChange}
+            useMargins={useMargins}
+            draggableHandle={PANEL_DRAG_HANDLE}
+            draggableCancel={undefined}
+            maximizedPanelId={hasMaximizedMember ? expandedPanelId : undefined}
+          >
+            {children}
+          </ResponsiveSizedGrid>
+        </div>
+      </div>
+    );
+  }
+}
+
+// Re-export so DashboardGrid can pass the same cancel selector to the outer grid.
+export { SECTION_INNER_GRID_CANCEL };

--- a/src/plugins/dashboard/public/application/embeddable/section/index.ts
+++ b/src/plugins/dashboard/public/application/embeddable/section/index.ts
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+export * from './section_embeddable';
+export * from './section_embeddable_factory';

--- a/src/plugins/dashboard/public/application/embeddable/section/section_embeddable.test.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/section/section_embeddable.test.tsx
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { ViewMode } from '../../../../../embeddable/public';
+import { SectionEmbeddable, DashboardSectionEmbeddableInput } from './section_embeddable';
+
+const buildInput = (
+  overrides: Partial<DashboardSectionEmbeddableInput> = {}
+): DashboardSectionEmbeddableInput => ({
+  id: 'section-1',
+  title: 'My section',
+  collapsed: false,
+  members: [],
+  ...overrides,
+});
+
+describe('SectionEmbeddable hidePanelActions sync', () => {
+  // A section has no panel actions in view mode (section actions are edit-only
+  // and generic actions are suppressed via isSectionEmbeddable), so its kebab
+  // would open an empty menu. The section drives the existing `hidePanelActions`
+  // input flag from view mode to hide the kebab -- no shared-plugin change.
+
+  test('constructing in view mode hides panel actions immediately', () => {
+    const section = new SectionEmbeddable(buildInput({ viewMode: ViewMode.VIEW }));
+    expect(section.getInput().hidePanelActions).toBe(true);
+  });
+
+  test('constructing in edit mode leaves panel actions visible', () => {
+    const section = new SectionEmbeddable(buildInput({ viewMode: ViewMode.EDIT }));
+    expect(Boolean(section.getInput().hidePanelActions)).toBe(false);
+  });
+
+  test('toggling edit -> view hides, and view -> edit re-shows the kebab', () => {
+    const section = new SectionEmbeddable(buildInput({ viewMode: ViewMode.EDIT }));
+    expect(Boolean(section.getInput().hidePanelActions)).toBe(false);
+
+    section.updateInput({ viewMode: ViewMode.VIEW });
+    expect(section.getInput().hidePanelActions).toBe(true);
+
+    section.updateInput({ viewMode: ViewMode.EDIT });
+    expect(section.getInput().hidePanelActions).toBe(false);
+  });
+
+  test('unrelated input changes in view mode do not flip the flag (no feedback loop)', () => {
+    const section = new SectionEmbeddable(buildInput({ viewMode: ViewMode.VIEW }));
+    expect(section.getInput().hidePanelActions).toBe(true);
+
+    // A title-only change must not toggle hidePanelActions off, and the guard
+    // must prevent an updateInput feedback loop.
+    section.updateInput({ title: 'Renamed section' });
+    expect(section.getInput().hidePanelActions).toBe(true);
+    expect(section.getInput().title).toBe('Renamed section');
+  });
+});

--- a/src/plugins/dashboard/public/application/embeddable/section/section_embeddable.tsx
+++ b/src/plugins/dashboard/public/application/embeddable/section/section_embeddable.tsx
@@ -1,0 +1,195 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Dashboard collapsible sections.
+// Mirrors PlaceholderEmbeddable's structure exactly: a synthetic,
+// non-visualization Embeddable living in the ordinary `panels` map, with its
+// own `type` and its own EmbeddableFactory (see section_embeddable_factory.ts).
+
+import { createRoot, Root } from 'react-dom/client';
+import React from 'react';
+import { EuiButtonIcon } from '@elastic/eui';
+import {
+  Embeddable,
+  EmbeddableInput,
+  IContainer,
+  IEmbeddable,
+  ViewMode,
+} from '../../../../../embeddable/public';
+
+export const DASHBOARD_SECTION_EMBEDDABLE = 'dashboard_section';
+
+/**
+ * Shared type guard for the dashboard section container.
+ *
+ * Panel actions that only make sense for real content panels (Maximize /
+ * Minimize, Replace panel, Clone, ...) call this from their `isCompatible`
+ * gate to exclude sections. Centralizing the check here avoids scattering
+ * `embeddable.type === DASHBOARD_SECTION_EMBEDDABLE` string comparisons across
+ * the action files.
+ */
+export function isSectionEmbeddable(embeddable?: IEmbeddable): boolean {
+  return Boolean(embeddable && embeddable.type === DASHBOARD_SECTION_EMBEDDABLE);
+}
+
+export interface DashboardSectionEmbeddableInput extends EmbeddableInput {
+  title: string;
+  collapsed: boolean;
+  /**
+   * Option 1 (section-owned member list). The section OWNS its
+   * members: this is the authoritative list of which panels belong to the
+   * section AND their SECTION-RELATIVE layout (coordinates within the section's
+   * own inner grid). The member panels themselves stay in the flat dashboard
+   * `panels` map with their own ABSOLUTE gridData untouched and NO sectionId --
+   * so when the sections feature is disabled (or the panel is released), each
+   * member is already a valid standalone panel at its absolute home position.
+   */
+  members: SectionMember[];
+}
+
+/** One member panel owned by the section: its id + SECTION-RELATIVE layout. */
+export interface SectionMember {
+  /** The member panel's id (its key in the dashboard's flat `panels` map). */
+  id: string;
+  /**
+   * Section-relative layout within the section's own inner grid. Wrapped in a
+   * `gridData` object (mirroring DashboardPanelState) so future per-member
+   * properties can sit alongside it without mixing into the layout fields.
+   * No `i` -- the react-grid-layout key is derived from `id` at render time.
+   */
+  gridData: { x: number; y: number; w: number; h: number };
+}
+
+/**
+ * Build a reverse lookup: member panel id -> { sectionId, member }, by scanning
+ * every section panel's `explicitInput.members`. This is how the grid and
+ * actions answer "is this panel a member, and of which section?" under Option 1
+ * (there is no `sectionId` on the member panel itself). First occurrence wins,
+ * so a panel accidentally listed in two sections resolves deterministically.
+ */
+export function buildSectionMemberMap(panels: {
+  [key: string]: { type: string; explicitInput: { id: string } };
+}): Map<string, { sectionId: string; member: SectionMember }> {
+  const map = new Map<string, { sectionId: string; member: SectionMember }>();
+  Object.values(panels).forEach((panel) => {
+    if (panel.type !== DASHBOARD_SECTION_EMBEDDABLE) return;
+    const members = (panel.explicitInput as Partial<DashboardSectionEmbeddableInput>).members;
+    if (!Array.isArray(members)) return;
+    members.forEach((member) => {
+      if (!map.has(member.id)) {
+        map.set(member.id, { sectionId: panel.explicitInput.id, member });
+      }
+    });
+  });
+  return map;
+}
+
+export class SectionEmbeddable extends Embeddable<DashboardSectionEmbeddableInput> {
+  public readonly type = DASHBOARD_SECTION_EMBEDDABLE;
+  private root?: Root;
+  private node?: HTMLElement;
+
+  constructor(initialInput: DashboardSectionEmbeddableInput, parent?: IContainer) {
+    super(initialInput, { title: initialInput.title }, parent);
+    this.getInput$().subscribe(() => {
+      // Keep the panel-chrome title in sync with the section's own title.
+      if (this.output.title !== this.input.title) {
+        this.updateOutput({ title: this.input.title });
+      }
+      // A section has no panel actions in view mode: every section-specific
+      // action (Add existing visualization, Move/Change section) is edit-only,
+      // and every generic panel action is suppressed for sections via
+      // isSectionEmbeddable. Its kebab would therefore open an EMPTY menu.
+      // Hide the kebab entirely in view mode by driving the existing
+      // `hidePanelActions` input flag -- no change to the shared embeddable
+      // panel chrome. EmbeddablePanel recomputes `hidePanelAction` from this on
+      // the container's input$ emit, and updating our own input (a container
+      // child) emits that stream, so this reacts to every view<->edit toggle.
+      this.syncHidePanelActions();
+      if (this.node) {
+        this.renderContent(this.node);
+      }
+    });
+  }
+
+  /**
+   * Keep `hidePanelActions` in lockstep with view mode so the section's
+   * (always-empty in view mode) options kebab is hidden. Guarded so it only
+   * writes on an actual change, avoiding an input$ feedback loop.
+   */
+  private syncHidePanelActions() {
+    const shouldHide = this.getInput().viewMode === ViewMode.VIEW;
+    if (Boolean(this.getInput().hidePanelActions) !== shouldHide) {
+      this.updateInput({ hidePanelActions: shouldHide });
+    }
+  }
+
+  /**
+   * the section's name is shown by the
+   * standard panel chrome title (getTitle -> output.title), NOT by a second
+   * header rendered in the panel body -- that produced a duplicate title.
+   */
+  public getTitle() {
+    return this.getInput().title;
+  }
+
+  /**
+   * contribute a collapse/expand chevron to the START of the
+   * panel header, BEFORE the title (see PanelHeader.getHeaderPrepend). This
+   * replaces the section's old in-body header, so the title appears exactly
+   * once (in the panel chrome) with the toggle immediately to its left.
+   */
+  public renderHeaderPrepend() {
+    const { collapsed } = this.getInput();
+    return (
+      <EuiButtonIcon
+        className="dshSectionEmbeddable__toggle"
+        data-test-subj={`dashboardSectionToggle-${this.id}`}
+        aria-label={collapsed ? 'Expand section' : 'Collapse section'}
+        iconType={collapsed ? 'arrowRight' : 'arrowDown'}
+        color="text"
+        // The panel header is itself the drag handle (embPanel__dragger); stop
+        // the mousedown so clicking the chevron toggles instead of starting a
+        // section drag.
+        onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+        onClick={(e: React.MouseEvent) => {
+          e.stopPropagation();
+          this.updateInput({ collapsed: !collapsed });
+        }}
+      />
+    );
+  }
+
+  public render(node: HTMLElement) {
+    this.node = node;
+    this.renderContent(node);
+  }
+
+  private renderContent(node: HTMLElement) {
+    if (this.root) {
+      this.root.unmount();
+    }
+    this.root = createRoot(node);
+    // The section's members are rendered by DashboardSectionGrid (a sibling in
+    // the outer grid item), and the title + toggle live in the panel chrome
+    // (getTitle / renderHeaderPrepend). The embeddable's own body is therefore
+    // empty -- it exists only to carry the section's data + panel actions.
+    this.root.render(
+      <div className="dshSectionEmbeddable" data-test-subj={`dashboardSection-${this.id}`} />
+    );
+  }
+
+  public reload() {
+    if (this.node) {
+      this.renderContent(this.node);
+    }
+  }
+}

--- a/src/plugins/dashboard/public/application/embeddable/section/section_embeddable_factory.ts
+++ b/src/plugins/dashboard/public/application/embeddable/section/section_embeddable_factory.ts
@@ -1,0 +1,46 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+// Mirrors
+// PlaceholderEmbeddableFactory exactly -- registered the same way in
+// plugin.tsx's setup() via embeddable.registerEmbeddableFactory().
+
+import { i18n } from '@osd/i18n';
+import { EmbeddableFactoryDefinition, IContainer } from '../../../../../embeddable/public';
+import {
+  SectionEmbeddable,
+  DashboardSectionEmbeddableInput,
+  DASHBOARD_SECTION_EMBEDDABLE,
+} from './section_embeddable';
+
+export class SectionEmbeddableFactory implements EmbeddableFactoryDefinition {
+  public readonly type = DASHBOARD_SECTION_EMBEDDABLE;
+
+  public async isEditable() {
+    return false;
+  }
+
+  // Sections are created via the "Add section" top-nav action, not via the
+  // generic add-panel flow.
+  public canCreateNew() {
+    return false;
+  }
+
+  public async create(initialInput: DashboardSectionEmbeddableInput, parent?: IContainer) {
+    return new SectionEmbeddable(initialInput, parent);
+  }
+
+  public getDisplayName() {
+    return i18n.translate('dashboard.section.factory.displayName', {
+      defaultMessage: 'section',
+    });
+  }
+}

--- a/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
+++ b/src/plugins/dashboard/public/application/utils/get_nav_actions.tsx
@@ -31,6 +31,15 @@ import {
 import { saveDashboard } from '../utils';
 import { DashboardContainer } from '../embeddable/dashboard_container';
 import { DashboardConstants, createDashboardEditUrl } from '../../dashboard_constants';
+import {
+  DASHBOARD_GRID_COLUMN_COUNT,
+  SECTION_HEADER_ROWS,
+} from '../embeddable/dashboard_constants';
+import {
+  DASHBOARD_SECTION_EMBEDDABLE,
+  buildSectionMemberMap,
+  DashboardSectionEmbeddableInput,
+} from '../embeddable/section';
 import { unhashUrl } from '../../../../opensearch_dashboards_utils/public';
 import { Dashboard } from '../../dashboard';
 import { showAddPanelPopover } from '../components/dashboard_top_nav/top_nav/show_add_panel_popover';
@@ -173,6 +182,14 @@ export const getNavActions = (
         showAddPanelPopover({
           anchorElement,
           uiActions: services.uiActions,
+          // "Add section" lives inside this "Create new" menu
+          // (after the Metrics visualization entry), not as a separate top-nav
+          // button. Reuses the same creation logic as navActions[ADD_SECTION].
+          // Gated behind the allowDashboardSections feature flag -- when off,
+          // onAddSection is undefined and the popover omits the "Section" item.
+          onAddSection: services.allowDashboardSections
+            ? () => navActions[TopNavIds.ADD_SECTION]?.(anchorElement)
+            : undefined,
           onAddExistingPanelFlyout: () => {
             openAddPanelFlyout({
               embeddable: currentContainer,
@@ -222,6 +239,70 @@ export const getNavActions = (
       throw new EmbeddableFactoryNotFoundError(type);
     }
     await factory.create({} as EmbeddableInput, currentContainer);
+  };
+
+  // Dashboard collapsible sections.
+  // Creates a section via the same container.addNewEmbeddable() primitive every
+  // other panel uses. addNewEmbeddable's default placement gives a half-width
+  // box (DEFAULT_PANEL_WIDTH); a section is widened to full-width right after,
+  // matching the plan's "row-spanning header marker" design -- no custom
+  // placement-strategy code needed.
+  navActions[TopNavIds.ADD_SECTION] = async () => {
+    if (!currentContainer || isErrorEmbeddable(currentContainer)) {
+      return;
+    }
+    const sectionEmbeddable = await currentContainer.addNewEmbeddable(
+      DASHBOARD_SECTION_EMBEDDABLE,
+      {
+        title: i18n.translate('dashboard.topNav.addSection.defaultTitle', {
+          defaultMessage: 'New section',
+        }),
+        collapsed: false,
+        // Option 1: the section owns its members. A new section starts empty.
+        members: [],
+      }
+    );
+    const panels = currentContainer.getInput().panels;
+    const sectionPanel = panels[sectionEmbeddable.id];
+    if (sectionPanel) {
+      // place a NEW section at the BOTTOM of the dashboard by
+      // default (below all existing top-level content), not wherever
+      // addNewEmbeddable's default top-left placement put it. Compute the
+      // max bottom edge across outer-space panels (ungrouped panels + section
+      // panels), treating each section's rendered height as its header rows
+      // plus its members' content -- mirroring DashboardGrid.
+      // computeSectionOuterHeight so we land just past the last section too.
+      const memberMap = buildSectionMemberMap(panels);
+      let maxBottom = 0;
+      Object.values(panels).forEach((p) => {
+        if (p.explicitInput.id === sectionEmbeddable.id) return;
+        if (memberMap.has(p.explicitInput.id)) return; // members live in inner grids
+        let effectiveH = p.gridData.h;
+        if (p.type === DASHBOARD_SECTION_EMBEDDABLE) {
+          const members =
+            (p.explicitInput as Partial<DashboardSectionEmbeddableInput>).members ?? [];
+          const innerRows = members.reduce((mx, m) => Math.max(mx, m.gridData.y + m.gridData.h), 0);
+          const collapsed = Boolean((p.explicitInput as { collapsed?: boolean }).collapsed);
+          effectiveH = collapsed ? SECTION_HEADER_ROWS : SECTION_HEADER_ROWS + innerRows;
+        }
+        maxBottom = Math.max(maxBottom, p.gridData.y + effectiveH);
+      });
+      currentContainer.updateInput({
+        panels: {
+          ...panels,
+          [sectionEmbeddable.id]: {
+            ...sectionPanel,
+            gridData: {
+              ...sectionPanel.gridData,
+              x: 0,
+              y: maxBottom,
+              w: DASHBOARD_GRID_COLUMN_COUNT,
+              h: 4,
+            },
+          },
+        },
+      });
+    }
   };
 
   navActions[TopNavIds.OPTIONS] = (anchorElement) => {

--- a/src/plugins/dashboard/public/application/utils/mocks.ts
+++ b/src/plugins/dashboard/public/application/utils/mocks.ts
@@ -34,6 +34,7 @@ export const createDashboardServicesMock = () => {
     dashboardConfig: {
       getHideWriteControls: jest.fn(),
     },
+    allowDashboardSections: false,
     dashboard,
     opensearchDashboardsVersion,
     usageCollection,

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -110,6 +110,15 @@ import {
   ACTION_LIBRARY_NOTIFICATION,
   LibraryNotificationActionContext,
   LibraryNotificationAction,
+  ACTION_MOVE_PANEL_TO_SECTION,
+  MovePanelToSectionAction,
+  MovePanelToSectionActionContext,
+  ACTION_ADD_PANEL_TO_SECTION,
+  AddPanelToSectionAction,
+  AddPanelToSectionActionContext,
+  ACTION_UNGROUP_SECTION,
+  UngroupSectionAction,
+  UngroupSectionActionContext,
 } from './application';
 import {
   createDashboardUrlGenerator,
@@ -120,6 +129,7 @@ import { createSavedDashboardLoader } from './saved_dashboards';
 import { DashboardConstants } from './dashboard_constants';
 import { addEmbeddableToDashboardUrl } from './url_utils/url_helper';
 import { PlaceholderEmbeddableFactory } from './application/embeddable/placeholder';
+import { SectionEmbeddableFactory } from './application/embeddable/section';
 import { UrlGeneratorState } from '../../share/public';
 import { AttributeService } from '.';
 import {
@@ -141,6 +151,7 @@ export type DashboardUrlGenerator = UrlGeneratorContract<typeof DASHBOARD_APP_UR
 
 export interface DashboardFeatureFlagConfig {
   allowByValueEmbeddables: boolean;
+  allowDashboardSections: boolean;
   variables: { enabled: boolean };
 }
 
@@ -204,6 +215,9 @@ declare module '../../../plugins/ui_actions/public' {
     [ACTION_ADD_TO_LIBRARY]: AddToLibraryActionContext;
     [ACTION_UNLINK_FROM_LIBRARY]: UnlinkFromLibraryActionContext;
     [ACTION_LIBRARY_NOTIFICATION]: LibraryNotificationActionContext;
+    [ACTION_MOVE_PANEL_TO_SECTION]: MovePanelToSectionActionContext;
+    [ACTION_ADD_PANEL_TO_SECTION]: AddPanelToSectionActionContext;
+    [ACTION_UNGROUP_SECTION]: UngroupSectionActionContext;
   }
 }
 
@@ -301,6 +315,15 @@ export class DashboardPlugin implements Plugin<
 
     const placeholderFactory = new PlaceholderEmbeddableFactory();
     embeddable.registerEmbeddableFactory(placeholderFactory.type, placeholderFactory);
+
+    // Dashboard collapsible sections.
+    // Section support is gated behind the allowDashboardSections feature flag.
+    // No saved-object migration is registered, so a dashboard saved with
+    // sections while the flag was on is not mutated when the flag is off.
+    if (this.dashboardFeatureFlagConfig?.allowDashboardSections) {
+      const sectionFactory = new SectionEmbeddableFactory();
+      embeddable.registerEmbeddableFactory(sectionFactory.type, sectionFactory);
+    }
 
     const {
       appMounted,
@@ -428,6 +451,7 @@ export class DashboardPlugin implements Plugin<
           }),
           core: coreStart,
           dashboardConfig,
+          allowDashboardSections: this.dashboardFeatureFlagConfig?.allowDashboardSections ?? false,
           navigateToDefaultApp,
           navigateToLegacyOpenSearchDashboardsUrl,
           navigation,
@@ -638,6 +662,26 @@ export class DashboardPlugin implements Plugin<
     const clonePanelAction = new ClonePanelAction(core);
     uiActions.registerAction(clonePanelAction);
     uiActions.attachAction(CONTEXT_MENU_TRIGGER, clonePanelAction.id);
+
+    // Dashboard collapsible sections.
+    // Gated behind the allowDashboardSections feature flag.
+    if (this.dashboardFeatureFlagConfig?.allowDashboardSections) {
+      const movePanelToSectionAction = new MovePanelToSectionAction(core);
+      uiActions.registerAction(movePanelToSectionAction);
+      uiActions.attachAction(CONTEXT_MENU_TRIGGER, movePanelToSectionAction.id);
+
+      const addPanelToSectionAction = new AddPanelToSectionAction(
+        core,
+        SavedObjectFinder,
+        plugins.embeddable.getEmbeddableFactories
+      );
+      uiActions.registerAction(addPanelToSectionAction);
+      uiActions.attachAction(CONTEXT_MENU_TRIGGER, addPanelToSectionAction.id);
+
+      const ungroupSectionAction = new UngroupSectionAction(core);
+      uiActions.registerAction(ungroupSectionAction);
+      uiActions.attachAction(CONTEXT_MENU_TRIGGER, ungroupSectionAction.id);
+    }
 
     if (this.dashboardFeatureFlagConfig?.allowByValueEmbeddables) {
       const addToLibraryAction = new AddToLibraryAction();

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -267,6 +267,9 @@ export interface DashboardServices extends CoreStart {
   savedDashboards: SavedObjectLoader;
   dashboardProviders: () => { [key: string]: DashboardProvider } | undefined;
   dashboardConfig: OpenSearchDashboardsLegacyStart['dashboardConfig'];
+  // whether the collapsible-sections feature is enabled
+  // (dashboard.allowDashboardSections). Gates the "Add section" menu entry.
+  allowDashboardSections: boolean;
   dashboardCapabilities: DashboardCapabilities;
   embeddableCapabilities: {
     visualizeCapabilities: any;

--- a/src/plugins/dashboard/server/index.ts
+++ b/src/plugins/dashboard/server/index.ts
@@ -35,6 +35,7 @@ import { configSchema, ConfigSchema } from '../config';
 export const config: PluginConfigDescriptor<ConfigSchema> = {
   exposeToBrowser: {
     allowByValueEmbeddables: true,
+    allowDashboardSections: true,
     variables: true,
   },
   schema: configSchema,

--- a/src/plugins/embeddable/public/lib/panel/embeddable_panel.tsx
+++ b/src/plugins/embeddable/public/lib/panel/embeddable_panel.tsx
@@ -221,7 +221,23 @@ export class EmbeddablePanel extends React.Component<Props, State> {
     if (this.state.errorEmbeddable) {
       this.state.errorEmbeddable.destroy();
     }
-    this.props.embeddable.destroy();
+    // Dashboard collapsible sections: only destroy a
+    // STANDALONE embeddable here. An embeddable that belongs to a container
+    // (has a `parent`) has its lifecycle owned by that container -- the
+    // container destroys it when its panel is removed from input
+    // (Container.onPanelRemoved) and when the container itself is destroyed.
+    // Destroying it here on a mere React unmount is redundant AND harmful:
+    // when a container child's panel simply MOVES in the React tree -- e.g. a
+    // dashboard panel moving between the dashboard grid and a section's nested
+    // grid, or a section being deleted so its members re-render at the top
+    // level -- React unmounts+remounts its EmbeddablePanel. Destroying the
+    // embeddable on that unmount tears down a child the container still holds
+    // in `panels`, and the container does not re-create a still-present child,
+    // so it renders blank after the move. Leave container-owned teardown to
+    // the container.
+    if (!this.props.embeddable.parent) {
+      this.props.embeddable.destroy();
+    }
   }
 
   public onFocus = (focusedPanelIndex: string) => {

--- a/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
+++ b/src/plugins/embeddable/public/lib/panel/panel_header/panel_header.tsx
@@ -127,6 +127,26 @@ function getViewDescription(embeddable: IEmbeddable | EmbeddableWithDescription)
   return '';
 }
 
+/**
+ * Dashboard collapsible sections: an embeddable may
+ * optionally contribute a small element rendered at the START of the panel
+ * header, before the title (e.g. a section's collapse/expand chevron). This
+ * is opt-in via a duck-typed method -- embeddables that don't implement it
+ * are completely unaffected. Kept generic (not section-specific) so the panel
+ * header has no dependency on the dashboard plugin.
+ */
+type EmbeddableWithHeaderPrepend = IEmbeddable & { renderHeaderPrepend: () => React.ReactNode };
+
+function getHeaderPrepend(embeddable: IEmbeddable): React.ReactNode {
+  if (
+    'renderHeaderPrepend' in embeddable &&
+    typeof (embeddable as EmbeddableWithHeaderPrepend).renderHeaderPrepend === 'function'
+  ) {
+    return (embeddable as EmbeddableWithHeaderPrepend).renderHeaderPrepend();
+  }
+  return null;
+}
+
 export function PanelHeader({
   title,
   isViewMode,
@@ -210,6 +230,7 @@ export function PanelHeader({
     >
       <h2 data-test-subj="dashboardPanelTitle" className="embPanel__title embPanel__dragger">
         <EuiScreenReaderOnly>{getAriaLabel()}</EuiScreenReaderOnly>
+        {getHeaderPrepend(embeddable)}
         {renderTitle()}
         {renderBadges(badges, embeddable)}
       </h2>


### PR DESCRIPTION
### Description

Adds opt-in **collapsible dashboard sections**, gated behind a new `dashboard.allowDashboardSections` config flag (default: off). When the flag is off, behavior is unchanged.

**Data model (additive, no migration).** A section is an ordinary panel with its own embeddable `type` (`dashboard_section`) that owns its members via `explicitInput.members: SectionMember[]`, where each member is `{ id, gridData: { x, y, w, h } }` (section-relative layout). Member panels stay as normal entries in the flat `panels` map with their own absolute `gridData` and carry no back-reference, so they remain valid standalone panels when the flag is off. No saved-object schema change and no migration; `members` round-trips inside the section panel's existing `embeddableConfig`.

**Rendering.** The outer dashboard grid renders ungrouped panels plus each section as a single full-width item; every expanded section renders its own nested `react-grid-layout` containing only its members. Drag isolation between the two levels uses disjoint `draggableHandle` selectors. Collapsing a section CSS-hides its inner grid (members stay mounted, so charts are not torn down), and because hidden panels never intersect the viewport, a collapsed section issues no data fetch until it is expanded.

**Authoring.** Add section (top nav), move/change section, add an existing visualization into a section, ungroup (removes the section, keeps its panels), and delete (removes the section and its panels) — the last two with a confirmation prompt.

### Issues Resolved

Part of #12433

### Testing

Unit tests cover the section membership model, the section actions (move/ungroup/delete), and the outer-grid height computation (collapsed, empty-expanded, expanded-with-members, member exclusion, and flag-off rendering). Existing dashboard plugin jest suites pass.

### Changelog

- feat: Add opt-in collapsible dashboard sections behind a feature flag ([#12433](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/12433))

### Check List

- [ ] All tests pass
- [ ] New functionality includes unit tests
- [ ] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
