### PR TITLE
[Chat] Namespace chat_tool_executed telemetry and add duration metric

### DIFF
--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -1408,7 +1408,11 @@ describe('ChatEventHandler', () => {
     const expectToolExecuted = (data: { toolName: string; status: string; source: string }) =>
       expect(mockTelemetryRecorder.recordEvent).toHaveBeenCalledWith({
         name: 'chat_tool_executed',
-        data,
+        data: {
+          chatToolCallToolName: data.toolName,
+          chatToolCallStatus: data.status,
+          chatToolCallSource: data.source,
+        },
       });
 
     it('should record success when a registered action resolves', async () => {
@@ -1485,6 +1489,24 @@ describe('ChatEventHandler', () => {
       } as ToolCallResultEvent);
 
       expectToolExecuted({ toolName: 'agentTool', status: 'success', source: 'agent' });
+    });
+
+    it('should record tool execution duration as a metric derived from TOOL_CALL_START', async () => {
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue('tool output');
+      mockToolResultDispatch('t-dur');
+
+      await runToolCall('t-dur', 'timedTool', '{"key": "value"}');
+
+      expect(mockTelemetryRecorder.recordMetric).toHaveBeenCalledWith({
+        name: 'chat_tool_executed_duration_ms',
+        value: expect.any(Number),
+        unit: 'ms',
+        labels: {
+          chatToolCallToolName: 'timedTool',
+          chatToolCallStatus: 'success',
+          chatToolCallSource: 'local',
+        },
+      });
     });
 
     it('should never call executeAction for agent tools (no await before markToolPending)', async () => {

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -74,6 +74,10 @@ export class ChatEventHandler {
   // Telemetry tracking
   private interactionStartTime: number | null = null;
   private runErrorOccurred = false;
+  // Start timestamp per tool call (keyed by toolCallId), captured on
+  // TOOL_CALL_START and consumed when the execution telemetry is recorded to
+  // compute the tool call duration (result time − start time).
+  private toolCallStartTimes = new Map<string, number>();
 
   constructor(config: ChatEventHandlerConfig) {
     this.assistantActionService = config.assistantActionService;
@@ -290,6 +294,10 @@ export class ChatEventHandler {
     this.onStartResponse(true);
     const { toolCallId, toolCallName, parentMessageId } = event;
 
+    // Record the start time so the execution duration can be reported when the
+    // tool completes (locally) or the agent returns a TOOL_CALL_RESULT.
+    this.toolCallStartTimes.set(toolCallId, Date.now());
+
     // Update tool call state in AssistantActionService
     this.assistantActionService.updateToolCallState(toolCallId, {
       id: toolCallId,
@@ -413,6 +421,7 @@ export class ChatEventHandler {
       // Check if tool execution was cancelled (e.g., due to cleanup)
       if (result.cancelled) {
         this.pendingToolCalls.delete(toolCallId);
+        this.toolCallStartTimes.delete(toolCallId);
         return;
       }
 
@@ -427,7 +436,7 @@ export class ChatEventHandler {
         });
 
         // Record rejected telemetry
-        this.recordToolExecuted(toolCall.function.name, 'rejected', 'local');
+        this.recordToolExecuted(toolCallId, toolCall.function.name, 'rejected', 'local');
 
         // Clean up pending tool call
         this.pendingToolCalls.delete(toolCallId);
@@ -460,6 +469,7 @@ export class ChatEventHandler {
 
         // Record tool execution telemetry
         this.recordToolExecuted(
+          toolCallId,
           toolCall.function.name,
           result.success ? 'success' : 'failure',
           'local'
@@ -495,7 +505,7 @@ export class ChatEventHandler {
       });
 
       // Record tool execution failure telemetry
-      this.recordToolExecuted(toolCall.function.name, 'error', 'local');
+      this.recordToolExecuted(toolCallId, toolCall.function.name, 'error', 'local');
     } finally {
       // Clean up pending tool call
       this.pendingToolCalls.delete(toolCallId);
@@ -546,21 +556,32 @@ export class ChatEventHandler {
     // if a duplicate TOOL_CALL_RESULT arrives after the entry was already cleared.
     if (this.toolExecutor.isPendingAgentResponse(toolCallId)) {
       const pendingTool = this.toolExecutor.getPendingTool(toolCallId);
-      this.recordToolExecuted(pendingTool?.name ?? 'unknown', 'success', 'agent');
+      this.recordToolExecuted(toolCallId, pendingTool?.name ?? 'unknown', 'success', 'agent');
       this.toolExecutor.clearPendingTool(toolCallId);
     }
   }
 
   /**
-   * Record a `chat_tool_executed` telemetry event.
+   * Record a `chat_tool_executed` telemetry event, plus a
+   * `chat_tool_executed_duration_ms` metric carrying the execution duration.
    * `source` distinguishes browser-executed actions ('local') from
    * agent-executed tools reported via TOOL_CALL_RESULT ('agent').
+   * The duration is the elapsed time from TOOL_CALL_START to this record,
+   * derived from the per-tool-call start timestamp; the metric is skipped when
+   * the start time is unknown (e.g. a tool call replayed from a snapshot with
+   * no observed TOOL_CALL_START).
    */
   private recordToolExecuted(
+    toolCallId: string,
     toolName: string,
     status: 'success' | 'failure' | 'error' | 'rejected',
     source: 'local' | 'agent'
   ): void {
+    // Always consume the start-time entry so it does not leak, even when
+    // telemetry is disabled.
+    const startTime = this.toolCallStartTimes.get(toolCallId);
+    this.toolCallStartTimes.delete(toolCallId);
+
     if (!this.telemetryRecorder) {
       return;
     }
@@ -568,11 +589,27 @@ export class ChatEventHandler {
     this.telemetryRecorder.recordEvent({
       name: 'chat_tool_executed',
       data: {
-        toolName,
-        status,
-        source,
+        chatToolCallToolName: toolName,
+        chatToolCallStatus: status,
+        chatToolCallSource: source,
       },
     });
+
+    // Report the execution duration as an aggregatable metric (avg/p90/etc.)
+    // rather than embedding it in the event payload. Only emitted when the
+    // TOOL_CALL_START timestamp was observed.
+    if (startTime !== undefined) {
+      this.telemetryRecorder.recordMetric({
+        name: 'chat_tool_executed_duration_ms',
+        value: Date.now() - startTime,
+        unit: 'ms',
+        labels: {
+          chatToolCallToolName: toolName,
+          chatToolCallStatus: status,
+          chatToolCallSource: source,
+        },
+      });
+    }
   }
 
   /**
@@ -912,6 +949,7 @@ export class ChatEventHandler {
   clearState(): void {
     this.activeAssistantMessages.clear();
     this.pendingToolCalls.clear();
+    this.toolCallStartTimes.clear();
     this.toolExecutor.clearAllPendingTools();
     this.lastTextMessageStartId = null;
     // Drain the process-wide AssistantActionService tool call states so


### PR DESCRIPTION
**Description**

The chat plugin's chat_tool_executed telemetry event wrote its properties directly on the shared telemetry data.* namespace. In particular data.status was written as a string, but data.status is already dynamically mapped as a long in the telemetry index, so those events were rejected/dropped on a field-type conflict.

This change prefixes the event's properties with chatToolCall so they get distinct field paths (data.chatToolCallToolName / data.chatToolCallStatus / data.chatToolCallSource) that no longer collide with any reserved data.* field, without introducing a nested object level.

It also reports the tool execution duration as a dedicated, aggregatable metric rather than embedding it in the event payload, mirroring the existing chat_interaction_duration_ms metric.

**Changes**

- chat_tool_executed event fields renamed to prefixed keys: chatToolCallToolName, chatToolCallStatus, chatToolCallSource (flat, no nested object).
- New chat_tool_executed_duration_ms metric: value in ms, unit 'ms', labels chatToolName / chatToolStatus / chatToolSource. The label keys are namespaced to avoid reusing reserved shared label names.
- Duration is the elapsed time from TOOL_CALL_START to when the execution telemetry is recorded, tracked via a per-toolCallId start-time map that is cleaned up on record, cancel, and clearState. The metric is skipped when no start time was observed (e.g. a snapshot-replayed tool call).

**Testing**

- Updated and extended unit tests in chat_event_handler.test.ts (58 passing), covering the prefixed event fields and the duration metric emission.

**Changelog**

- fix: Namespace chat_tool_executed telemetry event fields to avoid a field-mapping conflict
- feat: Record chat tool execution duration as a metric

Note: the changelog section above uses a bold label rather than an ATX heading; if the changelog CI requires a '## Changelog' header, please add it.