### PR TITLE
[Explore] Rebuild the query language picker as a source and language panel

### DIFF
--- a/changelogs/fragments/12659.yml
+++ b/changelogs/fragments/12659.yml
@@ -1,0 +1,2 @@
+feat:
+- Rebuild the Explore query language picker as a source type and language panel ([#12659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12659))

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.scss
@@ -53,16 +53,19 @@
 $exploreLanguagePickerSoftPrimary: tintOrShade($ouiColorPrimary, 90%, 70%);
 
 .exploreLanguagePicker {
+  // The toolbar row (`.exploreQueryPanelWidgets__left`) is a stretch flex
+  // container and this element is its direct child — the trigger itself sits
+  // two levels deeper, behind OuiPopover's anchor, where `align-self` is inert.
+  align-self: center;
+
   // create a new stacking context to allow for gradient border
   isolation: isolate;
 
   &__trigger {
-    // The toolbar row is a stretch flex container, so centre explicitly and
-    // pin the height to the 24px the beta badge this replaced occupied —
-    // the prototype's absolute sizes are drawn at a larger scale than the
-    // Explore toolbar actually runs at.
+    // Pinned to the 24px the beta badge this replaced occupied: the design
+    // prototype's absolute sizes are drawn at a larger scale than the Explore
+    // toolbar actually runs at. Centring is handled on the block above.
     align-items: center;
-    align-self: center;
     background: $ouiColorEmptyShade;
     border: 1px solid $ouiBorderColor;
     border-radius: $ouiSizeL;
@@ -188,13 +191,14 @@ $exploreLanguagePickerSoftPrimary: tintOrShade($ouiColorPrimary, 90%, 70%);
     padding: 5px 13px;
     white-space: nowrap;
 
-    &:hover:not(:disabled) {
+    &:hover:not([aria-current="true"]) {
       border-color: $ouiColorPrimary;
     }
 
-    // The selected chip is intentionally disabled — it must still read as
-    // selected rather than as an unavailable control.
-    &:disabled {
+    // The selected chip stays enabled and focusable so it keeps its place in the
+    // tab order and is announced as the current choice, but clicking it does
+    // nothing — so it should not offer a pointer.
+    &[aria-current="true"] {
       cursor: default;
     }
 

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.scss
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.scss
@@ -44,3 +44,174 @@
     }
   }
 }
+
+// The source-type + query-language picker in the Explore query panel. Kept
+// separate from `.exploreLanguageToggle` above, which the in-context
+// visualization editor still imports for its own copy of the toggle.
+// Sizes follow the design prototype; theme tokens are used wherever one lands
+// on the same value.
+$exploreLanguagePickerSoftPrimary: tintOrShade($ouiColorPrimary, 90%, 70%);
+
+.exploreLanguagePicker {
+  // create a new stacking context to allow for gradient border
+  isolation: isolate;
+
+  &__trigger {
+    // The toolbar row is a stretch flex container, so centre explicitly and
+    // pin the height to the 24px the beta badge this replaced occupied —
+    // the prototype's absolute sizes are drawn at a larger scale than the
+    // Explore toolbar actually runs at.
+    align-items: center;
+    align-self: center;
+    background: $ouiColorEmptyShade;
+    border: 1px solid $ouiBorderColor;
+    border-radius: $ouiSizeL;
+    color: $ouiTextColor;
+    display: inline-flex;
+    gap: $ouiSizeXS;
+    height: $ouiSizeL;
+    margin-right: $ouiSizeS;
+    padding: 0 $ouiSizeS;
+    position: relative;
+    transition:
+      border-color $ouiAnimSpeedFast ease-in,
+      box-shadow $ouiAnimSpeedFast ease-in;
+
+    &::before {
+      content: "";
+      position: absolute;
+      inset: -2px;
+      z-index: -1;
+      border-radius: inherit;
+      background: linear-gradient(90deg, #00d0ff 0%, #1034d4 50%, #9b1fa8 100%);
+      opacity: 0;
+    }
+
+    // Pointer affordance only, so the resting state stays neutral. AI mode
+    // owns the border through the gradient below and opts out of both.
+    &:hover:not(.exploreLanguagePicker__trigger--aiMode) {
+      border-color: $ouiColorPrimary;
+    }
+
+    // While the popover is open the outline also carries the halo, matching
+    // the prototype's `:focus-within` treatment.
+    &:focus-visible:not(.exploreLanguagePicker__trigger--aiMode),
+    &--open:not(.exploreLanguagePicker__trigger--aiMode) {
+      border-color: $ouiColorPrimary;
+      box-shadow: 0 0 0 3px $exploreLanguagePickerSoftPrimary;
+    }
+
+    &--aiMode {
+      background:
+        linear-gradient(180deg, rgba(87, 196, 251, 10%) 0%, rgba(165, 20, 255, 10%) 100%),
+        $ouiColorEmptyShade;
+      border-color: transparent;
+
+      &::before {
+        opacity: 1;
+        transition: opacity 0.3s ease;
+      }
+    }
+  }
+
+  // The divider between the logo and the language is this label's own left
+  // border, so the two never drift apart.
+  &__triggerLabel {
+    @include ouiCodeFont;
+
+    border-left: 1px solid $ouiBorderColor;
+    color: $ouiTextSubduedColor;
+    font-size: $ouiFontSizeXS;
+    font-weight: $ouiFontWeightMedium;
+    line-height: $ouiSize;
+    padding-left: $ouiSizeXS + $ouiSizeXXS;
+    white-space: nowrap;
+  }
+
+  &__triggerCaret {
+    color: $ouiTextSubduedColor;
+  }
+
+  &__panel {
+    display: flex;
+  }
+
+  &__section {
+    padding: $ouiSizeM 14px;
+
+    &--sourceType {
+      border-right: 1px solid $ouiColorLightShade;
+      padding: 10px;
+      width: 168px;
+    }
+  }
+
+  &__sectionTitle {
+    @include ouiCodeFont;
+
+    color: $ouiTextSubduedColor;
+    font-size: 10px;
+    letter-spacing: 1px;
+    padding: $ouiSizeXS $ouiSizeS 6px;
+    text-transform: uppercase;
+
+    &--flush {
+      padding-left: 0;
+    }
+  }
+
+  &__sourceType {
+    border-radius: 5px;
+    font-size: $ouiFontSizeS;
+    padding: $ouiSizeS 10px;
+
+    &--selected {
+      background: $exploreLanguagePickerSoftPrimary;
+      color: $ouiColorPrimaryText;
+      font-weight: $ouiFontWeightSemiBold;
+    }
+  }
+
+  &__chips {
+    display: flex;
+    flex-wrap: wrap;
+    gap: $ouiSizeS;
+  }
+
+  &__chip {
+    background: $ouiColorEmptyShade;
+    border: 1px solid $ouiBorderColor;
+    border-radius: $ouiSizeL;
+    color: $ouiTextColor;
+    font-size: $ouiFontSizeXS;
+    line-height: 1;
+    padding: 5px 13px;
+    white-space: nowrap;
+
+    &:hover:not(:disabled) {
+      border-color: $ouiColorPrimary;
+    }
+
+    // The selected chip is intentionally disabled — it must still read as
+    // selected rather than as an unavailable control.
+    &:disabled {
+      cursor: default;
+    }
+
+    &--ai {
+      border-color: $ouiColorPrimary;
+      border-style: dashed;
+      color: $ouiColorPrimaryText;
+    }
+
+    // Declared after `--ai` on purpose: an active AI chip drops the dashed
+    // outline, as in the prototype.
+    &--selected {
+      background: $exploreLanguagePickerSoftPrimary;
+      border-color: $ouiColorPrimary;
+      border-style: solid;
+      color: $ouiColorPrimaryText;
+      font-weight: $ouiFontWeightSemiBold;
+    }
+  }
+}

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
@@ -185,14 +185,28 @@ describe('LanguageToggle', () => {
   });
 
   describe('Menu Items', () => {
-    it('disables PPL option when not in prompt mode', () => {
+    it('marks the current PPL option as current, and leaves it enabled', () => {
       renderWithProvider(<LanguageToggle />);
 
       const button = screen.getByTestId('queryPanelFooterLanguageToggle');
       fireEvent.click(button);
 
+      // Selection is conveyed semantically rather than by disabling the control,
+      // which would announce as unavailable and leave the tab order.
       const pplOption = screen.getByTestId('queryPanelFooterLanguageToggle-PPL');
-      expect(pplOption).toBeDisabled();
+      expect(pplOption).toHaveAttribute('aria-current', 'true');
+      expect(pplOption).not.toBeDisabled();
+    });
+
+    it('does nothing when the already-current language is clicked', () => {
+      renderWithProvider(<LanguageToggle />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+      mockDispatch.mockClear();
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle-PPL'));
+
+      expect(mockDispatch).not.toHaveBeenCalled();
+      expect(mockSetQuery).not.toHaveBeenCalled();
     });
 
     it('enables PPL option when in prompt mode', () => {
@@ -219,7 +233,7 @@ describe('LanguageToggle', () => {
       expect(aiOption.closest('button')).not.toBeDisabled();
     });
 
-    it('disables AI option when in prompt mode', () => {
+    it('marks the AI option as current in prompt mode, and leaves it enabled', () => {
       mockSelectIsPromptEditorMode.mockReturnValue(true);
       mockSelectPromptModeIsAvailable.mockReturnValue(true);
 
@@ -229,7 +243,21 @@ describe('LanguageToggle', () => {
       fireEvent.click(button);
 
       const aiOption = screen.getByTestId('queryPanelFooterLanguageToggle-AI');
-      expect(aiOption).toBeDisabled();
+      expect(aiOption).toHaveAttribute('aria-current', 'true');
+      expect(aiOption).not.toBeDisabled();
+    });
+
+    it('does nothing when the AI chip is clicked while already in prompt mode', () => {
+      mockSelectIsPromptEditorMode.mockReturnValue(true);
+      mockSelectPromptModeIsAvailable.mockReturnValue(true);
+
+      renderWithProvider(<LanguageToggle />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+      mockDispatch.mockClear();
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle-AI'));
+
+      expect(mockDispatch).not.toHaveBeenCalled();
     });
 
     it('does not show AI option when prompt mode is not available', () => {
@@ -621,6 +649,24 @@ describe('LanguageToggle', () => {
 
       expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
       expect(screen.queryByTestId('queryPanelFooterLanguageToggle-AI')).not.toBeInTheDocument();
+    });
+
+    it('labels both columns as groups so the headings are announced as group names', () => {
+      renderWithProvider(<LanguageToggle />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+
+      expect(screen.getByRole('group', { name: 'Source type' })).toBeInTheDocument();
+      expect(screen.getByRole('group', { name: 'Query language' })).toBeInTheDocument();
+    });
+
+    it('exposes the trigger as a disclosure rather than a menu button', () => {
+      renderWithProvider(<LanguageToggle />);
+
+      // The panel is a labelled group of buttons, not a menu, so aria-haspopup
+      // (whose `true` value means "menu") must not be claimed.
+      const trigger = screen.getByTestId('queryPanelFooterLanguageToggle');
+      expect(trigger).not.toHaveAttribute('aria-haspopup');
     });
 
     it('reflects the popover open state on the trigger', () => {

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.test.tsx
@@ -566,4 +566,72 @@ describe('LanguageToggle', () => {
       expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
     });
   });
+
+  describe('Picker Layout', () => {
+    it('renders the source type section with OpenSearch as the selected entry', () => {
+      renderWithProvider(<LanguageToggle />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+
+      const sourceType = screen.getByTestId('queryPanelFooterSourceType-OpenSearch');
+      expect(sourceType).toHaveTextContent('OpenSearch');
+      expect(sourceType).toHaveClass('exploreLanguagePicker__sourceType--selected');
+    });
+
+    it('marks only the current language chip as selected', async () => {
+      mockGetTab.mockReturnValue({ supportedLanguages: ['PPL', 'SQL'] });
+      mockGetLanguage.mockImplementation((lang: string) => ({ title: lang }));
+
+      renderWithProvider(<LanguageToggle />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('queryPanelFooterLanguageToggle-SQL')).toBeInTheDocument();
+      });
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toHaveClass(
+        'exploreLanguagePicker__chip--selected'
+      );
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-SQL')).not.toHaveClass(
+        'exploreLanguagePicker__chip--selected'
+      );
+    });
+
+    it('marks the AI chip as selected in prompt mode and leaves the language chips unselected', () => {
+      mockSelectIsPromptEditorMode.mockReturnValue(true);
+
+      renderWithProvider(<LanguageToggle />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-AI')).toHaveClass(
+        'exploreLanguagePicker__chip--selected'
+      );
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).not.toHaveClass(
+        'exploreLanguagePicker__chip--selected'
+      );
+    });
+
+    it('does not render the AI chip when hideAI is set, even if prompt mode is available', () => {
+      mockSelectPromptModeIsAvailable.mockReturnValue(true);
+
+      renderWithProvider(<LanguageToggle hideAI />);
+
+      fireEvent.click(screen.getByTestId('queryPanelFooterLanguageToggle'));
+
+      expect(screen.getByTestId('queryPanelFooterLanguageToggle-PPL')).toBeInTheDocument();
+      expect(screen.queryByTestId('queryPanelFooterLanguageToggle-AI')).not.toBeInTheDocument();
+    });
+
+    it('reflects the popover open state on the trigger', () => {
+      renderWithProvider(<LanguageToggle />);
+
+      const trigger = screen.getByTestId('queryPanelFooterLanguageToggle');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger).toHaveTextContent('PPL');
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
 });

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { EuiBetaBadge, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
+import { EuiIcon, EuiPopover } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import classNames from 'classnames';
 import {
@@ -25,6 +25,28 @@ import './language_toggle.scss';
 const promptOptionText = i18n.translate('explore.queryPanelFooter.languageToggle.promptOption', {
   defaultMessage: 'AI',
 });
+
+const sourceTypeSectionTitle = i18n.translate(
+  'explore.queryPanelFooter.languageToggle.sourceTypeSectionTitle',
+  {
+    defaultMessage: 'Source type',
+  }
+);
+
+const queryLanguageSectionTitle = i18n.translate(
+  'explore.queryPanelFooter.languageToggle.queryLanguageSectionTitle',
+  {
+    defaultMessage: 'Query language',
+  }
+);
+
+const openPickerAriaLabel = i18n.translate('explore.queryPanelFooter.languageToggle.ariaLabel', {
+  defaultMessage: 'Select source type and query language',
+});
+
+// OpenSearch is the only source type the query panel can talk to today, so it is
+// rendered as the selected, non-interactive entry rather than a real list.
+const OPENSEARCH_SOURCE_TYPE = 'OpenSearch';
 
 interface LanguageToggleProps {
   hideAI?: boolean;
@@ -157,72 +179,114 @@ export const LanguageToggle = ({ hideAI = false }: LanguageToggleProps) => {
 
   const badgeLabel = isPromptMode ? promptOptionText : languageTitle;
 
-  const items = useMemo(() => {
-    const output: React.ReactElement[] = [];
-
-    // Add all supported languages for the active tab
-    for (const langId of supportedLanguages) {
+  const languageChips = useMemo(() => {
+    // A chip is selected exactly when it is the mode the editor is already in, and
+    // the selected chip is the one that cannot be clicked again.
+    return supportedLanguages.map((langId) => {
       const langConfig = languageService.getLanguage(langId);
       const title = langConfig?.title ?? langId;
-      output.push(
-        <EuiContextMenuItem
+      const isSelected = !isPromptMode && langId === language;
+      return (
+        <button
+          type="button"
           key={langId}
           onClick={() =>
             langId === language ? onItemClick(EditorMode.Query) : onLanguageClick(langId)
           }
-          disabled={!isPromptMode && langId === language}
+          disabled={isSelected}
+          className={classNames('exploreLanguagePicker__chip', {
+            ['exploreLanguagePicker__chip--selected']: isSelected,
+          })}
           data-test-subj={`queryPanelFooterLanguageToggle-${title}`}
         >
           {title}
-        </EuiContextMenuItem>
+        </button>
       );
+    });
+  }, [supportedLanguages, languageService, isPromptMode, language, onItemClick, onLanguageClick]);
+
+  const aiChip = useMemo(() => {
+    if (!promptModeIsAvailable || hideAI) {
+      return null;
     }
 
-    if (promptModeIsAvailable && !hideAI) {
-      output.push(
-        <EuiContextMenuItem
-          key="ai"
-          onClick={() => onItemClick(EditorMode.Prompt)}
-          disabled={isPromptMode}
-          data-test-subj="queryPanelFooterLanguageToggle-AI"
-        >
-          {promptOptionText}
-        </EuiContextMenuItem>
-      );
-    }
-
-    return output;
-  }, [
-    isPromptMode,
-    onItemClick,
-    onLanguageClick,
-    promptModeIsAvailable,
-    hideAI,
-    supportedLanguages,
-    language,
-    languageService,
-  ]);
+    return (
+      <button
+        type="button"
+        onClick={() => onItemClick(EditorMode.Prompt)}
+        disabled={isPromptMode}
+        className={classNames('exploreLanguagePicker__chip', 'exploreLanguagePicker__chip--ai', {
+          ['exploreLanguagePicker__chip--selected']: isPromptMode,
+        })}
+        data-test-subj="queryPanelFooterLanguageToggle-AI"
+      >
+        {promptOptionText}
+      </button>
+    );
+  }, [promptModeIsAvailable, hideAI, isPromptMode, onItemClick]);
 
   return (
     // This div is needed to allow for the gradient styling
-    <div className="exploreLanguageToggle">
+    <div className="exploreLanguagePicker">
       <EuiPopover
         button={
-          <EuiBetaBadge
+          <button
+            type="button"
             onClick={onButtonClick}
+            aria-haspopup="true"
+            aria-expanded={isPopoverOpen}
+            aria-label={openPickerAriaLabel}
             data-test-subj="queryPanelFooterLanguageToggle"
-            className={classNames('exploreLanguageToggle__button', {
-              ['exploreLanguageToggle__button--aiMode']: isPromptMode,
+            className={classNames('exploreLanguagePicker__trigger', {
+              ['exploreLanguagePicker__trigger--aiMode']: isPromptMode,
+              // Keep the hover outline while the popover is open, so moving the
+              // pointer off the button and into the panel does not drop it.
+              ['exploreLanguagePicker__trigger--open']: isPopoverOpen,
             })}
-            label={badgeLabel}
-          />
+          >
+            <EuiIcon type="logoOpenSearch" size="m" />
+            <span className="exploreLanguagePicker__triggerLabel">{badgeLabel}</span>
+            <EuiIcon type="arrowDown" size="s" className="exploreLanguagePicker__triggerCaret" />
+          </button>
         }
         isOpen={isPopoverOpen}
         closePopover={closePopover}
-        anchorPosition="downCenter"
+        anchorPosition="downLeft"
         panelPaddingSize="none"
+        hasArrow={false}
+        // Without an arrow OuiPopover drops to an 8px gap, most of which the
+        // open trigger's 3px halo eats, so the panel reads as touching the
+        // pill. The extra 4px lands its top edge at the query editor below.
+        offset={4}
+        // Focus stays on the trigger. With the default focus trap the popover
+        // focuses the first focusable child on open, which is never the current
+        // language — that chip is disabled — so the chip the user did not pick
+        // came up looking pre-highlighted. This branch of OuiPopover still
+        // closes on Escape and on an outside click.
+        ownFocus={false}
       >
-        <EuiContextMenuPanel size="s" items={items} />
+        <div className="exploreLanguagePicker__panel">
+          <div className="exploreLanguagePicker__section exploreLanguagePicker__section--sourceType">
+            <div className="exploreLanguagePicker__sectionTitle">{sourceTypeSectionTitle}</div>
+            <div
+              className="exploreLanguagePicker__sourceType exploreLanguagePicker__sourceType--selected"
+              data-test-subj={`queryPanelFooterSourceType-${OPENSEARCH_SOURCE_TYPE}`}
+            >
+              {OPENSEARCH_SOURCE_TYPE}
+            </div>
+          </div>
+          <div className="exploreLanguagePicker__section">
+            <div className="exploreLanguagePicker__sectionTitle exploreLanguagePicker__sectionTitle--flush">
+              {queryLanguageSectionTitle}
+            </div>
+            {/* One wrapping row: the AI chip flows with the languages rather
+                than being pinned to its own line. */}
+            <div className="exploreLanguagePicker__chips">
+              {languageChips}
+              {aiChip}
+            </div>
+          </div>
+        </div>
       </EuiPopover>
     </div>
   );

--- a/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
+++ b/src/plugins/explore/public/components/query_panel/query_panel_widgets/language_toggle/language_toggle.tsx
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { EuiIcon, EuiPopover } from '@elastic/eui';
+import { EuiIcon, EuiPopover, htmlIdGenerator } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
 import classNames from 'classnames';
 import {
@@ -179,9 +179,20 @@ export const LanguageToggle = ({ hideAI = false }: LanguageToggleProps) => {
 
   const badgeLabel = isPromptMode ? promptOptionText : languageTitle;
 
+  // The two columns are labelled groups, so the section headings are announced
+  // as the group name rather than as loose text before the controls.
+  const sourceTypeTitleId = useMemo(() => htmlIdGenerator('exploreLanguagePickerSourceType')(), []);
+  const queryLanguageTitleId = useMemo(
+    () => htmlIdGenerator('exploreLanguagePickerQueryLanguage')(),
+    []
+  );
+
   const languageChips = useMemo(() => {
-    // A chip is selected exactly when it is the mode the editor is already in, and
-    // the selected chip is the one that cannot be clicked again.
+    // A chip is selected exactly when it is the mode the editor is already in.
+    // Selection is announced with `aria-current` rather than by disabling the
+    // chip: a disabled button is announced as unavailable rather than as the
+    // current choice, and drops out of the tab order. Clicking the selected chip
+    // remains a no-op, as it was when the chip was disabled.
     return supportedLanguages.map((langId) => {
       const langConfig = languageService.getLanguage(langId);
       const title = langConfig?.title ?? langId;
@@ -190,10 +201,16 @@ export const LanguageToggle = ({ hideAI = false }: LanguageToggleProps) => {
         <button
           type="button"
           key={langId}
-          onClick={() =>
-            langId === language ? onItemClick(EditorMode.Query) : onLanguageClick(langId)
-          }
-          disabled={isSelected}
+          onClick={() => {
+            if (isSelected) return;
+            // Same language, but the editor is in prompt mode: go back to query mode.
+            if (langId === language) {
+              onItemClick(EditorMode.Query);
+            } else {
+              onLanguageClick(langId);
+            }
+          }}
+          aria-current={isSelected ? 'true' : undefined}
           className={classNames('exploreLanguagePicker__chip', {
             ['exploreLanguagePicker__chip--selected']: isSelected,
           })}
@@ -213,8 +230,11 @@ export const LanguageToggle = ({ hideAI = false }: LanguageToggleProps) => {
     return (
       <button
         type="button"
-        onClick={() => onItemClick(EditorMode.Prompt)}
-        disabled={isPromptMode}
+        onClick={() => {
+          if (isPromptMode) return;
+          onItemClick(EditorMode.Prompt);
+        }}
+        aria-current={isPromptMode ? 'true' : undefined}
         className={classNames('exploreLanguagePicker__chip', 'exploreLanguagePicker__chip--ai', {
           ['exploreLanguagePicker__chip--selected']: isPromptMode,
         })}
@@ -233,7 +253,9 @@ export const LanguageToggle = ({ hideAI = false }: LanguageToggleProps) => {
           <button
             type="button"
             onClick={onButtonClick}
-            aria-haspopup="true"
+            // A disclosure button: `aria-expanded` alone. `aria-haspopup` is
+            // deliberately absent — its `true` value means "menu", and the panel
+            // is a labelled group of buttons, not a menu with roving focus.
             aria-expanded={isPopoverOpen}
             aria-label={openPickerAriaLabel}
             data-test-subj="queryPanelFooterLanguageToggle"
@@ -259,24 +281,37 @@ export const LanguageToggle = ({ hideAI = false }: LanguageToggleProps) => {
         // pill. The extra 4px lands its top edge at the query editor below.
         offset={4}
         // Focus stays on the trigger. With the default focus trap the popover
-        // focuses the first focusable child on open, which is never the current
-        // language — that chip is disabled — so the chip the user did not pick
-        // came up looking pre-highlighted. This branch of OuiPopover still
+        // focuses the first focusable child on open, so a chip the user did not
+        // pick came up looking pre-highlighted. This branch of OuiPopover still
         // closes on Escape and on an outside click.
         ownFocus={false}
       >
         <div className="exploreLanguagePicker__panel">
-          <div className="exploreLanguagePicker__section exploreLanguagePicker__section--sourceType">
-            <div className="exploreLanguagePicker__sectionTitle">{sourceTypeSectionTitle}</div>
+          <div
+            className="exploreLanguagePicker__section exploreLanguagePicker__section--sourceType"
+            role="group"
+            aria-labelledby={sourceTypeTitleId}
+          >
+            <div className="exploreLanguagePicker__sectionTitle" id={sourceTypeTitleId}>
+              {sourceTypeSectionTitle}
+            </div>
             <div
               className="exploreLanguagePicker__sourceType exploreLanguagePicker__sourceType--selected"
+              aria-current="true"
               data-test-subj={`queryPanelFooterSourceType-${OPENSEARCH_SOURCE_TYPE}`}
             >
               {OPENSEARCH_SOURCE_TYPE}
             </div>
           </div>
-          <div className="exploreLanguagePicker__section">
-            <div className="exploreLanguagePicker__sectionTitle exploreLanguagePicker__sectionTitle--flush">
+          <div
+            className="exploreLanguagePicker__section"
+            role="group"
+            aria-labelledby={queryLanguageTitleId}
+          >
+            <div
+              className="exploreLanguagePicker__sectionTitle exploreLanguagePicker__sectionTitle--flush"
+              id={queryLanguageTitleId}
+            >
               {queryLanguageSectionTitle}
             </div>
             {/* One wrapping row: the AI chip flows with the languages rather


### PR DESCRIPTION
### Description
The Explore query panel's language toggle was an `EuiBetaBadge` that opened a single-column `EuiContextMenuPanel`. This rebuilds it to the new design:

- **Trigger** — a pill carrying the OpenSearch mark, a divider, the current language, and a caret. Neutral at rest, primary border on hover, border plus a soft halo while the popover is open. It keeps the 24px height of the badge it replaces and sets `align-self: center`, so the stretch flex toolbar no longer distorts it.
- **Panel** — two columns: `SOURCE TYPE` (OpenSearch, selected) and `QUERY LANGUAGE`, whose entries are now chips rather than menu rows. The AI chip carries a dashed outline that turns solid when prompt mode is active.
- The popover loses its arrow, takes a small offset so it clears the trigger, and no longer takes focus on open. The current language's chip is disabled, so the default focus target was always a chip the user had *not* picked — it came up looking pre-highlighted.

**No behaviour changes.** The supported-language gating (tab registry → `sqlSupport` flag → per-dataset engine gating), the query each switch writes, the auto-run that follows it, the prompt-mode handoff, and the timeout cleanup are all untouched.

The existing `.exploreLanguageToggle` styles are left in place rather than restyled, because `application/in_context_vis_editor/component/lauguage_toggle.tsx` imports this stylesheet for its own copy of the toggle. Restyling in place would have given that component a new trigger on top of its old menu.

### Issues Resolved

N/A — UI follow-up to the Explore query panel design.

## Screenshot

https://github.com/user-attachments/assets/7fd37781-a3f9-4a3b-8281-08e7659b07a4


### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
