### PR TITLE
Add human-in-the-loop support to the chat plugin

### DIFF
--- a/src/core/public/chat/types.ts
+++ b/src/core/public/chat/types.ts
@@ -23,26 +23,7 @@ interface BinaryInputContent {
   name?: string;
 }
 
-interface InputContentDataSource {
-  type: 'data';
-  value: string;
-  mimeType: string;
-}
-
-interface InputContentUrlSource {
-  type: 'url';
-  value: string;
-  mimeType?: string;
-}
-
-type InputContentSource = InputContentDataSource | InputContentUrlSource;
-
-interface ImageInputContent {
-  type: 'image';
-  source: InputContentSource;
-  metadata?: Record<string, unknown>;
-}
-export type InputContent = TextInputContent | BinaryInputContent | ImageInputContent;
+export type InputContent = TextInputContent | BinaryInputContent;
 
 /**
  * Function call interface

--- a/src/plugins/chat/common/index.ts
+++ b/src/plugins/chat/common/index.ts
@@ -8,6 +8,13 @@ export const PLUGIN_NAME = 'chat';
 export const CHAT_DEFAULT_AG_UI_URL = 'http://localhost:3000';
 
 /**
+ * Appended to a halted assistant message. Shown live when the user clicks stop, and persisted by
+ * the agent server on halt (OpenSearchSessionManager.HALT_MARKER), so an immediate halt and a
+ * later reload show the same "partial answer + this line". Keep the two definitions in sync.
+ */
+export const HALT_MARKER = '\n\nThe response was stopped.';
+
+/**
  * Prefix used on the tool result content when a tool execution fails locally
  * (e.g. JSON parse error, thrown exception in the executor).
  *

--- a/src/plugins/chat/public/components/ask_user_card.scss
+++ b/src/plugins/chat/public/components/ask_user_card.scss
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Direct child of the flex-column message list — pin to content size so it
+// doesn't stretch to fill the column's cross axis.
+.askUserCard {
+  align-self: flex-start;
+  width: 100%;
+  height: min-content;
+}
+
+// Placeholder shown while the question is still being generated, before the
+// card renders. Mirrors the message list's "Thinking…" text.
+.askUserCard__generating {
+  align-self: flex-start;
+  color: $euiColorMediumShade;
+  font-style: italic;
+  font-size: 14px;
+  padding: 8px 12px;
+  animation: askUserPulse 2.5s ease-in-out infinite;
+}
+
+// Local copy of the message list's pulse keyframe so this component does not
+// depend on chat_messages.scss being loaded first.
+@keyframes askUserPulse {
+  0%,
+  100% {
+    opacity: 0.5;
+  }
+
+  50% {
+    opacity: 1;
+  }
+}

--- a/src/plugins/chat/public/components/ask_user_card.test.tsx
+++ b/src/plugins/chat/public/components/ask_user_card.test.tsx
@@ -1,0 +1,268 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { AskUserCard, AskUserAnsweredCard, InlineAskUser } from './ask_user_card';
+import { AskUserRequest, HumanInputService } from '../services/human_input_service';
+
+const baseRequest = (overrides: Partial<AskUserRequest> = {}): AskUserRequest => ({
+  id: 'req-1',
+  toolCallId: 'tc-1',
+  prompt: 'Which index?',
+  inputType: 'text',
+  timestamp: 0,
+  ...overrides,
+});
+
+describe('AskUserCard', () => {
+  it('renders the prompt and a dismiss affordance', () => {
+    const { getByText, getByTestId } = render(
+      <AskUserCard request={baseRequest()} onAnswer={jest.fn()} onDismiss={jest.fn()} />
+    );
+
+    expect(getByText('Which index?')).toBeTruthy();
+    expect(getByTestId('askUserDismiss')).toBeTruthy();
+  });
+
+  it('calls onDismiss with the request id', () => {
+    const onDismiss = jest.fn();
+    const { getByTestId } = render(
+      <AskUserCard request={baseRequest()} onAnswer={jest.fn()} onDismiss={onDismiss} />
+    );
+
+    fireEvent.click(getByTestId('askUserDismiss'));
+    expect(onDismiss).toHaveBeenCalledWith('req-1');
+  });
+
+  describe('text input', () => {
+    it('submits trimmed text via the Send button', () => {
+      const onAnswer = jest.fn();
+      const { getByTestId } = render(
+        <AskUserCard request={baseRequest()} onAnswer={onAnswer} onDismiss={jest.fn()} />
+      );
+
+      fireEvent.change(getByTestId('askUserTextInput'), { target: { value: '  logs-2024  ' } });
+      fireEvent.click(getByTestId('askUserTextSubmit'));
+
+      expect(onAnswer).toHaveBeenCalledWith('req-1', 'logs-2024');
+    });
+
+    it('submits on Enter', () => {
+      const onAnswer = jest.fn();
+      const { getByTestId } = render(
+        <AskUserCard request={baseRequest()} onAnswer={onAnswer} onDismiss={jest.fn()} />
+      );
+
+      const input = getByTestId('askUserTextInput');
+      fireEvent.change(input, { target: { value: 'metrics' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+
+      expect(onAnswer).toHaveBeenCalledWith('req-1', 'metrics');
+    });
+
+    it('does not submit empty / whitespace-only text', () => {
+      const onAnswer = jest.fn();
+      const { getByTestId } = render(
+        <AskUserCard request={baseRequest()} onAnswer={onAnswer} onDismiss={jest.fn()} />
+      );
+
+      fireEvent.change(getByTestId('askUserTextInput'), { target: { value: '   ' } });
+      fireEvent.click(getByTestId('askUserTextSubmit'));
+
+      expect(onAnswer).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('confirm', () => {
+    it('sends yes / no', () => {
+      const onAnswer = jest.fn();
+      const { getByTestId } = render(
+        <AskUserCard
+          request={baseRequest({ inputType: 'confirm' })}
+          onAnswer={onAnswer}
+          onDismiss={jest.fn()}
+        />
+      );
+
+      fireEvent.click(getByTestId('askUserConfirmYes'));
+      expect(onAnswer).toHaveBeenCalledWith('req-1', 'yes');
+
+      fireEvent.click(getByTestId('askUserConfirmNo'));
+      expect(onAnswer).toHaveBeenCalledWith('req-1', 'no');
+    });
+  });
+
+  describe('select', () => {
+    const selectRequest = (overrides: Partial<AskUserRequest> = {}) =>
+      baseRequest({
+        inputType: 'select',
+        options: [
+          { label: 'Logs', value: 'logs' },
+          { label: 'Metrics', value: 'metrics' },
+        ],
+        ...overrides,
+      });
+
+    it('renders one button per option and sends its value', () => {
+      const onAnswer = jest.fn();
+      const { getByTestId } = render(
+        <AskUserCard request={selectRequest()} onAnswer={onAnswer} onDismiss={jest.fn()} />
+      );
+
+      fireEvent.click(getByTestId('askUserOption-metrics'));
+      expect(onAnswer).toHaveBeenCalledWith('req-1', 'metrics');
+    });
+
+    it('does not show a text field when allowFreeText is unset', () => {
+      const { queryByTestId } = render(
+        <AskUserCard request={selectRequest()} onAnswer={jest.fn()} onDismiss={jest.fn()} />
+      );
+
+      expect(queryByTestId('askUserTextInput')).toBeNull();
+    });
+
+    it('shows both option buttons and a text field when allowFreeText is set', () => {
+      const onAnswer = jest.fn();
+      const { getByTestId } = render(
+        <AskUserCard
+          request={selectRequest({ allowFreeText: true })}
+          onAnswer={onAnswer}
+          onDismiss={jest.fn()}
+        />
+      );
+
+      // Options still work.
+      expect(getByTestId('askUserOption-logs')).toBeTruthy();
+      // And the free-text path is available and submits the typed value.
+      fireEvent.change(getByTestId('askUserTextInput'), { target: { value: 'traces' } });
+      fireEvent.click(getByTestId('askUserTextSubmit'));
+      expect(onAnswer).toHaveBeenCalledWith('req-1', 'traces');
+    });
+
+    it('falls back to a text field when select has no options', () => {
+      const { getByTestId, queryByTestId } = render(
+        <AskUserCard
+          request={selectRequest({ options: [] })}
+          onAnswer={jest.fn()}
+          onDismiss={jest.fn()}
+        />
+      );
+
+      expect(getByTestId('askUserTextInput')).toBeTruthy();
+      expect(queryByTestId('askUserOption-logs')).toBeNull();
+    });
+  });
+});
+
+describe('AskUserAnsweredCard', () => {
+  it('shows the prompt and the answer when both are present', () => {
+    const { getByText } = render(<AskUserAnsweredCard prompt="Which index?" answer="logs" />);
+
+    expect(getByText('Which index?')).toBeTruthy();
+    expect(getByText('Your answer: logs')).toBeTruthy();
+  });
+
+  it('shows the prompt without an answer line when no answer is available', () => {
+    const { getByText, queryByText } = render(<AskUserAnsweredCard prompt="Which index?" />);
+
+    expect(getByText('Which index?')).toBeTruthy();
+    // No "Your answer:" line when there is no answer.
+    expect(queryByText(/Your answer:/)).toBeNull();
+  });
+
+  it('renders without crashing when neither prompt nor answer is present', () => {
+    const { getByTestId } = render(<AskUserAnsweredCard />);
+    expect(getByTestId('askUserAnsweredCard')).toBeTruthy();
+  });
+});
+
+describe('InlineAskUser', () => {
+  let service: HumanInputService;
+
+  beforeEach(() => {
+    service = new HumanInputService();
+  });
+
+  it('renders the interactive card while its toolCallId is pending', () => {
+    // Register a pending question for tc-1.
+    service.ask({ toolCallId: 'tc-1', prompt: 'Pick one', inputType: 'text' });
+
+    const { getByTestId } = render(
+      <InlineAskUser humanInputService={service} toolCallId="tc-1" prompt="Pick one" />
+    );
+
+    expect(getByTestId('askUserCard')).toBeTruthy();
+  });
+
+  it('renders the answered card when nothing is pending for the toolCallId', () => {
+    const { getByTestId, getByText } = render(
+      <InlineAskUser humanInputService={service} toolCallId="tc-1" prompt="Pick one" answer="A" />
+    );
+
+    expect(getByTestId('askUserAnsweredCard')).toBeTruthy();
+    expect(getByText('Your answer: A')).toBeTruthy();
+  });
+
+  it('shows a "generating" placeholder when not pending and no prompt/answer yet', () => {
+    // The window after the tool call arrives but before its arguments (prompt)
+    // stream in: show the generating indicator, not the card and not an empty node.
+    const { queryByTestId, getByTestId } = render(
+      <InlineAskUser humanInputService={service} toolCallId="tc-1" />
+    );
+
+    expect(queryByTestId('askUserCard')).toBeNull();
+    expect(queryByTestId('askUserAnsweredCard')).toBeNull();
+    expect(getByTestId('askUserGenerating')).toBeTruthy();
+  });
+
+  it('flips from interactive to answered in place, showing the answer immediately', () => {
+    service.ask({ toolCallId: 'tc-1', prompt: 'Pick one', inputType: 'text' });
+
+    const { getByTestId, queryByTestId, getByText } = render(
+      // No `answer` prop: the answer must come from the locally-recorded value,
+      // not a streamed tool result, proving it shows without the continuation run.
+      <InlineAskUser humanInputService={service} toolCallId="tc-1" prompt="Pick one" />
+    );
+
+    // Interactive initially.
+    expect(getByTestId('askUserCard')).toBeTruthy();
+
+    // Answer via the field; the service resolves and drops it from pending.
+    fireEvent.change(getByTestId('askUserTextInput'), { target: { value: 'chosen' } });
+    fireEvent.click(getByTestId('askUserTextSubmit'));
+
+    // Now no longer pending -> shows the answered card WITH the answer, even
+    // though no `answer` prop / tool result was provided.
+    expect(queryByTestId('askUserCard')).toBeNull();
+    expect(getByTestId('askUserAnsweredCard')).toBeTruthy();
+    expect(getByText('Your answer: chosen')).toBeTruthy();
+  });
+
+  it('prefers a locally-recorded answer over the answer prop', () => {
+    service.ask({ toolCallId: 'tc-1', prompt: 'Pick one', inputType: 'text' });
+
+    const { getByTestId, getByText } = render(
+      <InlineAskUser humanInputService={service} toolCallId="tc-1" prompt="Pick one" answer="old" />
+    );
+
+    fireEvent.change(getByTestId('askUserTextInput'), { target: { value: 'fresh' } });
+    fireEvent.click(getByTestId('askUserTextSubmit'));
+
+    expect(getByText('Your answer: fresh')).toBeTruthy();
+  });
+
+  it('does not match a different tool call still pending', () => {
+    service.ask({ toolCallId: 'other-tc', prompt: 'Different', inputType: 'text' });
+
+    const { getByTestId, queryByTestId } = render(
+      <InlineAskUser humanInputService={service} toolCallId="tc-1" prompt="Pick one" />
+    );
+
+    // tc-1 is not pending, so the answered card renders, not the interactive one.
+    expect(queryByTestId('askUserCard')).toBeNull();
+    expect(getByTestId('askUserAnsweredCard')).toBeTruthy();
+  });
+});

--- a/src/plugins/chat/public/components/ask_user_card.test.tsx
+++ b/src/plugins/chat/public/components/ask_user_card.test.tsx
@@ -8,6 +8,10 @@ import { render, fireEvent } from '@testing-library/react';
 import { AskUserCard, AskUserAnsweredCard, InlineAskUser } from './ask_user_card';
 import { AskUserRequest, HumanInputService } from '../services/human_input_service';
 
+// jsdom does not implement scrollIntoView, which InlineAskUser calls to bring a
+// pending question into view.
+Element.prototype.scrollIntoView = jest.fn();
+
 const baseRequest = (overrides: Partial<AskUserRequest> = {}): AskUserRequest => ({
   id: 'req-1',
   toolCallId: 'tc-1',

--- a/src/plugins/chat/public/components/ask_user_card.tsx
+++ b/src/plugins/chat/public/components/ask_user_card.tsx
@@ -1,0 +1,273 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useRef, useState } from 'react';
+import { useObservable } from 'react-use';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiFieldText,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiSpacer,
+  EuiText,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { AskUserRequest, HumanInputService } from '../services/human_input_service';
+
+import './ask_user_card.scss';
+
+interface AskUserCardProps {
+  request: AskUserRequest;
+  /** Deliver the user's answer for this request. */
+  onAnswer: (id: string, value: string) => void;
+  /** Called when the user explicitly declines to answer. */
+  onDismiss: (id: string) => void;
+}
+
+/**
+ * Renders a structured question from the assistant (the `ask_user` tool) and
+ * collects the user's answer. Rendered inline in the chat timeline while a
+ * question is pending; the run is paused until {@link onAnswer} or
+ * {@link onDismiss} is called.
+ */
+export const AskUserCard: React.FC<AskUserCardProps> = ({ request, onAnswer, onDismiss }) => {
+  const [textValue, setTextValue] = useState('');
+
+  const submitText = () => {
+    const trimmed = textValue.trim();
+    if (trimmed) {
+      onAnswer(request.id, trimmed);
+    }
+  };
+
+  const renderControls = () => {
+    if (request.inputType === 'confirm') {
+      return (
+        <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+          <EuiFlexItem grow={false}>
+            <EuiButton
+              size="s"
+              fill
+              onClick={() => onAnswer(request.id, 'yes')}
+              data-test-subj="askUserConfirmYes"
+            >
+              {i18n.translate('chat.askUser.confirmYes', { defaultMessage: 'Yes' })}
+            </EuiButton>
+          </EuiFlexItem>
+          <EuiFlexItem grow={false}>
+            <EuiButtonEmpty
+              size="s"
+              onClick={() => onAnswer(request.id, 'no')}
+              data-test-subj="askUserConfirmNo"
+            >
+              {i18n.translate('chat.askUser.confirmNo', { defaultMessage: 'No' })}
+            </EuiButtonEmpty>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      );
+    }
+
+    // Text field + Send, reused for `text` and appended to `select` when allowFreeText.
+    const textField = (
+      <EuiFlexGroup gutterSize="s" responsive={false} alignItems="center">
+        <EuiFlexItem>
+          <EuiFieldText
+            compressed
+            fullWidth
+            value={textValue}
+            onChange={(e) => setTextValue(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing) submitText();
+            }}
+            placeholder={i18n.translate('chat.askUser.textPlaceholder', {
+              defaultMessage: 'Type your answer...',
+            })}
+            data-test-subj="askUserTextInput"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={false}>
+          <EuiButton
+            size="s"
+            fill
+            onClick={submitText}
+            disabled={!textValue.trim()}
+            data-test-subj="askUserTextSubmit"
+          >
+            {i18n.translate('chat.askUser.textSubmit', { defaultMessage: 'Send' })}
+          </EuiButton>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+
+    if (request.inputType === 'select' && request.options && request.options.length > 0) {
+      return (
+        <>
+          <EuiFlexGroup gutterSize="s" responsive={false} wrap>
+            {request.options.map((option) => (
+              <EuiFlexItem grow={false} key={option.value}>
+                <EuiButton
+                  size="s"
+                  onClick={() => onAnswer(request.id, option.value)}
+                  data-test-subj={`askUserOption-${option.value}`}
+                >
+                  {option.label}
+                </EuiButton>
+              </EuiFlexItem>
+            ))}
+          </EuiFlexGroup>
+          {request.allowFreeText && (
+            <>
+              <EuiSpacer size="s" />
+              <EuiText size="xs" color="subdued">
+                {i18n.translate('chat.askUser.orTypeOwn', {
+                  defaultMessage: 'Or type your own answer:',
+                })}
+              </EuiText>
+              <EuiSpacer size="xs" />
+              {textField}
+            </>
+          )}
+        </>
+      );
+    }
+
+    return textField;
+  };
+
+  return (
+    <EuiPanel
+      paddingSize="s"
+      hasShadow={false}
+      hasBorder
+      data-test-subj="askUserCard"
+      className="askUserCard"
+    >
+      <EuiText size="s">
+        <p>{request.prompt}</p>
+      </EuiText>
+      <EuiSpacer size="s" />
+      {renderControls()}
+      <EuiSpacer size="xs" />
+      <EuiButtonEmpty
+        size="xs"
+        color="text"
+        onClick={() => onDismiss(request.id)}
+        data-test-subj="askUserDismiss"
+      >
+        {i18n.translate('chat.askUser.dismiss', { defaultMessage: "Skip / don't answer" })}
+      </EuiButtonEmpty>
+    </EuiPanel>
+  );
+};
+
+interface AskUserAnsweredCardProps {
+  /** The question prompt. */
+  prompt?: string;
+  /** The user's answer, when available (absent on reload until the result is restored). */
+  answer?: string;
+}
+
+/** Read-only rendering of a resolved / restored `ask_user` question: prompt + answer, no icon. */
+export const AskUserAnsweredCard: React.FC<AskUserAnsweredCardProps> = ({ prompt, answer }) => (
+  <EuiPanel
+    paddingSize="s"
+    hasShadow={false}
+    hasBorder
+    data-test-subj="askUserAnsweredCard"
+    className="askUserCard"
+  >
+    {prompt && (
+      <EuiText size="s">
+        <p>{prompt}</p>
+      </EuiText>
+    )}
+    {answer && (
+      <>
+        <EuiSpacer size="xs" />
+        <EuiText size="xs" color="subdued">
+          {i18n.translate('chat.askUser.answerLabel', {
+            defaultMessage: 'Your answer: {answer}',
+            values: { answer },
+          })}
+        </EuiText>
+      </>
+    )}
+  </EuiPanel>
+);
+
+interface InlineAskUserProps {
+  humanInputService: HumanInputService;
+  /** The tool call this row represents, used to find its pending question. */
+  toolCallId?: string;
+  /** Question prompt, from the persisted tool-call arguments (resolved fallback). */
+  prompt?: string;
+  /** The user's answer, once resolved / restored. */
+  answer?: string;
+}
+
+/**
+ * In-conversation rendering of an `ask_user` tool call (the tool's custom
+ * renderer, so the question sits inline at the tool-call position instead of
+ * floating near the composer). Shows the interactive {@link AskUserCard} while
+ * the question is pending in {@link HumanInputService}, else the read-only
+ * {@link AskUserAnsweredCard}.
+ */
+export const InlineAskUser: React.FC<InlineAskUserProps> = ({
+  humanInputService,
+  toolCallId,
+  prompt,
+  answer,
+}) => {
+  const pending = useObservable(humanInputService.getPending$(), humanInputService.getPending());
+  const request = toolCallId ? pending.find((req) => req.toolCallId === toolCallId) : undefined;
+
+  // Prefer the locally-recorded answer (set synchronously on click) so it shows
+  // immediately; fall back to the `answer` prop (from a restored result on reload).
+  const localAnswers = useObservable(
+    humanInputService.getAnswers$(),
+    humanInputService.getAnswers()
+  );
+  const resolvedAnswer = (toolCallId && localAnswers.get(toolCallId)) || answer;
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isPending = !!request;
+
+  // The card is driven by service state, not the timeline, so the message
+  // list's auto-scroll misses it. Scroll it into view when it becomes pending.
+  useEffect(() => {
+    if (isPending) {
+      containerRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [isPending]);
+
+  // Prompt not streamed in yet — show a lightweight loading line (mirrors the
+  // message list's "Thinking…" indicator) instead of nothing or an empty card,
+  // bridging the gap between the hidden "Thinking…" and the rendered question.
+  if (!request && !prompt && !resolvedAnswer) {
+    return (
+      <div className="askUserCard__generating" data-test-subj="askUserGenerating">
+        {i18n.translate('chat.askUser.generating', { defaultMessage: 'Generating…' })}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef}>
+      {request ? (
+        <AskUserCard
+          // Key by request id so a different question remounts (resets text input).
+          key={request.id}
+          request={request}
+          onAnswer={(id, value) => humanInputService.answer(id, value)}
+          onDismiss={(id) => humanInputService.decline(id)}
+        />
+      ) : (
+        <AskUserAnsweredCard prompt={prompt} answer={resolvedAnswer} />
+      )}
+    </div>
+  );
+};

--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -538,6 +538,31 @@ describe('ChatMessages', () => {
 });
 
 describe('convertTimelineToMessageRows', () => {
+  // Rows are keyed by tool call id and each row renders the tool's card, so a tool call referenced
+  // by several messages must still yield a single row.
+  it('emits one row per tool call even when several messages carry the same tool call', () => {
+    const toolCall = {
+      id: 'tooluse_iAFNqCSCNIniFcsnxrbbGf',
+      type: 'function' as const,
+      function: { name: 'ask_user', arguments: '{"prompt":"What?"}' },
+    };
+    const timeline: Message[] = [
+      { id: '0', role: 'user', content: 'ask me something' } as UserMessage,
+      { id: '1', role: 'assistant', toolCalls: [toolCall] } as AssistantMessage,
+      { id: 'fake-assistant-message-123', role: 'assistant', toolCalls: [toolCall] } as AssistantMessage,
+    ];
+
+    const rows = convertTimelineToMessageRows(timeline);
+    const toolCallRows = rows.filter((r: any) => r.role === 'toolCall');
+    const grouped = rows
+      .filter((r: any) => r.role === 'toolCallGroup')
+      .flatMap((r: any) => r.toolCalls);
+
+    expect([...toolCallRows.map((r: any) => r.toolCall.id), ...grouped.map((t: any) => t.id)]).toEqual([
+      toolCall.id,
+    ]);
+  });
+
   it('should handle empty timeline and simple messages without tool calls', () => {
     // Empty timeline
     expect(convertTimelineToMessageRows([])).toEqual([]);

--- a/src/plugins/chat/public/components/chat_messages.test.tsx
+++ b/src/plugins/chat/public/components/chat_messages.test.tsx
@@ -549,7 +549,11 @@ describe('convertTimelineToMessageRows', () => {
     const timeline: Message[] = [
       { id: '0', role: 'user', content: 'ask me something' } as UserMessage,
       { id: '1', role: 'assistant', toolCalls: [toolCall] } as AssistantMessage,
-      { id: 'fake-assistant-message-123', role: 'assistant', toolCalls: [toolCall] } as AssistantMessage,
+      {
+        id: 'fake-assistant-message-123',
+        role: 'assistant',
+        toolCalls: [toolCall],
+      } as AssistantMessage,
     ];
 
     const rows = convertTimelineToMessageRows(timeline);
@@ -558,9 +562,10 @@ describe('convertTimelineToMessageRows', () => {
       .filter((r: any) => r.role === 'toolCallGroup')
       .flatMap((r: any) => r.toolCalls);
 
-    expect([...toolCallRows.map((r: any) => r.toolCall.id), ...grouped.map((t: any) => t.id)]).toEqual([
-      toolCall.id,
-    ]);
+    expect([
+      ...toolCallRows.map((r: any) => r.toolCall.id),
+      ...grouped.map((t: any) => t.id),
+    ]).toEqual([toolCall.id]);
   });
 
   it('should handle empty timeline and simple messages without tool calls', () => {

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -220,10 +220,20 @@ export const convertTimelineToMessageRows = (
     return -1; // No closing message found
   };
 
+  // A tool call yields exactly one row, however many messages reference it: rows are keyed by tool
+  // call id, and each row renders the tool's own card.
+  const emittedToolCallIds = new Set<string>();
+  const takeUnemitted = (toolCalls: ToolCall[]): ToolCall[] =>
+    toolCalls.filter((tc) => {
+      if (emittedToolCallIds.has(tc.id)) return false;
+      emittedToolCallIds.add(tc.id);
+      return true;
+    });
+
   // Helper: Add tool calls as individual rows
   const addIndividualToolCalls = (toolCalls?: ToolCall[]) => {
     if (!toolCalls?.length) return;
-    toolCalls.forEach((tc) => {
+    takeUnemitted(toolCalls).forEach((tc) => {
       result.push({ role: 'toolCall', toolCall: toTimelineToolCall(tc) });
     });
   };
@@ -235,7 +245,7 @@ export const convertTimelineToMessageRows = (
   const addIndividualToolCallsBeforeCurrentMessage = (toolCalls?: ToolCall[]) => {
     if (!toolCalls?.length) return;
     const insertAt = Math.max(0, result.length - 1); // before the just-pushed message
-    const rows = toolCalls.map(
+    const rows = takeUnemitted(toolCalls).map(
       (tc) => ({ role: 'toolCall', toolCall: toTimelineToolCall(tc) }) as const
     );
     result.splice(insertAt, 0, ...rows);
@@ -244,9 +254,11 @@ export const convertTimelineToMessageRows = (
   // Helper: Add tool calls as a group
   const addToolCallGroup = (toolCalls: ToolCall[]) => {
     if (!toolCalls.length) return;
+    const fresh = takeUnemitted(toolCalls);
+    if (!fresh.length) return;
     result.push({
       role: 'toolCallGroup',
-      toolCalls: toolCalls.map(toTimelineToolCall),
+      toolCalls: fresh.map(toTimelineToolCall),
     });
   };
 

--- a/src/plugins/chat/public/components/chat_messages.tsx
+++ b/src/plugins/chat/public/components/chat_messages.tsx
@@ -201,6 +201,13 @@ export const convertTimelineToMessageRows = (
     return toolCalls.some((tc) => hasCustomRenderer(tc.function.name));
   };
 
+  // Helper: Check if every tool call renders its card below the assistant message
+  const rendersBelowMessage = (toolCalls?: ToolCall[]): boolean => {
+    if (!toolCalls?.length) return false;
+    const service = AssistantActionService.getInstance();
+    return toolCalls.every((tc) => service.getRenderPlacement(tc.function.name) === 'below');
+  };
+
   // Helper: Find next message that closes a tool call batch
   // (non-assistant message or assistant with content)
   const findBatchEndIndex = (startIndex: number): number => {
@@ -258,9 +265,10 @@ export const convertTimelineToMessageRows = (
     if (!toolCalls?.length) continue;
 
     // If any tool is running, show individually and continue processing.
-    // Custom-renderer tools render above the message text (see helper); others stay below.
+    // Custom-renderer tools render above the message text unless they opt into
+    // renderPlacement: 'below'; others stay below.
     if (hasRunningTool(toolCalls)) {
-      if (hasCustomRendererTool(toolCalls)) {
+      if (hasCustomRendererTool(toolCalls) && !rendersBelowMessage(toolCalls)) {
         addIndividualToolCallsBeforeCurrentMessage(toolCalls);
       } else {
         addIndividualToolCalls(toolCalls);
@@ -268,10 +276,14 @@ export const convertTimelineToMessageRows = (
       continue;
     }
 
-    // If any tool has custom renderer, show individually (don't group) and above
-    // the assistant text so the action card sits at the top of the turn.
+    // If any tool has custom renderer, show individually (don't group). The action
+    // chooses its placement: 'above' (default) tops the turn, 'below' follows the text.
     if (hasCustomRendererTool(toolCalls)) {
-      addIndividualToolCallsBeforeCurrentMessage(toolCalls);
+      if (rendersBelowMessage(toolCalls)) {
+        addIndividualToolCalls(toolCalls);
+      } else {
+        addIndividualToolCallsBeforeCurrentMessage(toolCalls);
+      }
       continue;
     }
 

--- a/src/plugins/chat/public/components/chat_mount.test.tsx
+++ b/src/plugins/chat/public/components/chat_mount.test.tsx
@@ -10,6 +10,7 @@ import { coreMock } from '../../../../core/public/mocks';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 import { ChatLayoutMode } from '../types';
 
 // Mock dependencies
@@ -47,6 +48,7 @@ describe('ChatMount', () => {
   let mockChatService: jest.Mocked<ChatService>;
   let mockSuggestedActionsService: jest.Mocked<SuggestedActionsService>;
   let mockConfirmationService: jest.Mocked<ConfirmationService>;
+  let mockHumanInputService: jest.Mocked<HumanInputService>;
   let mockContextProvider: any;
   let mockCharts: any;
   let defaultProps: any;
@@ -71,6 +73,10 @@ describe('ChatMount', () => {
       requestConfirmation: jest.fn(),
     } as any;
 
+    mockHumanInputService = {
+      ask: jest.fn(),
+    } as any;
+
     mockContextProvider = {
       getContextProvider: jest.fn(),
     };
@@ -86,6 +92,7 @@ describe('ChatMount', () => {
       chatService: mockChatService,
       suggestedActionsService: mockSuggestedActionsService,
       confirmationService: mockConfirmationService,
+      humanInputService: mockHumanInputService,
     };
   });
 

--- a/src/plugins/chat/public/components/chat_mount.tsx
+++ b/src/plugins/chat/public/components/chat_mount.tsx
@@ -15,6 +15,7 @@ import { ChatLayoutMode } from '../types';
 import { ContextProviderStart } from '../../../context_provider/public';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 import { GlobalAssistantProvider } from '../../../context_provider/public';
 
 import './chat_mount.scss';
@@ -26,6 +27,7 @@ interface ChatMountProps {
   charts?: any;
   suggestedActionsService: SuggestedActionsService;
   confirmationService: ConfirmationService;
+  humanInputService: HumanInputService;
 }
 
 export const ChatMount = ({
@@ -35,6 +37,7 @@ export const ChatMount = ({
   charts,
   suggestedActionsService,
   confirmationService,
+  humanInputService,
 }: ChatMountProps) => {
   const services = useMemo(
     () => ({
@@ -65,6 +68,7 @@ export const ChatMount = ({
                 chatService={chatService}
                 suggestedActionsService={suggestedActionsService}
                 confirmationService={confirmationService}
+                humanInputService={humanInputService}
               >
                 <ChatWindow layoutMode={ChatLayoutMode.SIDECAR} onClose={handleClose} />
               </ChatProvider>

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -1639,11 +1639,25 @@ describe('ChatWindow', () => {
 
       // Two parallel ask_user calls, each as START/ARGS/END (as injectUnfinishedToolCallEvents emits).
       const mockEvents = [
-        { type: 'MESSAGES_SNAPSHOT', messages: [{ id: 'u1', role: 'user', content: 'Hi' }], timestamp: Date.now() },
-        { type: 'TOOL_CALL_START', toolCallId: 'tc-A', toolCallName: 'ask_user', timestamp: Date.now() },
+        {
+          type: 'MESSAGES_SNAPSHOT',
+          messages: [{ id: 'u1', role: 'user', content: 'Hi' }],
+          timestamp: Date.now(),
+        },
+        {
+          type: 'TOOL_CALL_START',
+          toolCallId: 'tc-A',
+          toolCallName: 'ask_user',
+          timestamp: Date.now(),
+        },
         { type: 'TOOL_CALL_ARGS', toolCallId: 'tc-A', delta: '{}', timestamp: Date.now() },
         { type: 'TOOL_CALL_END', toolCallId: 'tc-A', timestamp: Date.now() },
-        { type: 'TOOL_CALL_START', toolCallId: 'tc-B', toolCallName: 'ask_user', timestamp: Date.now() },
+        {
+          type: 'TOOL_CALL_START',
+          toolCallId: 'tc-B',
+          toolCallName: 'ask_user',
+          timestamp: Date.now(),
+        },
         { type: 'TOOL_CALL_ARGS', toolCallId: 'tc-B', delta: '{}', timestamp: Date.now() },
         { type: 'TOOL_CALL_END', toolCallId: 'tc-B', timestamp: Date.now() },
       ];

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -38,6 +38,7 @@ jest.mock('../services/chat_event_handler', () => ({
     clearState: jest.fn(),
     cancelToolResultDispatch: jest.fn(),
     handleStreamTermination: jest.fn(),
+    markStreamingMessageHalted: jest.fn(),
     sendToolResultToAssistant: jest.fn(),
     sendToolResultsToAssistant: jest.fn(),
   })),
@@ -791,6 +792,10 @@ describe('ChatWindow', () => {
         handleEvent: jest.fn(),
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        markStreamingMessageHalted: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
       }));
 
       const ref = React.createRef<ChatWindowInstance>();
@@ -1499,6 +1504,7 @@ describe('ChatWindow', () => {
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
         handleStreamTermination: jest.fn(),
+        markStreamingMessageHalted: jest.fn(),
         sendToolResultToAssistant: jest.fn(),
         sendToolResultsToAssistant: jest.fn(),
       }));
@@ -1554,6 +1560,7 @@ describe('ChatWindow', () => {
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
         handleStreamTermination: jest.fn(),
+        markStreamingMessageHalted: jest.fn(),
         sendToolResultToAssistant: jest.fn(),
         sendToolResultsToAssistant: jest.fn(),
       }));
@@ -1625,6 +1632,7 @@ describe('ChatWindow', () => {
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
         handleStreamTermination: jest.fn(),
+        markStreamingMessageHalted: jest.fn(),
         sendToolResultToAssistant: jest.fn(),
         sendToolResultsToAssistant: jest.fn(),
       }));
@@ -1765,6 +1773,7 @@ describe('ChatWindow', () => {
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
         handleStreamTermination: jest.fn(),
+        markStreamingMessageHalted: jest.fn(),
         sendToolResultToAssistant: jest.fn(),
         sendToolResultsToAssistant: jest.fn(),
       }));
@@ -2324,9 +2333,10 @@ describe('ChatWindow', () => {
           handleEvent: jest.fn(),
           clearState: jest.fn(),
           cancelToolResultDispatch: jest.fn(),
-        handleStreamTermination: jest.fn(),
-        sendToolResultToAssistant: jest.fn(),
-        sendToolResultsToAssistant: jest.fn(),
+          handleStreamTermination: jest.fn(),
+          markStreamingMessageHalted: jest.fn(),
+          sendToolResultToAssistant: jest.fn(),
+          sendToolResultsToAssistant: jest.fn(),
         };
       });
 
@@ -2366,9 +2376,10 @@ describe('ChatWindow', () => {
           handleEvent: jest.fn(),
           clearState: jest.fn(),
           cancelToolResultDispatch: jest.fn(),
-        handleStreamTermination: jest.fn(),
-        sendToolResultToAssistant: jest.fn(),
-        sendToolResultsToAssistant: jest.fn(),
+          handleStreamTermination: jest.fn(),
+          markStreamingMessageHalted: jest.fn(),
+          sendToolResultToAssistant: jest.fn(),
+          sendToolResultsToAssistant: jest.fn(),
         };
       });
 
@@ -2406,6 +2417,7 @@ describe('ChatWindow', () => {
           clearState: jest.fn(),
           cancelToolResultDispatch: jest.fn(),
           handleStreamTermination: jest.fn(),
+          markStreamingMessageHalted: jest.fn(),
           sendToolResultsToAssistant: jest.fn(),
           sendToolResultToAssistant: jest.fn().mockResolvedValue(undefined),
         };

--- a/src/plugins/chat/public/components/chat_window.test.tsx
+++ b/src/plugins/chat/public/components/chat_window.test.tsx
@@ -13,6 +13,7 @@ import { ChatProvider } from '../contexts/chat_context';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 
 // Create mock observable before using it in mocks
 const mockObservable = of({ toolDefinitions: [], toolCallStates: new Map() });
@@ -36,6 +37,9 @@ jest.mock('../services/chat_event_handler', () => ({
     handleEvent: jest.fn(),
     clearState: jest.fn(),
     cancelToolResultDispatch: jest.fn(),
+    handleStreamTermination: jest.fn(),
+    sendToolResultToAssistant: jest.fn(),
+    sendToolResultsToAssistant: jest.fn(),
   })),
 }));
 
@@ -59,6 +63,7 @@ describe('ChatWindow', () => {
   let mockChatService: jest.Mocked<ChatService>;
   let mockSuggestedActionsService: jest.Mocked<SuggestedActionsService>;
   let mockConfirmationService: jest.Mocked<ConfirmationService>;
+  let mockHumanInputService: jest.Mocked<HumanInputService>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -108,6 +113,14 @@ describe('ChatWindow', () => {
       cancel: jest.fn(),
       cleanAll: jest.fn(),
     } as any;
+    mockHumanInputService = {
+      getPending$: jest.fn().mockReturnValue(of([])),
+      getPending: jest.fn().mockReturnValue([]),
+      hasPending: jest.fn().mockReturnValue(false),
+      ask: jest.fn(),
+      answer: jest.fn(),
+      cleanAll: jest.fn(),
+    } as any;
   });
 
   const renderWithContext = (component: React.ReactElement) => {
@@ -119,6 +132,7 @@ describe('ChatWindow', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           {component}
         </ChatProvider>
@@ -1484,6 +1498,9 @@ describe('ChatWindow', () => {
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
       }));
 
       const mockEvents = [
@@ -1536,6 +1553,9 @@ describe('ChatWindow', () => {
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
       }));
 
       const mockEvents = [
@@ -1582,6 +1602,77 @@ describe('ChatWindow', () => {
       const calledTypes = mockHandleEvent.mock.calls.map((call: any) => call[0]?.type);
       expect(calledTypes).toContain('MESSAGES_SNAPSHOT');
       expect(calledTypes).toContain('TOOL_CALL_START');
+    });
+
+    it('should not await TOOL_CALL_END during replay, so parallel halt-type tools all register', async () => {
+      // Regression for: reloading a thread with several parallel `ask_user` calls showed only
+      // one card. A halt-type tool blocks inside handleToolCallEnd on humanInputService.ask()
+      // forever during replay; awaiting its TOOL_CALL_END stalled the loop so the synthetic
+      // events for the other parallel calls were never consumed. TOOL_CALL_END must be
+      // fire-and-forget so every parallel tool's synthetic events get dispatched.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { ChatEventHandler } = require('../services/chat_event_handler');
+      const mockClearState = jest.fn();
+      // First TOOL_CALL_END blocks forever (mimics ask_user awaiting a user answer).
+      const mockHandleEvent = jest.fn().mockImplementation((event: any) => {
+        if (event?.type === 'TOOL_CALL_END') {
+          return new Promise(() => {}); // never resolves
+        }
+        return Promise.resolve();
+      });
+      ChatEventHandler.mockImplementation(() => ({
+        handleEvent: mockHandleEvent,
+        clearState: mockClearState,
+        cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
+      }));
+
+      // Two parallel ask_user calls, each as START/ARGS/END (as injectUnfinishedToolCallEvents emits).
+      const mockEvents = [
+        { type: 'MESSAGES_SNAPSHOT', messages: [{ id: 'u1', role: 'user', content: 'Hi' }], timestamp: Date.now() },
+        { type: 'TOOL_CALL_START', toolCallId: 'tc-A', toolCallName: 'ask_user', timestamp: Date.now() },
+        { type: 'TOOL_CALL_ARGS', toolCallId: 'tc-A', delta: '{}', timestamp: Date.now() },
+        { type: 'TOOL_CALL_END', toolCallId: 'tc-A', timestamp: Date.now() },
+        { type: 'TOOL_CALL_START', toolCallId: 'tc-B', toolCallName: 'ask_user', timestamp: Date.now() },
+        { type: 'TOOL_CALL_ARGS', toolCallId: 'tc-B', delta: '{}', timestamp: Date.now() },
+        { type: 'TOOL_CALL_END', toolCallId: 'tc-B', timestamp: Date.now() },
+      ];
+      // @ts-expect-error TS2345 TODO(ts-error): fixme
+      mockChatService.loadConversation.mockImplementation(async (threadId: string) => {
+        (mockChatService.getThreadId as jest.Mock).mockReturnValue(threadId);
+        return mockEvents;
+      });
+
+      const { getByLabelText, getByText } = renderWithContext(<ChatWindow onClose={jest.fn()} />);
+
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      const historyButton = getByLabelText('Show conversation history');
+      await act(async () => {
+        historyButton.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 10));
+      });
+      const conversationItem = getByText('Test conversation');
+      await act(async () => {
+        conversationItem.click();
+      });
+      await act(async () => {
+        await new Promise((r) => setTimeout(r, 50));
+      });
+
+      // Both tool calls' synthetic events must all be dispatched even though the first
+      // TOOL_CALL_END never resolves — proving the loop did not await it.
+      const calledTypes = mockHandleEvent.mock.calls.map((call: any) => call[0]?.type);
+      const calledIds = mockHandleEvent.mock.calls.map((call: any) => call[0]?.toolCallId);
+      expect(mockHandleEvent).toHaveBeenCalledTimes(mockEvents.length);
+      expect(calledTypes.filter((t: string) => t === 'TOOL_CALL_END')).toHaveLength(2);
+      expect(calledIds).toContain('tc-A');
+      expect(calledIds).toContain('tc-B');
     });
 
     it('should cancel ongoing streaming when switching to another conversation', async () => {
@@ -1673,6 +1764,9 @@ describe('ChatWindow', () => {
         handleEvent: mockHandleEvent,
         clearState: mockClearState,
         cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
       }));
 
       // Mock ongoing streaming that continues after switch
@@ -2230,6 +2324,9 @@ describe('ChatWindow', () => {
           handleEvent: jest.fn(),
           clearState: jest.fn(),
           cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
         };
       });
 
@@ -2269,6 +2366,9 @@ describe('ChatWindow', () => {
           handleEvent: jest.fn(),
           clearState: jest.fn(),
           cancelToolResultDispatch: jest.fn(),
+        handleStreamTermination: jest.fn(),
+        sendToolResultToAssistant: jest.fn(),
+        sendToolResultsToAssistant: jest.fn(),
         };
       });
 
@@ -2305,6 +2405,8 @@ describe('ChatWindow', () => {
           handleEvent: jest.fn(),
           clearState: jest.fn(),
           cancelToolResultDispatch: jest.fn(),
+          handleStreamTermination: jest.fn(),
+          sendToolResultsToAssistant: jest.fn(),
           sendToolResultToAssistant: jest.fn().mockResolvedValue(undefined),
         };
       });

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -589,6 +589,9 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
     // Helper function to stop streaming and clean up subscriptions
     const stopStreaming = useCallback(() => {
+      // Mark the streaming message as halted before tearing down, so the user immediately sees
+      // "partial answer + stop line" — matching what the agent server persists for the reload.
+      eventHandler.markStreamingMessageHalted();
       // Abort the current streaming request
       chatService.abort();
       // Unsubscribe from current observable if exists

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -465,20 +465,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 
       // Prepare additional messages for sending (but don't add to timeline yet)
       const additionalMessages = options?.messages ?? [];
-      // Only add screenshot data if messages not provided
+
+      // Merge the screenshot INTO the user message content rather than sending it as a separate
+      // message. A separate message is dropped on the delta-only send path (only the single user
+      // message is transmitted when full history is off), so the agent would never see the image.
       if (!options?.input && typeof messageContent === 'string' && screenshotData) {
         messageContent = [
-          // {
-          //   type: 'image',
-          //   source: {
-          //     type: 'data',
-          //     value: screenshotData.base64,
-          //     mimeType: screenshotData.mimeType,
-          //   },
-          // },
-
-          // binary is deprecated
-          // change to image when strands is introduced.
+          // binary is deprecated on the wire; the agent server upgrades it to an image block.
           {
             type: 'binary' as const,
             mimeType: screenshotData.mimeType,
@@ -506,7 +499,8 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         if (!result.valid) return;
 
         // Check if this is a slash command — pass userMsg so executeSlashCommand
-        // can replace it (by id) with the resolved command message.
+        // can replace it (by id) with the resolved command message. Only plain-text
+        // input can be a command (a multimodal message carries an image block).
         if (typeof messageContent === 'string') {
           const handled = await executeSlashCommand(messageContent, messagesToSend, userMsg);
           if (handled) return;

--- a/src/plugins/chat/public/components/chat_window.tsx
+++ b/src/plugins/chat/public/components/chat_window.tsx
@@ -21,7 +21,8 @@ import { useChatContext } from '../contexts/chat_context';
 import { ChatEventHandler } from '../services/chat_event_handler';
 import { AssistantActionService } from '../../../context_provider/public';
 import { ConfirmationRequest } from '../services/confirmation_service';
-import { type Event as ChatEvent } from '../../common/events';
+import { AskUserRequest } from '../services/human_input_service';
+import { type Event as ChatEvent, EventType } from '../../common/events';
 import type { InputContent, Message, SystemMessage, UserMessage } from '../../common/types';
 import { ChatLayoutMode } from '../types';
 import { ChatContainer } from './chat_container';
@@ -65,7 +66,7 @@ export const ChatWindow = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
 const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
   ({ layoutMode = ChatLayoutMode.SIDECAR, onClose }, ref) => {
     const service = AssistantActionService.getInstance();
-    const { chatService, confirmationService } = useChatContext();
+    const { chatService, confirmationService, humanInputService } = useChatContext();
     const { services } = useOpenSearchDashboards<{ core: CoreStart }>();
     const toasts = services.core?.notifications?.toasts;
     const [timeline, setTimeline] = useState<Message[]>([]);
@@ -75,6 +76,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
     const [pendingConfirmation, setPendingConfirmation] = useState<ConfirmationRequest | null>(
       null
     );
+    const [pendingAskUser, setPendingAskUser] = useState<AskUserRequest | null>(null);
     const [showHistory, setShowHistory] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const handleSendRef = useRef<typeof handleSend>();
@@ -145,6 +147,16 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       return () => subscription.unsubscribe();
     }, [confirmationService]);
 
+    // Track a pending ask_user question only to lock the composer; the question
+    // UI is rendered inline at its tool-call position by InlineAskUser, not here.
+    useEffect(() => {
+      const subscription = humanInputService.getPending$().subscribe((requests) => {
+        setPendingAskUser(requests.length > 0 ? requests[0] : null);
+      });
+
+      return () => subscription.unsubscribe();
+    }, [humanInputService]);
+
     // Get telemetry recorder from core services
     const telemetryRecorder = useMemo(
       () => services.core?.telemetry?.getPluginRecorder('chat'),
@@ -183,12 +195,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       return () => subscription.unsubscribe();
     }, [service, chatService]);
 
-    // Clean up event handler on component unmount
+    // Clean up event handler and human input service on component unmount
     useEffect(() => {
       return () => {
+        humanInputService.cleanAll();
         eventHandler.clearState();
       };
-    }, [eventHandler]);
+    }, [eventHandler, humanInputService]);
 
     // Initialize with fresh conversation on mount
     useMount(() => {
@@ -277,12 +290,14 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             },
             error: (error: any) => {
               console.error('Subscription error:', error);
+              eventHandler.handleStreamTermination();
               isStreamingRef.current = false;
               setStartResponse(false);
               setIsStreaming(false);
               currentSubscriptionRef.current = null;
             },
             complete: () => {
+              eventHandler.handleStreamTermination();
               isStreamingRef.current = false;
               setStartResponse(false);
               setIsStreaming(false);
@@ -561,7 +576,13 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
         if (isStreamingRef.current || hasActiveToolCallsRef.current) return;
         // Remove the error message from timeline
         setTimelineSynced((prev) => prev.filter((msg) => msg.id !== messageId));
-        await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
+        // If toolResult is a batch array (from sendToolResultsToAssistant's sync_timeout),
+        // dispatch it through the batched path so each item's toolCallId is preserved.
+        if (Array.isArray(toolResult)) {
+          await eventHandler.sendToolResultsToAssistant(toolResult);
+        } else {
+          await eventHandler.sendToolResultToAssistant(toolCallId, toolResult);
+        }
       },
       [eventHandler, setTimelineSynced]
     );
@@ -598,13 +619,22 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
       setTimelineSynced([]);
       setCurrentRunId(null);
       setPendingConfirmation(null);
+      setPendingAskUser(null);
       setPendingMessage(null);
       setAvailableDataSources([]);
       isValidatingRef.current = false;
       setIsValidating(false);
       confirmationService.cleanAll();
+      humanInputService.cleanAll();
       setShowHistory(false);
-    }, [chatService, confirmationService, eventHandler, stopStreaming, setTimelineSynced]);
+    }, [
+      chatService,
+      confirmationService,
+      eventHandler,
+      humanInputService,
+      stopStreaming,
+      setTimelineSynced,
+    ]);
 
     const handleStop = useCallback(() => {
       stopStreaming();
@@ -700,17 +730,34 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
             eventHandler.clearState();
             setCurrentRunId(null);
             setPendingConfirmation(null);
+            setPendingAskUser(null);
             confirmationService.cleanAll();
+            humanInputService.cleanAll();
             setShowHistory(false);
             setIsLoading(false);
 
-            // Replay all events to reconstruct the conversation
+            // Replay all events to reconstruct the conversation.
+            //
+            // TOOL_CALL_END is dispatched WITHOUT awaiting. A halt-type frontend
+            // tool (e.g. `ask_user`) blocks inside handleToolCallEnd on
+            // humanInputService.ask() until the user answers, which never happens
+            // during replay. Awaiting it would stall the loop on the first such
+            // tool, so the synthetic events for the remaining parallel tool calls
+            // would never be consumed — only one ask_user card would appear. This
+            // mirrors the live path, where the RxJS subscriber's async `next` does
+            // not await handleEvent, letting parallel tool calls register
+            // concurrently. All other events stay awaited to preserve order.
             for (const event of events) {
               // Check abort signal during replay
               if (abortController.signal.aborted) {
                 return;
               }
-              await eventHandler.handleEvent(event);
+              if (event.type === EventType.TOOL_CALL_END) {
+                // Fire-and-forget: let parallel halt-type tools register together.
+                void eventHandler.handleEvent(event);
+              } else {
+                await eventHandler.handleEvent(event);
+              }
             }
           }
         } catch (error: any) {
@@ -738,7 +785,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
           }
         }
       },
-      [chatService, eventHandler, confirmationService, toasts, stopStreaming]
+      [chatService, eventHandler, confirmationService, humanInputService, toasts, stopStreaming]
     );
 
     const windowInstance = useMemo<ChatWindowInstance>(
@@ -873,6 +920,7 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
                 hasActiveToolCalls ||
                 hasPendingResend ||
                 !!pendingConfirmation ||
+                !!pendingAskUser ||
                 availableDataSources.length > 0 ||
                 isValidating
               }
@@ -881,19 +929,23 @@ const ChatWindowContent = React.forwardRef<ChatWindowInstance, ChatWindowProps>(
                   ? i18n.translate('chat.input.selectDataSource', {
                       defaultMessage: 'Select a data source to continue...',
                     })
-                  : pendingConfirmation
-                    ? i18n.translate('chat.input.waitingForConfirmation', {
-                        defaultMessage: 'Waiting for confirmation...',
+                  : pendingAskUser
+                    ? i18n.translate('chat.input.waitingForAnswer', {
+                        defaultMessage: 'Answer the question above to continue...',
                       })
-                    : hasPendingResend
-                      ? i18n.translate('chat.input.pendingResend', {
-                          defaultMessage: 'Resend the tool result to continue...',
+                    : pendingConfirmation
+                      ? i18n.translate('chat.input.waitingForConfirmation', {
+                          defaultMessage: 'Waiting for confirmation...',
                         })
-                      : hasActiveToolCalls
-                        ? i18n.translate('chat.input.waitingForToolExecution', {
-                            defaultMessage: 'Waiting for tool execution...',
+                      : hasPendingResend
+                        ? i18n.translate('chat.input.pendingResend', {
+                            defaultMessage: 'Resend the tool result to continue...',
                           })
-                        : undefined
+                        : hasActiveToolCalls
+                          ? i18n.translate('chat.input.waitingForToolExecution', {
+                              defaultMessage: 'Waiting for tool execution...',
+                            })
+                          : undefined
               }
               onInputChange={setInput}
               onSend={handleSend}

--- a/src/plugins/chat/public/components/chat_window_conversation_name.test.tsx
+++ b/src/plugins/chat/public/components/chat_window_conversation_name.test.tsx
@@ -13,6 +13,7 @@ import { ChatProvider } from '../contexts/chat_context';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 import { ChatEventHandler } from '../services/chat_event_handler';
 
 // Create mock observable before using it in mocks
@@ -63,6 +64,7 @@ describe('ChatWindow - Conversation Name', () => {
   let mockChatService: jest.Mocked<ChatService>;
   let mockSuggestedActionsService: jest.Mocked<SuggestedActionsService>;
   let mockConfirmationService: jest.Mocked<ConfirmationService>;
+  let mockHumanInputService: jest.Mocked<HumanInputService>;
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -111,6 +113,14 @@ describe('ChatWindow - Conversation Name', () => {
       reject: jest.fn(),
       cancel: jest.fn(),
     } as any;
+    mockHumanInputService = {
+      getPending$: jest.fn().mockReturnValue(of([])),
+      getPending: jest.fn().mockReturnValue([]),
+      hasPending: jest.fn().mockReturnValue(false),
+      ask: jest.fn(),
+      answer: jest.fn(),
+      cleanAll: jest.fn(),
+    } as any;
   });
 
   const renderWithContext = (component: React.ReactElement) => {
@@ -122,6 +132,7 @@ describe('ChatWindow - Conversation Name', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           {component}
         </ChatProvider>

--- a/src/plugins/chat/public/components/message_row.tsx
+++ b/src/plugins/chat/public/components/message_row.tsx
@@ -12,7 +12,6 @@ import type { Message, AssistantMessage } from '../../common/types';
 import { stripInlineSuggestions } from '../../common/parse_inline_suggestions';
 import { getImageSrc } from '../utils/user_message_input';
 import { ShareModal } from './share_modal';
-import { getImageSrc } from '../utils/user_message_input';
 import './message_row.scss';
 
 interface MessageRowProps {

--- a/src/plugins/chat/public/components/message_row.tsx
+++ b/src/plugins/chat/public/components/message_row.tsx
@@ -12,6 +12,7 @@ import type { Message, AssistantMessage } from '../../common/types';
 import { stripInlineSuggestions } from '../../common/parse_inline_suggestions';
 import { getImageSrc } from '../utils/user_message_input';
 import { ShareModal } from './share_modal';
+import { getImageSrc } from '../utils/user_message_input';
 import './message_row.scss';
 
 interface MessageRowProps {
@@ -73,6 +74,9 @@ export const MessageRow: React.FC<MessageRowProps> = ({
       return (
         <>
           {content
+            // Named blocks (e.g. visualization_context) are context for the agent, not for the
+            // user bubble; skip them here. getImageSrc resolves both the legacy `binary` shape
+            // and the `image` shape, so images survive a reload either way.
             .filter((block: any) => !block.name)
             .map((block: any, index: number) => {
               const imageSrc = getImageSrc(block);

--- a/src/plugins/chat/public/components/tool_call_row.tsx
+++ b/src/plugins/chat/public/components/tool_call_row.tsx
@@ -327,6 +327,7 @@ const getCustomizedRenderOptions = ({
     args,
     result: renderResult,
     error: toolCall.status === 'error' ? new Error(toolCall.result || 'Unknown error') : undefined,
+    toolCallId: toolCall.id,
     onApprove,
     onReject,
   };

--- a/src/plugins/chat/public/contexts/chat_context.test.tsx
+++ b/src/plugins/chat/public/contexts/chat_context.test.tsx
@@ -8,16 +8,19 @@ import { ChatProvider, useChatContext } from './chat_context';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action/suggested_actions_service';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 
 // Mock services
 jest.mock('../services/chat_service');
 jest.mock('../services/suggested_action/suggested_actions_service');
 jest.mock('../services/confirmation_service');
+jest.mock('../services/human_input_service');
 
 describe('ChatContext', () => {
   let mockChatService: jest.Mocked<ChatService>;
   let mockSuggestedActionsService: jest.Mocked<SuggestedActionsService>;
   let mockConfirmationService: jest.Mocked<ConfirmationService>;
+  let mockHumanInputService: jest.Mocked<HumanInputService>;
 
   beforeEach(() => {
     mockChatService = {
@@ -47,6 +50,15 @@ describe('ChatContext', () => {
       getPendingConfirmations: jest.fn(),
       hasPendingConfirmations: jest.fn(),
     } as any;
+
+    mockHumanInputService = {
+      getPending$: jest.fn(),
+      getPending: jest.fn(),
+      hasPending: jest.fn(),
+      ask: jest.fn(),
+      answer: jest.fn(),
+      cleanAll: jest.fn(),
+    } as any;
   });
 
   describe('ChatProvider', () => {
@@ -65,6 +77,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -88,6 +101,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -113,6 +127,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -138,6 +153,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -154,6 +170,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <div data-test-subj="child">Child Component</div>
         </ChatProvider>
@@ -179,6 +196,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -202,6 +220,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -250,6 +269,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -259,7 +279,7 @@ describe('ChatContext', () => {
       expect(screen.getByTestId('has-suggested-actions-service')).toHaveTextContent('true');
       expect(screen.getByTestId('has-confirmation-service')).toHaveTextContent('true');
       expect(screen.getByTestId('context-keys')).toHaveTextContent(
-        'chatService,confirmationService,suggestedActionsService'
+        'chatService,confirmationService,humanInputService,suggestedActionsService'
       );
     });
   });
@@ -279,6 +299,7 @@ describe('ChatContext', () => {
           chatService={service1}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -291,6 +312,7 @@ describe('ChatContext', () => {
           chatService={service2}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -313,6 +335,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={confirmationService1}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -325,6 +348,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={confirmationService2}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -351,6 +375,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <Consumer1 />
           <Consumer2 />
@@ -385,6 +410,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <Consumer1 />
           <Consumer2 />
@@ -413,6 +439,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -427,6 +454,7 @@ describe('ChatContext', () => {
           chatService={newChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -454,6 +482,7 @@ describe('ChatContext', () => {
           chatService={mockChatService}
           suggestedActionsService={mockSuggestedActionsService}
           confirmationService={mockConfirmationService}
+          humanInputService={mockHumanInputService}
         >
           <TestComponent />
         </ChatProvider>
@@ -466,6 +495,7 @@ describe('ChatContext', () => {
             chatService={mockChatService}
             suggestedActionsService={mockSuggestedActionsService}
             confirmationService={mockConfirmationService}
+            humanInputService={mockHumanInputService}
           >
             <TestComponent />
           </ChatProvider>

--- a/src/plugins/chat/public/contexts/chat_context.tsx
+++ b/src/plugins/chat/public/contexts/chat_context.tsx
@@ -7,11 +7,13 @@ import React, { createContext, useContext, ReactNode } from 'react';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 
 interface ChatContextType {
   chatService: ChatService;
   suggestedActionsService: SuggestedActionsService;
   confirmationService: ConfirmationService;
+  humanInputService: HumanInputService;
 }
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -21,6 +23,7 @@ interface ChatProviderProps {
   chatService: ChatService;
   suggestedActionsService: SuggestedActionsService;
   confirmationService: ConfirmationService;
+  humanInputService: HumanInputService;
 }
 
 export const ChatProvider: React.FC<ChatProviderProps> = ({
@@ -28,9 +31,12 @@ export const ChatProvider: React.FC<ChatProviderProps> = ({
   chatService,
   suggestedActionsService,
   confirmationService,
+  humanInputService,
 }) => {
   return (
-    <ChatContext.Provider value={{ chatService, suggestedActionsService, confirmationService }}>
+    <ChatContext.Provider
+      value={{ chatService, suggestedActionsService, confirmationService, humanInputService }}
+    >
       {children}
     </ChatContext.Provider>
   );

--- a/src/plugins/chat/public/plugin.test.ts
+++ b/src/plugins/chat/public/plugin.test.ts
@@ -513,6 +513,7 @@ describe('ChatPlugin', () => {
         charts: mockDeps.charts,
         suggestedActionsService: expect.any(Object),
         confirmationService: expect.any(Object),
+        humanInputService: expect.any(Object),
       });
     });
 

--- a/src/plugins/chat/public/plugin.ts
+++ b/src/plugins/chat/public/plugin.ts
@@ -29,6 +29,9 @@ import { SuggestedActionsService } from './services/suggested_action';
 import { isChatEnabled } from '../common/chat_capabilities';
 import { CommandRegistryService } from './services/command_registry_service';
 import { ConfirmationService } from './services/confirmation_service';
+import { HumanInputService } from './services/human_input_service';
+import { createAskUserAction } from './services/ask_user_action';
+import { AssistantActionService } from '../../context_provider/public';
 import { AgenticMemoryProvider } from './services/agentic_memory_provider';
 import { ChatMountService } from './services/chat_mount_service';
 
@@ -53,6 +56,7 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
   private suggestedActionsService = new SuggestedActionsService();
   private commandRegistryService = new CommandRegistryService();
   private confirmationService = new ConfirmationService();
+  private humanInputService = new HumanInputService();
   private chatMountService?: ChatMountService;
   private paddingSizeSubscription?: Subscription;
   private windowStateChangeSubscription?: Subscription;
@@ -192,6 +196,16 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
       }
     }
 
+    // Register the `ask_user` human-in-the-loop tool eagerly, before any
+    // conversation replay can run. The AssistantActionService is a
+    // process-wide singleton, so registering here (rather than in a React
+    // effect) guarantees `hasAction('ask_user')` is true when
+    // `injectUnfinishedToolCallEvents` decides whether to replay an unfinished
+    // question on reload — closing the effect-ordering race.
+    AssistantActionService.getInstance().registerAction(
+      createAskUserAction(this.humanInputService)
+    );
+
     this.chatMountService = new ChatMountService();
 
     this.chatMountService.start({
@@ -201,6 +215,7 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
       charts: deps.charts,
       suggestedActionsService: this.suggestedActionsService!,
       confirmationService: this.confirmationService,
+      humanInputService: this.humanInputService,
     });
 
     // Register chat button in header with conditional visibility
@@ -264,5 +279,7 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
     this.autoFocusWindowCloseSubscription?.();
     this.chatService?.destroy();
     this.confirmationService.cleanAll();
+    this.humanInputService.cleanAll();
+    AssistantActionService.getInstance().unregisterAction('ask_user');
   }
 }

--- a/src/plugins/chat/public/services/ag_ui_agent.ts
+++ b/src/plugins/chat/public/services/ag_ui_agent.ts
@@ -117,7 +117,8 @@ export class AgUiAgent {
           this.activeConnection = false;
 
           if (error.name === 'AbortError') {
-            return; // Request was cancelled
+            observer.complete();
+            return;
           }
 
           // eslint-disable-next-line no-console

--- a/src/plugins/chat/public/services/ag_ui_agent.ts
+++ b/src/plugins/chat/public/services/ag_ui_agent.ts
@@ -30,17 +30,13 @@ export class AgUiAgent {
 
   public runAgent(input: RunAgentInput, dataSourceId?: string): Observable<BaseEvent> {
     return new Observable<BaseEvent>((observer) => {
-      // Only abort if we're not in the middle of an active connection
-      // This prevents tool result submissions from breaking the main SSE stream
-      if (this.abortController && !this.activeConnection) {
+      // Serialize requests on this instance: a new request supersedes the previous one so the
+      // same thread never has two concurrent runs. (Restore polling uses its own instance.)
+      if (this.abortController) {
         this.abortController.abort();
       }
-
-      // Create new controller if none exists OR if the existing one is aborted
-      if (!this.abortController || this.abortController.signal.aborted) {
-        this.abortController = new AbortController();
-        this.sseBuffer = ''; // Reset buffer for new request
-      }
+      this.abortController = new AbortController();
+      this.sseBuffer = ''; // Reset buffer for new request
 
       // Set active connection flag
       this.activeConnection = true;

--- a/src/plugins/chat/public/services/ask_user_action.test.tsx
+++ b/src/plugins/chat/public/services/ask_user_action.test.tsx
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createAskUserAction } from './ask_user_action';
+import { HumanInputService } from './human_input_service';
+
+const makeService = (askImpl?: jest.Mock) =>
+  (({
+    ask: askImpl ?? jest.fn().mockResolvedValue({ answer: 'blue' }),
+    getPending$: jest.fn(),
+    getPending: jest.fn().mockReturnValue([]),
+    getAnswers$: jest.fn(),
+    getAnswers: jest.fn().mockReturnValue(new Map()),
+  } as unknown) as HumanInputService);
+
+describe('createAskUserAction', () => {
+  it('asks under the tool call id it was given', async () => {
+    const ask = jest.fn().mockResolvedValue({ answer: 'blue' });
+    const action = createAskUserAction(makeService(ask));
+
+    const result = await action.handler!({ prompt: 'Favourite colour?' }, 'tooluse_abc');
+
+    expect(ask).toHaveBeenCalledWith(
+      expect.objectContaining({ toolCallId: 'tooluse_abc', prompt: 'Favourite colour?' })
+    );
+    expect(result).toEqual({ answered: true, question: 'Favourite colour?', answer: 'blue' });
+  });
+
+  it('normalizes bare string options to {label, value}', async () => {
+    const ask = jest.fn().mockResolvedValue({ answer: 'a' });
+    const action = createAskUserAction(makeService(ask));
+
+    await action.handler!({ prompt: 'Pick', options: ['a', { label: 'B', value: 'b' }] }, 'tc-1');
+
+    expect(ask).toHaveBeenCalledWith(
+      expect.objectContaining({
+        options: [
+          { label: 'a', value: 'a' },
+          { label: 'B', value: 'b' },
+        ],
+      })
+    );
+  });
+
+  it('fails instead of asking when no tool call id is supplied', async () => {
+    // render() locates the pending question by tool call id, so a question registered under a
+    // substitute id could never be shown and the handler would block until teardown.
+    const ask = jest.fn();
+    const action = createAskUserAction(makeService(ask));
+
+    await expect(action.handler!({ prompt: 'Favourite colour?' }, undefined)).rejects.toThrow(
+      /requires a toolCallId/
+    );
+    expect(ask).not.toHaveBeenCalled();
+  });
+
+  it('uses a failure message ToolExecutor will not reroute to the agent-tool path', async () => {
+    // ToolExecutor treats "not found"/"not registered" as "this is not a registered action" and
+    // sends the call down the agent-tool path, which would mask the failure.
+    const action = createAskUserAction(makeService(jest.fn()));
+
+    let message = '';
+    try {
+      await action.handler!({ prompt: 'q' }, undefined);
+    } catch (e) {
+      message = (e as Error).message;
+    }
+    expect(message).toBeTruthy();
+    expect(message).not.toMatch(/not found|not registered/);
+  });
+
+  it('reports a declined answer with the question echoed back', async () => {
+    const ask = jest.fn().mockResolvedValue({ declined: true });
+    const action = createAskUserAction(makeService(ask));
+
+    expect(await action.handler!({ prompt: 'q' }, 'tc-1')).toEqual({
+      answered: false,
+      declined: true,
+      question: 'q',
+    });
+  });
+
+  it('cancels when the request is torn down', async () => {
+    const ask = jest.fn().mockResolvedValue({ cancelled: true });
+    const action = createAskUserAction(makeService(ask));
+
+    expect(await action.handler!({ prompt: 'q' }, 'tc-1')).toEqual({ cancelled: true });
+  });
+});

--- a/src/plugins/chat/public/services/ask_user_action.test.tsx
+++ b/src/plugins/chat/public/services/ask_user_action.test.tsx
@@ -7,13 +7,13 @@ import { createAskUserAction } from './ask_user_action';
 import { HumanInputService } from './human_input_service';
 
 const makeService = (askImpl?: jest.Mock) =>
-  (({
+  ({
     ask: askImpl ?? jest.fn().mockResolvedValue({ answer: 'blue' }),
     getPending$: jest.fn(),
     getPending: jest.fn().mockReturnValue([]),
     getAnswers$: jest.fn(),
     getAnswers: jest.fn().mockReturnValue(new Map()),
-  } as unknown) as HumanInputService);
+  }) as unknown as HumanInputService;
 
 describe('createAskUserAction', () => {
   it('asks under the tool call id it was given', async () => {

--- a/src/plugins/chat/public/services/ask_user_action.tsx
+++ b/src/plugins/chat/public/services/ask_user_action.tsx
@@ -1,0 +1,125 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AssistantAction } from '../../../context_provider/public';
+import { HumanInputService, AskUserOption } from './human_input_service';
+import { InlineAskUser } from '../components/ask_user_card';
+
+interface AskUserArgs {
+  prompt: string;
+  inputType?: 'select' | 'confirm' | 'text';
+  options?: Array<string | AskUserOption>;
+  allowFreeText?: boolean;
+}
+
+/**
+ * Build the `ask_user` frontend-tool definition. The handler blocks on
+ * {@link HumanInputService.ask} until the user answers; the run pauses at the
+ * tool-use boundary and resumes with a continuation run carrying the answer.
+ *
+ * A plain factory (not a React hook) so it can be registered imperatively at
+ * plugin `start()` — before any conversation replay. This avoids a race where
+ * replay's `hasAction('ask_user')` check (`injectUnfinishedToolCallEvents`)
+ * could run before a React effect registered the action, dropping a pending
+ * question on reload.
+ */
+export const createAskUserAction = (
+  humanInputService: HumanInputService
+): AssistantAction<AskUserArgs> => ({
+  name: 'ask_user',
+  description:
+    'Ask the user a structured question and wait for their answer before continuing. ' +
+    'Use this to resolve ambiguity, let the user choose between options, or confirm an ' +
+    'action before proceeding — instead of guessing or asking in free-form text. ' +
+    "Set inputType to 'select' with options for a multiple-choice question, 'confirm' for " +
+    "a yes/no decision, or 'text' for free-form input. For a 'select' question, set " +
+    'allowFreeText: true to also offer a text field so the user can answer with something ' +
+    'not in the options. ' +
+    'If a result comes back with declined: true, the user chose not to answer that ' +
+    'question (identified by the echoed question field) — do NOT ask it again, in a card ' +
+    'or in free-form text. Acknowledge briefly and proceed with a sensible default or ' +
+    'continue without that detail.',
+  parameters: {
+    type: 'object',
+    properties: {
+      prompt: {
+        type: 'string',
+        description: 'The question to show the user.',
+      },
+      inputType: {
+        type: 'string',
+        enum: ['select', 'confirm', 'text'],
+        description: "How the user should answer. Defaults to 'text'.",
+      },
+      options: {
+        type: 'array',
+        items: { type: 'string' },
+        description: "Choices for a 'select' question.",
+      },
+      allowFreeText: {
+        type: 'boolean',
+        description:
+          "For a 'select' question, also show a free-text field so the user can answer with " +
+          'something not listed in options. Ignored for other input types.',
+      },
+    },
+    required: ['prompt'],
+  },
+  // Render the question inline at the tool-call position (replacing the generic
+  // "Running" spinner). See InlineAskUser for the pending/resolved handling.
+  useCustomRenderer: true,
+  // The assistant text introduces the question, so the card follows it rather than
+  // leading the turn.
+  renderPlacement: 'below',
+  render: ({ args, result, toolCallId }) => {
+    const prompt = args && typeof args === 'object' ? (args as AskUserArgs).prompt : undefined;
+    const answer =
+      result && typeof result === 'object' && typeof (result as any).answer === 'string'
+        ? (result as any).answer
+        : undefined;
+    return (
+      <InlineAskUser
+        humanInputService={humanInputService}
+        toolCallId={toolCallId}
+        prompt={prompt}
+        answer={answer}
+      />
+    );
+  },
+  handler: async (args, toolCallId) => {
+    // The pending question is keyed by the tool call id, and `render` above locates it by that
+    // exact id. Registering under any substitute id would leave the card unrenderable and this
+    // promise pending until teardown, so a missing id fails instead of asking unanswerably.
+    // (Message avoids "not found"/"not registered" — ToolExecutor treats those as "not a
+    // registered action" and reroutes the call to the agent-tool path.)
+    if (!toolCallId) {
+      throw new Error('ask_user requires a toolCallId to correlate the answer with its card');
+    }
+
+    // Normalize options: accept bare strings or {label, value}.
+    const options: AskUserOption[] | undefined = args.options?.map((opt) =>
+      typeof opt === 'string' ? { label: opt, value: opt } : opt
+    );
+
+    const response = await humanInputService.ask({
+      toolCallId,
+      prompt: args.prompt,
+      inputType: args.inputType,
+      options,
+      allowFreeText: args.allowFreeText,
+    });
+
+    // Torn down (conversation reset) — cancel so the executor skips dispatch.
+    if (response.cancelled) {
+      return { cancelled: true };
+    }
+    // Echo `question` so the result self-anchors to which question it answers,
+    // instead of the model matching a bare answer back to the toolUse by position.
+    if (response.declined) {
+      return { answered: false, declined: true, question: args.prompt };
+    }
+    return { answered: true, question: args.prompt, answer: response.answer };
+  },
+});

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -2250,4 +2250,167 @@ describe('ChatEventHandler', () => {
       ]);
     });
   });
+
+  describe('restore of a conversation ending in an unfinished frontend tool', () => {
+    // A restored snapshot can still carry the tool call that the replayed TOOL_CALL_START
+    // re-attaches. Each toolCalls entry renders its own card, so the message must never end up
+    // holding the same tool call twice — an unanswered ask_user would show as two cards.
+    it('does not duplicate a tool call the snapshot already carries', async () => {
+      const toolCallId = 'tooluse_ask';
+      const toolCall = {
+        id: toolCallId,
+        type: 'function',
+        function: { name: 'ask_user', arguments: '{"prompt":"What?"}' },
+      };
+
+      await chatEventHandler.handleEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [
+          { id: '0', role: 'user', content: 'ask me some question' },
+          { id: '1', role: 'assistant', toolCalls: [toolCall] },
+        ],
+      } as any);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'ask_user',
+        parentMessageId: '1',
+      } as any);
+
+      const assistant = timeline.find((m) => m.id === '1') as AssistantMessage;
+      expect(assistant.toolCalls?.filter((tc) => tc.id === toolCallId)).toHaveLength(1);
+      expect(timeline.filter((m) => m.id === '1')).toHaveLength(1);
+    });
+
+    // Restore shape: the snapshot carries the tool call and replay re-announces it via a synthetic
+    // TOOL_CALL_START. It must land on the existing message even when the parent lookup misses.
+    it('keeps one message when the re-announced tool call cannot resolve its parent', async () => {
+      const toolCallId = 'tooluse_iAFNqCSCNIniFcsnxrbbGf';
+      const toolCall = {
+        id: toolCallId,
+        type: 'function',
+        function: { name: 'ask_user', arguments: '{"prompt":"What?"}' },
+      };
+
+      // Snapshot as the server sends it: assistant already carries the tool call.
+      await chatEventHandler.handleEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [
+          { id: '0', role: 'user', content: 'ask me something' },
+          { id: '1', role: 'assistant', toolCalls: [toolCall] },
+        ],
+      } as any);
+
+      // Timeline read lags a render behind mid-replay, so parent/dedupe lookups via it miss.
+      mockGetTimeline.mockReturnValue([]);
+
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'ask_user',
+        parentMessageId: '1',
+      } as any);
+
+      const assistants = timeline.filter((m) => m.role === 'assistant');
+      expect(assistants).toHaveLength(1);
+      expect(
+        (assistants[0] as AssistantMessage).toolCalls?.filter((tc) => tc.id === toolCallId)
+      ).toHaveLength(1);
+    });
+
+    // A repeated TOOL_CALL_START for one tool call still leaves a single entry on the message.
+    it('does not duplicate when the same TOOL_CALL_START is replayed twice', async () => {
+      const toolCallId = 'tooluse_ask_twice';
+
+      await chatEventHandler.handleEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [
+          { id: '0', role: 'user', content: 'ask me some question' },
+          { id: '1', role: 'assistant', toolCalls: [] },
+        ],
+      } as any);
+
+      for (let i = 0; i < 2; i++) {
+        await chatEventHandler.handleEvent({
+          type: EventType.TOOL_CALL_START,
+          toolCallId,
+          toolCallName: 'ask_user',
+          parentMessageId: '1',
+        } as any);
+        await chatEventHandler.handleEvent({
+          type: EventType.TOOL_CALL_ARGS,
+          toolCallId,
+          delta: '{"prompt":"What?"}',
+        } as any);
+      }
+
+      const assistant = timeline.find((m) => m.id === '1') as AssistantMessage;
+      expect(assistant.toolCalls?.filter((tc) => tc.id === toolCallId)).toHaveLength(1);
+      expect(timeline.filter((m) => m.id === '1')).toHaveLength(1);
+    });
+
+    // The caller keeps the restore event array for further restores, so replay leaves it untouched.
+    it('does not mutate the snapshot event messages when re-attaching', async () => {
+      const toolCallId = 'tooluse_ask2';
+      const snapshotAssistant: any = { id: '1', role: 'assistant', toolCalls: [] };
+      const event: any = {
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [{ id: '0', role: 'user', content: 'q' }, snapshotAssistant],
+      };
+
+      await chatEventHandler.handleEvent(event);
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName: 'ask_user',
+        parentMessageId: '1',
+      } as any);
+
+      expect(snapshotAssistant.toolCalls).toHaveLength(0);
+      const assistant = timeline.find((m) => m.id === '1') as AssistantMessage;
+      expect(assistant.toolCalls?.map((tc) => tc.id)).toEqual([toolCallId]);
+    });
+
+    // With a stale getTimeline() mid-replay, the re-announced tool call still re-attaches to the
+    // existing assistant message (resolved via activeAssistantMessages) rather than spawning a
+    // second message with the same id.
+    it('re-attaches the re-injected tool call to the snapshot message even when getTimeline is stale', async () => {
+      // 1. Replay the (patched) snapshot: assistant "1" has its ask_user stripped.
+      await chatEventHandler.handleEvent({
+        type: EventType.MESSAGES_SNAPSHOT,
+        messages: [
+          { id: '0', role: 'user', content: 'ask me some question' },
+          { id: '1', role: 'assistant', content: 'let me ask', toolCalls: [] },
+        ],
+      } as any);
+
+      expect(timeline).toHaveLength(2);
+
+      // 2. Simulate React not having flushed the snapshot into timelineRef yet:
+      // getTimeline() returns a stale (empty) view while the synthetic tool-call
+      // events replay. onTimelineUpdate still applies to the real timeline.
+      mockGetTimeline.mockReturnValue([]);
+
+      // 3. The re-injected unfinished ask_user, parented to message "1".
+      await chatEventHandler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId: 'tooluse_ask',
+        toolCallName: 'ask_user',
+        parentMessageId: '1',
+      } as any);
+
+      // Exactly one message with id "1" — no duplicate turn.
+      const idOnes = timeline.filter((m) => m.id === '1');
+      expect(idOnes).toHaveLength(1);
+
+      // The original assistant text is preserved, and the tool call is attached to it.
+      const assistant = idOnes[0] as AssistantMessage;
+      expect(assistant.content).toBe('let me ask');
+      expect(assistant.toolCalls?.map((tc) => tc.id)).toEqual(['tooluse_ask']);
+
+      // The whole timeline is still just [user, assistant].
+      expect(timeline).toHaveLength(2);
+    });
+  });
 });

--- a/src/plugins/chat/public/services/chat_event_handler.test.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.test.ts
@@ -273,9 +273,20 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
-      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('registered_action', {
-        param: 'value',
-      });
+      // Frontend tool results are now buffered and dispatched when the batch is
+      // sealed on RUN_FINISHED, so drive that event to trigger the dispatch.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      // The batch flush dispatches asynchronously; drain the microtask queue so
+      // the tool result message lands in the timeline before asserting.
+      await new Promise((r) => setImmediate(r));
+
+      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith(
+        'registered_action',
+        {
+          param: 'value',
+        },
+        toolCallId
+      );
 
       expect(mockAssistantActionService.updateToolCallState).toHaveBeenCalledWith(toolCallId, {
         status: 'complete',
@@ -596,6 +607,10 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
+      // Rejection results are now buffered and dispatched when the batch is
+      // sealed on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+
       // Should update state to failed
       expect(mockAssistantActionService.updateToolCallState).toHaveBeenCalledWith(toolCallId, {
         status: 'failed',
@@ -650,6 +665,10 @@ describe('ChatEventHandler', () => {
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
+
+      // Frontend tool results are now buffered and dispatched when the batch is
+      // sealed on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
 
       // Should update state to complete
       expect(mockAssistantActionService.updateToolCallState).toHaveBeenCalledWith(toolCallId, {
@@ -729,6 +748,10 @@ describe('ChatEventHandler', () => {
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
+
+      // The error result is buffered and dispatched when the batch is sealed
+      // on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
 
       // The payload sent to the assistant starts with the execution error
       // prefix so a snapshot reload can render the tool row as an error
@@ -845,6 +868,12 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
+      // Dispatch is deferred to the batch flush on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      // The batch flush dispatches asynchronously; drain the microtask queue so
+      // the observable is subscribed and the teardown captured.
+      await new Promise((r) => setImmediate(r));
+
       // Clear previous calls to focus on the teardown
       mockOnStartResponse.mockClear();
 
@@ -905,6 +934,12 @@ describe('ChatEventHandler', () => {
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
+
+      // Dispatch is deferred to the batch flush on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      // The batch flush dispatches asynchronously; drain the microtask queue so
+      // the observable is subscribed and the error/teardown callbacks captured.
+      await new Promise((r) => setImmediate(r));
 
       // Clear previous calls to focus on the error callback
       mockOnStartResponse.mockClear();
@@ -1143,6 +1178,13 @@ describe('ChatEventHandler', () => {
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
+
+      // Dispatch (and therefore the subscribe) is deferred to the batch flush
+      // on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      // The batch flush dispatches asynchronously; drain the microtask queue so
+      // the observable is subscribed before asserting.
+      await new Promise((r) => setImmediate(r));
 
       // Verify streaming was started
       expect(mockObservable.subscribe).toHaveBeenCalled();
@@ -1586,6 +1628,11 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
+      // Dispatch is deferred to the batch flush on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      // The batch flush dispatches asynchronously; drain the microtask queue.
+      await new Promise((r) => setImmediate(r));
+
       const toolMessagesInTimeline = timeline.filter((m) => m.role === 'tool');
       expect(toolMessagesInTimeline).not.toContainEqual(constructedToolMessage);
 
@@ -1678,6 +1725,11 @@ describe('ChatEventHandler', () => {
         toolCallId,
       } as ToolCallEndEvent);
 
+      // Dispatch is deferred to the batch flush on RUN_FINISHED.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      // The batch flush dispatches asynchronously; drain the microtask queue.
+      await new Promise((r) => setImmediate(r));
+
       expect(timeline).toContainEqual(constructedToolMessage);
       const skipInfoMessage = timeline.find((m) => (m as any).id?.startsWith('tool-skipped-'));
       expect(skipInfoMessage).toBeUndefined();
@@ -1704,6 +1756,14 @@ describe('ChatEventHandler', () => {
         type: EventType.TOOL_CALL_END,
         toolCallId,
       } as ToolCallEndEvent);
+
+      // Frontend tool results are buffered and only dispatched once the batch
+      // is sealed on RUN_FINISHED, so seal it to trigger the dispatch.
+      await handler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+
+      // The batch flush dispatches via a fire-and-forget async call, so let the
+      // microtask queue drain until the dispatch's awaits settle.
+      await new Promise((r) => setImmediate(r));
     };
 
     beforeEach(() => {
@@ -1890,6 +1950,304 @@ describe('ChatEventHandler', () => {
       expect(noThreadMessage.toolCallId).toBe(toolCallId);
       // No resend affordance — retrying without a thread would hit the same path.
       expect(noThreadMessage.canResend).toBeUndefined();
+    });
+  });
+
+  describe('parallel frontend tool calls (batching)', () => {
+    // A minimal observable stub matching what the handler subscribes to: its
+    // subscribe returns a subscription with unsubscribe + add.
+    const makeMockObservable = () => ({
+      subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn(), add: jest.fn() }),
+    });
+
+    // Drain the microtask queue so the fire-and-forget batch flush (and the
+    // awaits inside sendToolResult(s)ToAssistant) settle before assertions.
+    const flushMicrotasks = () => new Promise((r) => setImmediate(r));
+
+    // Drive a single frontend tool through START -> ARGS -> END. The END is
+    // awaited by default; pass awaitEnd=false to fire it without awaiting (used
+    // to keep a slow tool in flight while later events are delivered).
+    const driveTool = async (
+      handler: ChatEventHandler,
+      toolCallId: string,
+      toolCallName: string,
+      { awaitEnd = true }: { awaitEnd?: boolean } = {}
+    ) => {
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_START,
+        toolCallId,
+        toolCallName,
+      } as ToolCallStartEvent);
+
+      await handler.handleEvent({
+        type: EventType.TOOL_CALL_ARGS,
+        toolCallId,
+        delta: '{}',
+      } as ToolCallArgsEvent);
+
+      const endPromise = handler.handleEvent({
+        type: EventType.TOOL_CALL_END,
+        toolCallId,
+      } as ToolCallEndEvent);
+
+      if (awaitEnd) await endPromise;
+      return endPromise;
+    };
+
+    beforeEach(() => {
+      // Both dispatch APIs are stubbed so either path can be asserted on. The
+      // singular path is used for a batch of one; the plural path for 2+.
+      mockChatService.sendToolResult = jest.fn().mockResolvedValue({
+        observable: makeMockObservable(),
+        toolMessage: { id: 'tm', role: 'tool', content: '{}', toolCallId: 'x' } as ToolMessage,
+      });
+      (mockChatService as any).sendToolResults = jest.fn().mockResolvedValue({
+        observable: makeMockObservable(),
+        toolMessages: [] as ToolMessage[],
+      });
+    });
+
+    it('dispatches two parallel frontend tools as a single batched send on RUN_FINISHED', async () => {
+      const resultA = { value: 'A' };
+      const resultB = { value: 'B' };
+      mockAssistantActionService.executeAction = jest
+        .fn()
+        .mockResolvedValueOnce(resultA)
+        .mockResolvedValueOnce(resultB);
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      await driveTool(chatEventHandler, 'tool-A', 'tool_a');
+      await driveTool(chatEventHandler, 'tool-B', 'tool_b');
+
+      // Nothing dispatched until the batch is sealed.
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalled();
+      expect((mockChatService as any).sendToolResults).not.toHaveBeenCalled();
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+
+      // The two results go out in one batched (plural) run; the singular path
+      // is untouched.
+      expect((mockChatService as any).sendToolResults).toHaveBeenCalledTimes(1);
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalled();
+
+      const items = (mockChatService as any).sendToolResults.mock.calls[0][0];
+      expect(items).toEqual([
+        { toolCallId: 'tool-A', result: resultA },
+        { toolCallId: 'tool-B', result: resultB },
+      ]);
+    });
+
+    it('preserves toolUse order (A before B) in the batched items array', async () => {
+      mockAssistantActionService.executeAction = jest
+        .fn()
+        .mockResolvedValueOnce({ value: 'A' })
+        .mockResolvedValueOnce({ value: 'B' });
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      await driveTool(chatEventHandler, 'tool-A', 'tool_a');
+      await driveTool(chatEventHandler, 'tool-B', 'tool_b');
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+
+      const items = (mockChatService as any).sendToolResults.mock.calls[0][0];
+      expect(items.map((i: any) => i.toolCallId)).toEqual(['tool-A', 'tool-B']);
+    });
+
+    it('routes a batch of one through the singular sendToolResult path', async () => {
+      const resultA = { value: 'A' };
+      mockAssistantActionService.executeAction = jest.fn().mockResolvedValue(resultA);
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      await driveTool(chatEventHandler, 'tool-solo', 'tool_solo');
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+
+      // Single-frontend-tool case collapses to the unchanged singular path.
+      expect(mockChatService.sendToolResult).toHaveBeenCalledTimes(1);
+      expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
+        'tool-solo',
+        resultA,
+        expect.any(Array),
+        expect.any(AbortSignal)
+      );
+      expect((mockChatService as any).sendToolResults).not.toHaveBeenCalled();
+    });
+
+    it('dispatches only the frontend tool when mixed with a backend (waitingForAgentResponse) tool', async () => {
+      const resultA = { value: 'A' };
+      // Frontend tool resolves; backend tool is not a registered action, so the
+      // executor treats it as an agent tool (waitingForAgentResponse).
+      mockAssistantActionService.hasAction = jest.fn((name: string) => name !== 'backend_tool');
+      mockAssistantActionService.executeAction = jest.fn((name: string) =>
+        name === 'backend_tool'
+          ? Promise.reject(new Error('Action not found'))
+          : Promise.resolve(resultA)
+      );
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      await driveTool(chatEventHandler, 'tool-A', 'frontend_tool');
+      await driveTool(chatEventHandler, 'tool-B', 'backend_tool');
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+
+      // The backend tool is removed from the batch, which collapses to one
+      // member -> the singular path dispatches only the frontend tool.
+      expect(mockChatService.sendToolResult).toHaveBeenCalledTimes(1);
+      expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
+        'tool-A',
+        resultA,
+        expect.any(Array),
+        expect.any(AbortSignal)
+      );
+      // The backend tool never goes through either dispatch path — it waits for
+      // its TOOL_CALL_RESULT event instead.
+      expect((mockChatService as any).sendToolResults).not.toHaveBeenCalled();
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalledWith(
+        'tool-B',
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('drops the pending entry for a backend tool once it hands off to the agent', async () => {
+      // Every terminal branch releases its pendingToolCalls entry; the backend-tool path is not
+      // exempt, since TOOL_CALL_RESULT does not read that map.
+      mockAssistantActionService.hasAction = jest.fn().mockReturnValue(false);
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+      await driveTool(chatEventHandler, 'tool-B', 'backend_tool');
+      await flushMicrotasks();
+
+      expect((chatEventHandler as any).pendingToolCalls.has('tool-B')).toBe(false);
+    });
+
+    it('flushes a sealed batch when a member leaves it after RUN_FINISHED', async () => {
+      // A registered action can be unregistered while it runs (its component unmounts), so
+      // executeAction rejects with "not found" and the call falls back to the agent-tool path.
+      // Removing that member is what completes the batch, so this branch must re-check the flush.
+      const resultA = { value: 'A' };
+      let rejectB: (e: Error) => void = () => {};
+      const bPending = new Promise((_resolve, reject) => {
+        rejectB = reject;
+      });
+      mockAssistantActionService.hasAction = jest.fn().mockReturnValue(true);
+      mockAssistantActionService.executeAction = jest.fn((name: string) =>
+        name === 'tool_b' ? (bPending as Promise<any>) : Promise.resolve(resultA)
+      );
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      await driveTool(chatEventHandler, 'tool-A', 'tool_a');
+      // B stays in flight: its END is not awaited and its action promise is still pending.
+      driveTool(chatEventHandler, 'tool-B', 'tool_b', { awaitEnd: false });
+      await flushMicrotasks();
+
+      // Seal while B is unresolved — the batch cannot flush yet.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalled();
+
+      // B's action turns out to be gone, so it drops out, leaving {A} fully resolved.
+      rejectB(new Error('Action not found'));
+      await flushMicrotasks();
+
+      expect(mockChatService.sendToolResult).toHaveBeenCalledTimes(1);
+      expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
+        'tool-A',
+        resultA,
+        expect.any(Array),
+        expect.any(AbortSignal)
+      );
+    });
+
+    it('drops a cancelled tool from the batch and dispatches only the survivor', async () => {
+      const resultA = { value: 'A' };
+      // Tool B resolves as cancelled; the executor surfaces { cancelled: true }
+      // and the handler drops it from the batch.
+      mockAssistantActionService.executeAction = jest
+        .fn()
+        .mockResolvedValueOnce(resultA)
+        .mockResolvedValueOnce({ cancelled: true });
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      await driveTool(chatEventHandler, 'tool-A', 'tool_a');
+      await driveTool(chatEventHandler, 'tool-B', 'tool_b');
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+
+      // Batch collapses to just A (singular path); the cancelled tool is absent.
+      expect(mockChatService.sendToolResult).toHaveBeenCalledTimes(1);
+      expect(mockChatService.sendToolResult).toHaveBeenCalledWith(
+        'tool-A',
+        resultA,
+        expect.any(Array),
+        expect.any(AbortSignal)
+      );
+      expect((mockChatService as any).sendToolResults).not.toHaveBeenCalled();
+      // The cancelled tool's id never appears in any dispatched items.
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalledWith(
+        'tool-B',
+        expect.anything(),
+        expect.anything(),
+        expect.anything()
+      );
+    });
+
+    it('waits for a slow tool before flushing, then dispatches the whole batch', async () => {
+      const resultA = { value: 'A' };
+      const resultB = { value: 'B' };
+
+      // B stays pending until we resolve it, simulating a slow frontend tool.
+      let resolveB: (v: any) => void = () => {};
+      const bPromise = new Promise((resolve) => {
+        resolveB = resolve;
+      });
+
+      mockAssistantActionService.executeAction = jest
+        .fn()
+        .mockResolvedValueOnce(resultA)
+        .mockReturnValueOnce(bPromise);
+
+      await chatEventHandler.handleEvent({ type: EventType.RUN_STARTED } as any);
+
+      // A resolves fully.
+      await driveTool(chatEventHandler, 'tool-A', 'tool_a');
+
+      // B is fired but left in flight (its execution promise is unresolved).
+      // The synchronous prefix of handleToolCallEnd still adds B to the batch.
+      driveTool(chatEventHandler, 'tool-B', 'tool_b', { awaitEnd: false });
+      await flushMicrotasks();
+
+      // Seal the batch while B is still pending — must NOT dispatch yet.
+      await chatEventHandler.handleEvent({ type: EventType.RUN_FINISHED } as any);
+      await flushMicrotasks();
+
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalled();
+      expect((mockChatService as any).sendToolResults).not.toHaveBeenCalled();
+
+      // Now B resolves; the completed batch dispatches with both members.
+      resolveB(resultB);
+      await flushMicrotasks();
+
+      expect((mockChatService as any).sendToolResults).toHaveBeenCalledTimes(1);
+      expect(mockChatService.sendToolResult).not.toHaveBeenCalled();
+
+      const items = (mockChatService as any).sendToolResults.mock.calls[0][0];
+      expect(items).toEqual([
+        { toolCallId: 'tool-A', result: resultA },
+        { toolCallId: 'tool-B', result: resultB },
+      ]);
     });
   });
 });

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -71,6 +71,14 @@ export class ChatEventHandler {
   // agent fetch is cancelled.
   private toolResultAbortController: AbortController | null = null;
 
+  // Parallel frontend tool calls in one turn are buffered and dispatched
+  // together once complete. `expected`
+  // holds ids that resolve locally, `results` their outcomes; `sealed` flips on
+  // RUN_FINISHED, after which a full `results` set triggers dispatch.
+  private batchExpected = new Set<string>();
+  private batchResults = new Map<string, any>();
+  private batchSealed = false;
+
   // Telemetry tracking
   private interactionStartTime: number | null = null;
   private runErrorOccurred = false;
@@ -147,6 +155,11 @@ export class ChatEventHandler {
   private handleRunStarted(event: any): void {
     this.onStreamingStateChange(true);
 
+    // Fresh run, fresh batch.
+    this.batchExpected.clear();
+    this.batchResults.clear();
+    this.batchSealed = false;
+
     // Start timing for telemetry
     this.interactionStartTime = Date.now();
     this.runErrorOccurred = false;
@@ -157,6 +170,12 @@ export class ChatEventHandler {
    */
   private handleRunFinished(event: any): void {
     this.onStreamingStateChange(false);
+
+    // Seal the batch — all tool calls for this turn have been emitted. If every
+    // member already resolved, this triggers the dispatch.
+    this.batchSealed = true;
+    this.maybeFlushBatch();
+
     // Clear any remaining active messages (cleanup)
     this.activeAssistantMessages.clear();
     // Reset the connection state to allow new chats
@@ -392,6 +411,9 @@ export class ChatEventHandler {
       return;
     }
 
+    // Provisionally a batch member; removed below if it's a backend tool.
+    this.batchExpected.add(toolCallId);
+
     try {
       const isAgentTool = !this.assistantActionService.hasAction(toolCall.function.name);
 
@@ -418,55 +440,54 @@ export class ChatEventHandler {
             this.chatService.getCurrentTimeRange()
           );
 
-      // Check if tool execution was cancelled (e.g., due to cleanup)
+      // Cancelled (teardown): no result, drop from batch, not reported.
       if (result.cancelled) {
+        this.batchExpected.delete(toolCallId);
         this.pendingToolCalls.delete(toolCallId);
         this.toolCallStartTimes.delete(toolCallId);
+        this.assistantActionService.updateToolCallState(toolCallId, { status: 'failed' });
+        this.maybeFlushBatch();
         return;
       }
 
       if (result.userRejected) {
-        // User rejected the tool execution. Hold off on marking 'failed'
-        // until the rejection has actually been delivered to the assistant,
-        // so the tool row keeps its running indicator during the send
-        // rather than showing a failed state while still doing work.
-        await this.sendToolResultToAssistant(toolCallId, result);
+        // Buffer the rejection as this member's result.
+        this.batchResults.set(toolCallId, result);
         this.assistantActionService.updateToolCallState(toolCallId, {
           status: 'failed',
         });
-
         // Record rejected telemetry
         this.recordToolExecuted(toolCallId, toolCall.function.name, 'rejected', 'local');
 
         // Clean up pending tool call
         this.pendingToolCalls.delete(toolCallId);
+        this.maybeFlushBatch();
         return;
       }
 
       if (result.waitingForAgentResponse) {
-        // Agent will handle this tool and send results back via events
+        // Backend tool: completes in the original run via TOOL_CALL_RESULT, so
+        // it's not a batch member.
+        this.batchExpected.delete(toolCallId);
         this.toolExecutor.markToolPending(toolCallId, {
           id: toolCallId,
           name: toolCall.function.name,
           args: toolCall.function.arguments,
         });
-        // Don't send result back immediately, wait for TOOL_CALL_RESULT event
+        // Don't send result back immediately, wait for TOOL_CALL_RESULT event — which does not read
+        // pendingToolCalls, so this entry is done with and dropped like on every other terminal
+        // branch.
+        this.pendingToolCalls.delete(toolCallId);
+        // Dropping this member can be what makes an already-sealed batch complete, so the flush
+        // has to be re-checked here as it is on every other terminal branch.
+        this.maybeFlushBatch();
       } else {
-        // Tool was executed locally. Hold off on marking 'complete' until
-        // the result has actually been delivered to the assistant and the
-        // next streaming turn has started. Otherwise there would be a
-        // confusing window where the tool row shows a checkmark while the
-        // UI is still waiting on the network round-trip with no visible
-        // activity. If the send itself fails, `sendToolResultToAssistant`
-        // appends a system message to the timeline so the user can see the
-        // conversation is out of sync — the tool call itself still
-        // completed locally, so mark it 'complete'.
-        await this.sendToolResultToAssistant(toolCallId, result.data);
+        // Executed locally (includes `declined`): buffer for batch dispatch.
+        this.batchResults.set(toolCallId, result.data);
         this.assistantActionService.updateToolCallState(toolCallId, {
           status: 'complete',
           result: result.data,
         });
-
         // Record tool execution telemetry
         this.recordToolExecuted(
           toolCallId,
@@ -474,41 +495,61 @@ export class ChatEventHandler {
           result.success ? 'success' : 'failure',
           'local'
         );
+        this.pendingToolCalls.delete(toolCallId);
+        this.maybeFlushBatch();
       }
     } catch (error: any) {
       // eslint-disable-next-line no-console
       console.error(`Error executing tool ${toolCall.function.name}:`, error);
 
-      // Send error back to assistant. Prefix the content with
-      // `TOOL_EXECUTION_ERROR_PREFIX` so a snapshot reload can render the
-      // tool row as an error via `getToolStatus` — `chatService.sendToolResult`
-      // passes this string straight into the ToolMessage content (which is
-      // what is persisted to agentic memory), so the UI can detect the
-      // prefix without needing a separate local-only ToolMessage that
-      // would diverge from the saved conversation. Natural-language prose
-      // also keeps the payload readable for the LLM on the next turn.
-      //
-      // Hold off on marking 'failed' until the error has actually been
-      // delivered, so the tool row keeps its running indicator during the
-      // send rather than flipping to a failed state while the UI is still
-      // doing work. `sendToolResultToAssistant` owns the timeline append on
-      // success, skip, and send failure.
-      await this.sendToolResultToAssistant(
-        toolCallId,
-        `${TOOL_EXECUTION_ERROR_PREFIX}${error.message}`
-      );
+      // Buffer the error as this member's result. The prefix lets a snapshot
+      // reload render the tool row as an error via `getToolStatus`.
+      this.batchResults.set(toolCallId, `${TOOL_EXECUTION_ERROR_PREFIX}${error.message}`);
 
       // Update state to failed
       this.assistantActionService.updateToolCallState(toolCallId, {
         status: 'failed',
         error: error instanceof Error ? error : new Error(error.message),
       });
-
       // Record tool execution failure telemetry
       this.recordToolExecuted(toolCallId, toolCall.function.name, 'error', 'local');
     } finally {
       // Clean up pending tool call
       this.pendingToolCalls.delete(toolCallId);
+      // Dropping this member can be what completes an already-sealed batch, so the
+      // flush is re-checked here as it is on every terminal branch above. Idempotent:
+      // `maybeFlushBatch` consumes the batch before dispatching, so the explicit
+      // calls above make this a no-op.
+      this.maybeFlushBatch();
+    }
+  }
+
+  /**
+   * Dispatch the buffered batch once it's sealed and every member has a result;
+   * a no-op until then. A batch of one uses the unchanged single-result path,
+   * so only genuine parallel batches (2+) take the multi-result run.
+   */
+  private maybeFlushBatch(): void {
+    if (!this.batchSealed) return;
+    if (this.batchExpected.size === 0) return;
+    for (const id of this.batchExpected) {
+      if (!this.batchResults.has(id)) return;
+    }
+
+    // Order preserved by insertion order of `batchExpected`.
+    const items = Array.from(this.batchExpected).map((toolCallId) => ({
+      toolCallId,
+      result: this.batchResults.get(toolCallId),
+    }));
+
+    // Consume before dispatching so a late event can't re-flush.
+    this.batchExpected.clear();
+    this.batchResults.clear();
+
+    if (items.length === 1) {
+      void this.sendToolResultToAssistant(items[0].toolCallId, items[0].result);
+    } else {
+      void this.sendToolResultsToAssistant(items);
     }
   }
 
@@ -617,6 +658,18 @@ export class ChatEventHandler {
    */
   private handleRunError(event: any): void {
     this.runErrorOccurred = true;
+
+    // Run failed — mark any pending batch members as failed so their tool-call
+    // state is cleaned up (prevents a stale 'executing' from locking the composer).
+    for (const id of this.batchExpected) {
+      if (!this.batchResults.has(id)) {
+        this.assistantActionService.updateToolCallState(id, { status: 'failed' });
+      }
+    }
+    this.batchExpected.clear();
+    this.batchResults.clear();
+    this.batchSealed = false;
+
     const errorMessage: SystemMessage = {
       id: `error-${Date.now()}`,
       role: 'system',
@@ -912,6 +965,138 @@ export class ChatEventHandler {
     this.toolResultSubscription = subscription;
   }
 
+  /**
+   * Batched sibling of {@link sendToolResultToAssistant}: sends a whole batch of
+   * frontend tool results in one continuation run. Skip/error system messages
+   * are keyed off the first toolCallId in the batch.
+   */
+  async sendToolResultsToAssistant(
+    items: Array<{ toolCallId: string; result: any }>
+  ): Promise<void> {
+    if (items.length === 0) return;
+    const anchorId = items[0].toolCallId;
+
+    // Abort any in-flight tool result send so we don't leak controllers or
+    // race two dispatches.
+    if (this.toolResultAbortController) {
+      this.toolResultAbortController.abort();
+    }
+    const abortController = new AbortController();
+    this.toolResultAbortController = abortController;
+
+    const releaseController = () => {
+      if (this.toolResultAbortController === abortController) {
+        this.toolResultAbortController = null;
+      }
+    };
+
+    let observable: Observable<ChatEvent>;
+    let toolMessages: ToolMessage[];
+    let skipped:
+      | { reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted' }
+      | undefined;
+
+    try {
+      const messages = this.getTimeline();
+      ({ observable, toolMessages, skipped } = await this.chatService.sendToolResults(
+        items,
+        messages,
+        abortController.signal
+      ));
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to send tool results:', error);
+      releaseController();
+      const failureMessage: SystemMessage = {
+        id: `tool-send-failed-${anchorId}-${Date.now()}`,
+        role: 'system',
+        content: i18n.translate('chat.toolResult.sendFailed', {
+          defaultMessage:
+            'Failed to send tool result to the assistant. The conversation may be out of sync.',
+        }),
+      };
+      this.onTimelineUpdate((prev) => [...prev, failureMessage]);
+      return;
+    }
+
+    if (skipped) {
+      if (skipped.reason === 'aborted') {
+        releaseController();
+        return;
+      }
+
+      if (skipped.reason === 'sync_timeout') {
+        // Store the batch so the user can resend it as a unit.
+        const timeoutMessage: SystemMessage = {
+          id: `tool-sync-timeout-${anchorId}-${Date.now()}`,
+          role: 'system',
+          content: i18n.translate('chat.toolResult.syncTimeout', {
+            defaultMessage:
+              'We could not confirm the tool call was synced before sending the result. You can resend the tool result to try again.',
+          }),
+          toolCallId: anchorId,
+          canResend: true,
+          toolResult: items,
+        };
+        this.onTimelineUpdate((prev) => [...prev, timeoutMessage]);
+        releaseController();
+        return;
+      }
+
+      if (skipped.reason === 'no_thread_id') {
+        const noThreadMessage: SystemMessage = {
+          id: `tool-no-thread-${anchorId}-${Date.now()}`,
+          role: 'system',
+          content: i18n.translate('chat.toolResult.noThreadId', {
+            defaultMessage:
+              'Tool result could not be sent because the conversation thread is missing. Start a new chat and try again.',
+          }),
+          toolCallId: anchorId,
+        };
+        this.onTimelineUpdate((prev) => [...prev, noThreadMessage]);
+        releaseController();
+        return;
+      }
+
+      // result_already_exists: another window already persisted results.
+      const infoMessage: SystemMessage = {
+        id: `tool-skipped-${anchorId}-${Date.now()}`,
+        role: 'system',
+        content: i18n.translate('chat.toolResult.alreadySubmitted', {
+          defaultMessage: 'This tool result was already submitted from another window.',
+        }),
+      };
+      this.onTimelineUpdate((prev) => [...prev, infoMessage]);
+      releaseController();
+      return;
+    }
+
+    // Append every tool message so each parallel tool call shows its result.
+    this.onTimelineUpdate((prev) => [...prev, ...toolMessages]);
+
+    this.onStreamingStateChange(true);
+
+    const subscription = observable.subscribe({
+      next: (event: ChatEvent) => {
+        this.handleEvent(event);
+      },
+      error: (error: Error) => {
+        if (error?.name !== 'AbortError') {
+          // eslint-disable-next-line no-console
+          console.error('Tool result response error:', error);
+        }
+      },
+    });
+    subscription.add(() => {
+      this.onStreamingStateChange(false);
+      this.onStartResponse(false);
+      this.toolResultSubscription = null;
+      releaseController();
+    });
+
+    this.toolResultSubscription = subscription;
+  }
+
   // timelineToMessages method removed - timeline is now directly AG-UI compatible
 
   /**
@@ -944,6 +1129,38 @@ export class ChatEventHandler {
   }
 
   /**
+   * Handle abnormal stream termination (connection drop or error without
+   * RUN_FINISHED). If the batch was already sealed and flushed by a normal
+   * RUN_FINISHED this is a no-op. Otherwise, marks still-pending batch
+   * members as failed so the composer is not permanently locked, and
+   * attempts to flush any completed results.
+   */
+  handleStreamTermination(): void {
+    if (this.batchSealed || this.batchExpected.size === 0) return;
+
+    // Mark any batch members that never resolved as failed
+    for (const id of this.batchExpected) {
+      if (!this.batchResults.has(id)) {
+        this.assistantActionService.updateToolCallState(id, { status: 'failed' });
+      }
+    }
+
+    // Seal the batch so any already-buffered results can flush. Members
+    // whose results are still missing will simply be absent from the
+    // dispatch (they were already marked failed above).
+    this.batchSealed = true;
+    this.maybeFlushBatch();
+
+    // If maybeFlushBatch couldn't flush (some members still pending),
+    // discard the batch entirely — no partial dispatch on stream error.
+    if (this.batchExpected.size > 0) {
+      this.batchExpected.clear();
+      this.batchResults.clear();
+      this.batchSealed = false;
+    }
+  }
+
+  /**
    * Clear all state (useful for resetting)
    */
   clearState(): void {
@@ -952,6 +1169,10 @@ export class ChatEventHandler {
     this.toolCallStartTimes.clear();
     this.toolExecutor.clearAllPendingTools();
     this.lastTextMessageStartId = null;
+    // Drop any half-gathered batch.
+    this.batchExpected.clear();
+    this.batchResults.clear();
+    this.batchSealed = false;
     // Drain the process-wide AssistantActionService tool call states so
     // stale pending/executing entries from a previous run do not bleed
     // into a freshly replayed or newly started conversation and leave

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -6,7 +6,7 @@
 import { Observable, Subscription } from 'rxjs';
 import { i18n } from '@osd/i18n';
 import { EventType } from '../../common/events';
-import { TOOL_EXECUTION_ERROR_PREFIX } from '../../common';
+import { TOOL_EXECUTION_ERROR_PREFIX, HALT_MARKER } from '../../common';
 import type {
   Event as ChatEvent,
   TextMessageStartEvent,
@@ -253,6 +253,37 @@ export class ChatEventHandler {
         });
       }
     }
+  }
+
+  /**
+   * Append the halt marker to the assistant message currently streaming, so a stopped run reads
+   * as "partial answer + stop line" immediately — the same shape the agent server persists on
+   * halt, so a reload matches. No-op if no assistant message is streaming (e.g. stopped before
+   * any text arrived). Matched to the last TEXT_MESSAGE_START, which is the streaming turn.
+   */
+  markStreamingMessageHalted(): void {
+    const messageId = this.lastTextMessageStartId;
+    if (!messageId) {
+      return;
+    }
+    const assistantMessage = this.activeAssistantMessages.get(messageId);
+    if (!assistantMessage) {
+      return;
+    }
+    const existing = (assistantMessage.content as string) || '';
+    if (existing.endsWith(HALT_MARKER)) {
+      return; // already marked
+    }
+    assistantMessage.content = existing + HALT_MARKER;
+    this.onTimelineUpdate((prev) => {
+      const index = prev.findIndex((m) => m.id === messageId);
+      if (index >= 0) {
+        const updated = [...prev];
+        updated[index] = { ...assistantMessage };
+        return updated;
+      }
+      return prev;
+    });
   }
 
   /**

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -1065,8 +1065,7 @@ export class ChatEventHandler {
     let observable: Observable<ChatEvent>;
     let toolMessages: ToolMessage[];
     let skipped:
-      | { reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted' }
-      | undefined;
+      { reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted' } | undefined;
 
     try {
       const messages = this.getTimeline();

--- a/src/plugins/chat/public/services/chat_event_handler.ts
+++ b/src/plugins/chat/public/services/chat_event_handler.ts
@@ -369,6 +369,13 @@ export class ChatEventHandler {
     // Add to pending map for args accumulation
     this.pendingToolCalls.set(toolCallId, toolCall);
 
+    // A tool call belongs to exactly one message: if some message already carries this id, it is
+    // updated there rather than attached again elsewhere.
+    const host = this.findMessageIdWithToolCall(toolCallId);
+    if (host && this.addToolCallToMessage(host, toolCall)) {
+      return;
+    }
+
     // Strategy 1: Use explicitly provided parent message ID
     // This is the most reliable approach when the backend provides it
     if (parentMessageId && this.addToolCallToMessage(parentMessageId, toolCall)) {
@@ -401,6 +408,15 @@ export class ChatEventHandler {
     // Since there's no TEXT_MESSAGE_START event, we need to create a fake assistant message
     // to hold the tool calls so they appear in the correct position in the timeline.
     const newMessageId = parentMessageId ?? `fake-assistant-message-` + new Date().getTime();
+
+    // Message ids are unique in the timeline: when this id already exists, the tool call folds into
+    // that message instead of appending a duplicate.
+    if (this.getTimeline().some((m) => m.id === newMessageId)) {
+      this.addToolCallToMessage(newMessageId, toolCall);
+      this.lastTextMessageStartId = newMessageId;
+      return;
+    }
+
     const newMessage: AssistantMessage = {
       id: newMessageId,
       role: 'assistant',
@@ -749,14 +765,38 @@ export class ChatEventHandler {
   }
 
   /**
-   * Add tool call to a specific message in timeline
+   * Id of the message already carrying `toolCallId`, or null. Checks the active map first, then the
+   * timeline (which may lag a render behind mid-replay).
+   */
+  private findMessageIdWithToolCall(toolCallId: string): string | null {
+    for (const [messageId, message] of this.activeAssistantMessages) {
+      if (message.toolCalls?.some((tc) => tc.id === toolCallId)) return messageId;
+    }
+    const known = this.getTimeline().find(
+      (m) =>
+        m.role === 'assistant' &&
+        (m as AssistantMessage).toolCalls?.some((tc) => tc.id === toolCallId)
+    );
+    return known ? known.id : null;
+  }
+
+  /**
+   * Add tool call to a specific message in timeline. Tool calls are keyed by id — an id already on
+   * the message is replaced, not appended, since each entry renders its own card.
    */
   private addToolCallToMessage(messageId: string, toolCall: ToolCall): boolean {
+    const upsert = (list: ToolCall[]): ToolCall[] => {
+      const at = list.findIndex((tc) => tc.id === toolCall.id);
+      if (at < 0) return [...list, toolCall];
+      const merged = [...list];
+      merged[at] = toolCall;
+      return merged;
+    };
+
     // Check if message is in active messages
     const activeMessage = this.activeAssistantMessages.get(messageId);
     if (activeMessage) {
-      activeMessage.toolCalls = activeMessage.toolCalls || [];
-      activeMessage.toolCalls.push(toolCall);
+      activeMessage.toolCalls = upsert(activeMessage.toolCalls || []);
 
       // Update timeline
       this.onTimelineUpdate((prev) => {
@@ -783,9 +823,10 @@ export class ChatEventHandler {
         const message = updated[messageIndex];
         if (message.role === 'assistant') {
           const assistantMsg = message as AssistantMessage;
-          assistantMsg.toolCalls = assistantMsg.toolCalls || [];
-          assistantMsg.toolCalls.push(toolCall);
-          updated[messageIndex] = { ...assistantMsg };
+          updated[messageIndex] = {
+            ...assistantMsg,
+            toolCalls: upsert(assistantMsg.toolCalls || []),
+          };
         }
       }
 
@@ -1135,10 +1176,31 @@ export class ChatEventHandler {
    * Simply sets the timeline to the saved messages
    */
   private async handleMessagesSnapshot(event: MessagesSnapshotEvent): Promise<void> {
+    // Copies, not the event's own objects: replay re-attaches tool calls by mutating the assistant
+    // message it resolves, and the caller keeps this event array for further restores.
+    const snapshotMessages: Message[] = (event.messages || []).map((message) =>
+      message.role === 'assistant'
+        ? ({
+            ...message,
+            ...((message as AssistantMessage).toolCalls
+              ? { toolCalls: [...(message as AssistantMessage).toolCalls!] }
+              : {}),
+          } as Message)
+        : message
+    );
+
+    // Registered so a replayed TOOL_CALL_START resolves its parent through this map — the timeline
+    // read it would otherwise fall back on may not have flushed yet mid-replay.
+    for (const message of snapshotMessages) {
+      if (message.role === 'assistant') {
+        this.activeAssistantMessages.set(message.id, message as AssistantMessage);
+      }
+    }
+
     // agent backends may serialize a user message's `InputContent[]` to str
     // restore multimodal user messages
     this.onTimelineUpdate((prev) => {
-      const snapshot = event.messages || [];
+      const snapshot = snapshotMessages;
 
       const localArrayContent = new Map<string, unknown>();
       for (const message of prev) {

--- a/src/plugins/chat/public/services/chat_mount_service.test.tsx
+++ b/src/plugins/chat/public/services/chat_mount_service.test.tsx
@@ -8,6 +8,7 @@ import { ChatMountService } from './chat_mount_service';
 import { ChatService } from './chat_service';
 import { SuggestedActionsService } from './suggested_action';
 import { ConfirmationService } from './confirmation_service';
+import { HumanInputService } from './human_input_service';
 import { SIDECAR_DOCKED_MODE } from '../../../../core/public';
 
 // Mock React and react-dom
@@ -29,6 +30,7 @@ describe('ChatMountService', () => {
   let mockChatService: any;
   let mockSuggestedActionsService: SuggestedActionsService;
   let mockConfirmationService: ConfirmationService;
+  let mockHumanInputService: HumanInputService;
   let mockChromeVisible$: BehaviorSubject<boolean>;
   let mockSidecarRef: any;
   let onWindowOpenCallback: Function;
@@ -81,6 +83,9 @@ describe('ChatMountService', () => {
     // Mock confirmation service
     mockConfirmationService = {} as ConfirmationService;
 
+    // Mock human input service
+    mockHumanInputService = {} as HumanInputService;
+
     chatMountService = new ChatMountService();
   });
 
@@ -95,6 +100,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       expect(contract).toEqual({
@@ -110,6 +116,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       expect(mockCore.chat.onWindowOpen).toHaveBeenCalledWith(expect.any(Function));
@@ -122,6 +129,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       expect(mockCore.chrome.getIsVisible$).toHaveBeenCalled();
@@ -135,6 +143,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();
@@ -160,6 +169,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();
@@ -173,6 +183,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();
@@ -189,6 +200,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Trigger the window open callback
@@ -205,6 +217,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();
@@ -219,6 +232,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       expect(() => contract.close()).not.toThrow();
@@ -230,6 +244,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Open the sidecar first
@@ -249,6 +264,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.toggleOpen();
@@ -262,6 +278,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();
@@ -278,6 +295,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Initially chrome is visible (default)
@@ -294,6 +312,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Open the sidecar
@@ -316,6 +335,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Open the sidecar while chrome is visible
@@ -341,6 +361,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Don't open the sidecar
@@ -373,6 +394,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Make chrome visible
@@ -404,6 +426,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       // Make chrome visible (schedules openSidecar)
@@ -427,6 +450,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();
@@ -442,6 +466,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       chatMountService.stop();
@@ -469,6 +494,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       chatMountService.stop();
@@ -483,6 +509,7 @@ describe('ChatMountService', () => {
         chatService: mockChatService,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       expect(() => {
@@ -501,6 +528,7 @@ describe('ChatMountService', () => {
         charts: {} as any,
         suggestedActionsService: mockSuggestedActionsService,
         confirmationService: mockConfirmationService,
+        humanInputService: mockHumanInputService,
       });
 
       contract.open();

--- a/src/plugins/chat/public/services/chat_mount_service.tsx
+++ b/src/plugins/chat/public/services/chat_mount_service.tsx
@@ -15,6 +15,7 @@ import { ContextProviderStart } from '../../../context_provider/public';
 import { ChatService } from '../services/chat_service';
 import { SuggestedActionsService } from '../services/suggested_action';
 import { ConfirmationService } from '../services/confirmation_service';
+import { HumanInputService } from '../services/human_input_service';
 import { ChatMount } from '../components/chat_mount';
 
 export interface ChatMountStartContract {
@@ -39,6 +40,7 @@ export class ChatMountService {
     charts?: any;
     suggestedActionsService: SuggestedActionsService;
     confirmationService: ConfirmationService;
+    humanInputService: HumanInputService;
   }): ChatMountStartContract {
     const { core, chatService } = options;
 

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -601,6 +601,33 @@ describe('ChatService', () => {
       ); // dataSourceId is undefined when no uiSettings provided
     });
 
+    it('should abort the halted main run BEFORE the sync-poll window, not just at dispatch', async () => {
+      // Regression guard for the stuck-session race: the tool-result run is a continuation of
+      // the halted main run and must supersede it up front. If the main run's SSE stayed open
+      // across waitForToolCallSync (up to 15s), both runs would write the same thread and race
+      // on message_id. Assert abort() is called, and that it happens before runAgent dispatch.
+      const callOrder: string[] = [];
+      mockAgent.abort.mockImplementation(() => {
+        callOrder.push('abort');
+      });
+      const mockObservable = new Observable<BaseEvent>();
+      mockAgent.runAgent.mockImplementation(() => {
+        callOrder.push('runAgent');
+        return mockObservable;
+      });
+
+      const toolCallId = 'tool-call-123';
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
+
+      await chatService.sendToolResult(toolCallId, { success: true }, []);
+
+      expect(mockAgent.abort).toHaveBeenCalled();
+      expect(callOrder[0]).toBe('abort');
+      expect(callOrder.indexOf('abort')).toBeLessThan(callOrder.indexOf('runAgent'));
+    });
+
     it('should handle string results directly', async () => {
       const mockObservable = new Observable<BaseEvent>();
       mockAgent.runAgent.mockReturnValue(mockObservable);
@@ -987,6 +1014,11 @@ describe('ChatService', () => {
         expect(response.skipped).toBeUndefined();
         expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
 
+        // sendToolResult aborts the halted main run up front (before the sync window), so one
+        // abort has already happened by now. This test verifies the *signal-driven* abort that
+        // fires after dispatch — assert on the additional call, not an absolute count.
+        const abortsBeforeSignal = mockAgent.abort.mock.calls.length;
+
         const nextSpy = jest.fn();
         const errorSpy = jest.fn();
         const completeSpy = jest.fn();
@@ -999,7 +1031,7 @@ describe('ChatService', () => {
 
         controller.abort();
 
-        expect(mockAgent.abort).toHaveBeenCalledTimes(1);
+        expect(mockAgent.abort.mock.calls.length).toBe(abortsBeforeSignal + 1);
         expect(errorSpy).toHaveBeenCalledTimes(1);
         const emittedError = errorSpy.mock.calls[0][0];
         expect(emittedError).toBeInstanceOf(Error);

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -1810,6 +1810,45 @@ describe('ChatService', () => {
       expect(lastMsg.toolCalls).toHaveLength(0);
     });
 
+    it('injects synthetic tool call events before RUN_FINISHED', async () => {
+      // RUN_FINISHED clears the event handler's active-message map, so a tool call replayed after it
+      // cannot resolve its parent and spawns a second assistant message (losing the restored one's
+      // text). Synthetic events must sit where they do in a live stream: before the run ends.
+      (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(
+        (name: string) => name === 'ask_user'
+      );
+
+      const messages = [
+        { id: '0', role: 'user', content: 'ask me some question' },
+        {
+          id: '1',
+          role: 'assistant',
+          content: "I'd love to chat!",
+          toolCalls: [
+            { id: 'tc-ask', type: 'function', function: { name: 'ask_user', arguments: '{}' } },
+          ],
+        },
+      ];
+
+      chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue([
+        { type: 'RUN_STARTED', timestamp: Date.now() },
+        { type: 'MESSAGES_SNAPSHOT', messages, timestamp: Date.now() },
+        { type: 'RUN_FINISHED', timestamp: Date.now() },
+      ]);
+
+      const result = await chatService.loadConversation(mockThreadId);
+
+      const types = result!.map((e: any) => e.type);
+      expect(types).toEqual([
+        'RUN_STARTED',
+        'MESSAGES_SNAPSHOT',
+        'TOOL_CALL_START',
+        'TOOL_CALL_ARGS',
+        'TOOL_CALL_END',
+        'RUN_FINISHED',
+      ]);
+    });
+
     it('should not inject synthetic events for non-frontend tool calls', async () => {
       const mockHasAction = jest.fn().mockReturnValue(false);
       (AssistantActionService.getInstance().hasAction as jest.Mock).mockImplementation(

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -772,7 +772,6 @@ describe('ChatService', () => {
       });
     });
 
-
     describe('abort signal', () => {
       beforeEach(() => {
         mockCoreChatService.getMemoryProvider = jest
@@ -1120,7 +1119,6 @@ describe('ChatService', () => {
         toolCallId: 'tool-B',
       });
     });
-
 
     it('should include full history and skip the sync wait when includeFullHistory is true', async () => {
       const mockObservable = new Observable<BaseEvent>();

--- a/src/plugins/chat/public/services/chat_service.test.ts
+++ b/src/plugins/chat/public/services/chat_service.test.ts
@@ -601,11 +601,9 @@ describe('ChatService', () => {
       ); // dataSourceId is undefined when no uiSettings provided
     });
 
-    it('should abort the halted main run BEFORE the sync-poll window, not just at dispatch', async () => {
+    it('should abort the halted main run before dispatching the continuation', async () => {
       // Regression guard for the stuck-session race: the tool-result run is a continuation of
-      // the halted main run and must supersede it up front. If the main run's SSE stayed open
-      // across waitForToolCallSync (up to 15s), both runs would write the same thread and race
-      // on message_id. Assert abort() is called, and that it happens before runAgent dispatch.
+      // the halted main run and must supersede it. Assert abort() is called before runAgent.
       const callOrder: string[] = [];
       mockAgent.abort.mockImplementation(() => {
         callOrder.push('abort');
@@ -703,27 +701,26 @@ describe('ChatService', () => {
       });
     });
 
-    it('should wait for tool call sync when includeFullHistory is false', async () => {
+    it('should dispatch directly without a client-side sync wait (server reconciles)', async () => {
+      // The client dispatches the result without polling getConversation; the server reconciles
+      // it via its wire->native map.
       const mockObservable = new Observable<BaseEvent>();
       mockAgent.runAgent.mockReturnValue(mockObservable);
 
-      // Mock memory provider with includeFullHistory = false
       mockCoreChatService.getMemoryProvider = jest
         .fn()
         .mockReturnValue({ includeFullHistory: false });
 
       const toolCallId = 'tool-call-sync-test';
-
-      // Mock getConversation to return MESSAGES_SNAPSHOT with the tool call
-      chatService.conversationHistoryService.getConversation = jest
-        .fn()
-        .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
+      chatService.conversationHistoryService.getConversation = jest.fn();
 
       const response = await chatService.sendToolResult(toolCallId, { success: true }, []);
 
-      // Verify getConversation was called to check for sync
-      expect(chatService.conversationHistoryService.getConversation).toHaveBeenCalled();
+      // No sync poll — getConversation is not called; the result is dispatched straight away.
+      expect(chatService.conversationHistoryService.getConversation).not.toHaveBeenCalled();
+      expect(mockAgent.runAgent).toHaveBeenCalled();
       expect(response.toolMessage.toolCallId).toBe(toolCallId);
+      expect(response.skipped).toBeUndefined();
     });
 
     it('should skip waiting for tool call sync when includeFullHistory is true', async () => {
@@ -756,50 +753,6 @@ describe('ChatService', () => {
       );
     });
 
-    it('should retry polling when tool call result is not yet synced', async () => {
-      const mockObservable = new Observable<BaseEvent>();
-      mockAgent.runAgent.mockReturnValue(mockObservable);
-
-      // Mock memory provider with includeFullHistory = false
-      mockCoreChatService.getMemoryProvider = jest
-        .fn()
-        .mockReturnValue({ includeFullHistory: false });
-
-      const toolCallId = 'tool-call-retry-test';
-
-      // Mock getConversation to return empty first, then with the tool call in MESSAGES_SNAPSHOT
-      let callCount = 0;
-      chatService.conversationHistoryService.getConversation = jest.fn().mockImplementation(() => {
-        callCount++;
-        if (callCount < 3) {
-          // First two calls return MESSAGES_SNAPSHOT without the tool call
-          return Promise.resolve([
-            {
-              type: 'MESSAGES_SNAPSHOT',
-              timestamp: Date.now(),
-              messages: [
-                {
-                  role: 'user',
-                  id: 'user-msg-1',
-                  content: 'Test message',
-                },
-              ],
-            },
-          ]);
-        }
-        // Subsequent calls return MESSAGES_SNAPSHOT with the tool call
-        return Promise.resolve(createMockMessagesSnapshot(toolCallId));
-      });
-
-      const response = await chatService.sendToolResult(toolCallId, { success: true }, []);
-
-      // Verify getConversation was polled multiple times. We require 3
-      // consecutive synced observations before treating the tool call as
-      // stably synced, so after the first synced snapshot (call #3) two more
-      // confirming polls are needed (calls #4 and #5).
-      expect(chatService.conversationHistoryService.getConversation).toHaveBeenCalledTimes(5);
-      expect(response.toolMessage.toolCallId).toBe(toolCallId);
-    });
     it('should skip dispatch with reason no_thread_id when thread ID is not set', async () => {
       // Create a new service without calling newThread
       const newService = new ChatService(mockUiSettings, mockCoreChatService);
@@ -819,115 +772,6 @@ describe('ChatService', () => {
       });
     });
 
-    describe('skip branch (duplicate tool result across windows)', () => {
-      // Snapshot containing both the synced tool call and a ToolMessage with
-      // the same toolCallId — another window has already persisted the result.
-      const createSnapshotWithToolResult = (toolCallId: string) => [
-        {
-          type: 'MESSAGES_SNAPSHOT',
-          timestamp: Date.now(),
-          messages: [
-            { role: 'user', id: 'user-msg-1', content: 'Run it' },
-            {
-              role: 'assistant',
-              id: 'assistant-msg-1',
-              content: 'Running',
-              toolCalls: [
-                {
-                  id: toolCallId,
-                  type: 'function',
-                  function: { name: 'test_tool', arguments: '{}' },
-                },
-              ],
-            },
-            {
-              role: 'tool',
-              id: 'tool-msg-1',
-              content: '"already done"',
-              toolCallId,
-            },
-          ],
-        },
-      ];
-
-      beforeEach(() => {
-        mockCoreChatService.getMemoryProvider = jest
-          .fn()
-          .mockReturnValue({ includeFullHistory: false });
-      });
-
-      it('should skip dispatch and return skipped reason when tool result already exists', async () => {
-        const toolCallId = 'tool-call-duplicate';
-
-        chatService.conversationHistoryService.getConversation = jest
-          .fn()
-          .mockResolvedValue(createSnapshotWithToolResult(toolCallId));
-
-        const response = await chatService.sendToolResult(toolCallId, { ok: true }, []);
-
-        expect(mockAgent.runAgent).not.toHaveBeenCalled();
-        expect(response.skipped).toEqual({ reason: 'result_already_exists' });
-        expect(response.toolMessage).toEqual({
-          id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
-          role: 'tool',
-          content: JSON.stringify({ ok: true }),
-          toolCallId,
-        });
-      });
-
-      it('should return an observable that completes without emitting on skip', async () => {
-        const toolCallId = 'tool-call-complete-only';
-
-        chatService.conversationHistoryService.getConversation = jest
-          .fn()
-          .mockResolvedValue(createSnapshotWithToolResult(toolCallId));
-
-        const response = await chatService.sendToolResult(toolCallId, 'result', []);
-
-        const nextSpy = jest.fn();
-        const errorSpy = jest.fn();
-        const completeSpy = jest.fn();
-
-        response.observable.subscribe({
-          next: nextSpy,
-          error: errorSpy,
-          complete: completeSpy,
-        });
-
-        expect(nextSpy).not.toHaveBeenCalled();
-        expect(errorSpy).not.toHaveBeenCalled();
-        expect(completeSpy).toHaveBeenCalledTimes(1);
-        expect((chatService as any).activeRequests.size).toBe(0);
-      });
-
-      it('should short-circuit result_already_exists over synced when both are present in the same snapshot', async () => {
-        const toolCallId = 'tool-call-both-present';
-
-        chatService.conversationHistoryService.getConversation = jest
-          .fn()
-          .mockResolvedValue(createSnapshotWithToolResult(toolCallId));
-
-        const response = await chatService.sendToolResult(toolCallId, 'result', []);
-
-        expect(response.skipped).toEqual({ reason: 'result_already_exists' });
-        expect(mockAgent.runAgent).not.toHaveBeenCalled();
-      });
-
-      it('should NOT skip when snapshot contains only the synced tool call without a tool result', async () => {
-        const toolCallId = 'tool-call-synced-only';
-        const mockObservable = new Observable<BaseEvent>();
-        mockAgent.runAgent.mockReturnValue(mockObservable);
-
-        chatService.conversationHistoryService.getConversation = jest
-          .fn()
-          .mockResolvedValue(createMockMessagesSnapshot(toolCallId));
-
-        const response = await chatService.sendToolResult(toolCallId, { ok: true }, []);
-
-        expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
-        expect(response.skipped).toBeUndefined();
-      });
-    });
 
     describe('abort signal', () => {
       beforeEach(() => {
@@ -958,35 +802,6 @@ describe('ChatService', () => {
         expect((chatService as any).activeRequests.size).toBe(0);
       });
 
-      it('should skip with reason aborted when signal fires during sync polling', async () => {
-        const toolCallId = 'tool-call-abort-mid-sync';
-        const controller = new AbortController();
-
-        // Return a pending snapshot so the poller loops (no synced observation)
-        chatService.conversationHistoryService.getConversation = jest.fn().mockResolvedValue([
-          {
-            type: 'MESSAGES_SNAPSHOT',
-            timestamp: Date.now(),
-            messages: [{ role: 'user', id: 'u1', content: 'hi' }],
-          },
-        ]);
-
-        // Fire the abort shortly after the first poll resolves so the
-        // interruptible sleep can observe it.
-        setTimeout(() => controller.abort(), 5);
-
-        const response = await chatService.sendToolResult(
-          toolCallId,
-          { ok: true },
-          [],
-          controller.signal
-        );
-
-        expect(response.skipped).toEqual({ reason: 'aborted' });
-        expect(mockAgent.runAgent).not.toHaveBeenCalled();
-        expect((chatService as any).activeRequests.size).toBe(0);
-      });
-
       it('should emit AbortError and call agent.abort when signal fires after dispatch', async () => {
         const toolCallId = 'tool-call-abort-during-stream';
         const controller = new AbortController();
@@ -1014,9 +829,9 @@ describe('ChatService', () => {
         expect(response.skipped).toBeUndefined();
         expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
 
-        // sendToolResult aborts the halted main run up front (before the sync window), so one
-        // abort has already happened by now. This test verifies the *signal-driven* abort that
-        // fires after dispatch — assert on the additional call, not an absolute count.
+        // sendToolResult aborts the halted main run up front, so one abort has already happened by
+        // now. This test verifies the *signal-driven* abort that fires after dispatch — assert on
+        // the additional call, not an absolute count.
         const abortsBeforeSignal = mockAgent.abort.mock.calls.length;
 
         const nextSpy = jest.fn();
@@ -1124,6 +939,220 @@ describe('ChatService', () => {
         expect(nextSpy).toHaveBeenCalledTimes(1);
         expect(completeSpy).not.toHaveBeenCalled();
       });
+    });
+  });
+
+  describe('sendToolResults (parallel batch)', () => {
+    // Snapshot whose assistant message carries one toolCall per id.
+    const createMockMessagesSnapshotMulti = (toolCallIds: string[]) => [
+      {
+        type: 'MESSAGES_SNAPSHOT',
+        timestamp: Date.now(),
+        messages: [
+          {
+            role: 'user',
+            id: 'user-msg-1',
+            content: 'Test message',
+          },
+          {
+            role: 'assistant',
+            id: 'assistant-msg-1',
+            content: 'Response with parallel tool calls',
+            toolCalls: toolCallIds.map((id) => ({
+              id,
+              type: 'function',
+              function: { name: 'test_tool', arguments: '{}' },
+            })),
+          },
+        ],
+      },
+    ];
+
+    beforeEach(() => {
+      // Initialize a thread first - required for sendToolResults
+      chatService.newThread();
+      (global as any).window = {
+        assistantContextStore: {
+          getAllContexts: jest.fn().mockReturnValue([]),
+          getBackendFormattedContexts: jest.fn().mockReturnValue([]),
+        },
+      };
+
+      // Default: includeFullHistory false so the sync-poll path is exercised.
+      mockCoreChatService.getMemoryProvider = jest
+        .fn()
+        .mockReturnValue({ includeFullHistory: false });
+    });
+
+    afterEach(() => {
+      delete (global as any).window;
+    });
+
+    it('should dispatch a batch of two tool results in a single run', async () => {
+      const mockObservable = new Observable<BaseEvent>();
+      mockAgent.runAgent.mockReturnValue(mockObservable);
+
+      const items = [
+        { toolCallId: 'tool-A', result: { ok: 1 } },
+        { toolCallId: 'tool-B', result: 'txt' },
+      ];
+
+      // Snapshot contains both tool calls; the last id (tool-B) drives the sync check.
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue(createMockMessagesSnapshotMulti(['tool-A', 'tool-B']));
+
+      const response = await chatService.sendToolResults(items, []);
+
+      // One ToolMessage per item, in order, with the correct role/toolCallId/content.
+      expect(response.toolMessages).toHaveLength(2);
+      expect(response.toolMessages[0]).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'tool',
+        content: JSON.stringify({ ok: 1 }), // object -> JSON.stringify
+        toolCallId: 'tool-A',
+      });
+      expect(response.toolMessages[1]).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'tool',
+        content: 'txt', // string -> as-is
+        toolCallId: 'tool-B',
+      });
+
+      expect(response.skipped).toBeUndefined();
+      expect(response.observable).toBeDefined();
+
+      // Single continuation run carrying both tool messages in order.
+      expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
+      expect(mockAgent.runAgent).toHaveBeenCalledWith(
+        {
+          threadId: expect.stringMatching(/^thread-\d+-[a-z0-9]{9}$/),
+          runId: expect.stringMatching(/^run-\d+-[a-z0-9]{9}$/),
+          messages: [response.toolMessages[0], response.toolMessages[1]],
+          tools: [],
+          context: [],
+          state: {},
+          forwardedProps: {},
+        },
+        undefined
+      );
+    });
+
+    it('should abort the halted main run before dispatching the continuation', async () => {
+      // Same regression guard as the singular path: one abort() must supersede the halted
+      // main run before runAgent, so the runs never overlap.
+      const callOrder: string[] = [];
+      mockAgent.abort.mockImplementation(() => {
+        callOrder.push('abort');
+      });
+      const mockObservable = new Observable<BaseEvent>();
+      mockAgent.runAgent.mockImplementation(() => {
+        callOrder.push('runAgent');
+        return mockObservable;
+      });
+
+      chatService.conversationHistoryService.getConversation = jest
+        .fn()
+        .mockResolvedValue(createMockMessagesSnapshotMulti(['tool-A', 'tool-B']));
+
+      await chatService.sendToolResults(
+        [
+          { toolCallId: 'tool-A', result: { ok: 1 } },
+          { toolCallId: 'tool-B', result: { ok: 2 } },
+        ],
+        []
+      );
+
+      expect(mockAgent.abort).toHaveBeenCalled();
+      expect(callOrder[0]).toBe('abort');
+      expect(callOrder.indexOf('abort')).toBeLessThan(callOrder.indexOf('runAgent'));
+    });
+
+    it('should dispatch the batch directly without a client-side sync wait (server reconciles)', async () => {
+      const mockObservable = new Observable<BaseEvent>();
+      mockAgent.runAgent.mockReturnValue(mockObservable);
+
+      // No sync poll: the server reconciles each result durably via its wire->native map.
+      const getConversation = jest.fn();
+      chatService.conversationHistoryService.getConversation = getConversation;
+
+      const response = await chatService.sendToolResults(
+        [
+          { toolCallId: 'tool-A', result: { ok: 1 } },
+          { toolCallId: 'tool-B', result: { ok: 2 } },
+        ],
+        []
+      );
+
+      expect(getConversation).not.toHaveBeenCalled();
+      expect(mockAgent.runAgent).toHaveBeenCalledTimes(1);
+      expect(response.skipped).toBeUndefined();
+      expect(response.toolMessages).toHaveLength(2);
+    });
+
+    it('should skip dispatch with reason no_thread_id when thread ID is not set', async () => {
+      // Fresh service without calling newThread, mirroring the singular no_thread_id test.
+      const newService = new ChatService(mockUiSettings, mockCoreChatService);
+      mockCoreChatService.getThreadId.mockReturnValue(undefined);
+
+      const items = [
+        { toolCallId: 'tool-A', result: 'a' },
+        { toolCallId: 'tool-B', result: 'b' },
+      ];
+
+      const response = await newService.sendToolResults(items, []);
+
+      expect(response.skipped).toEqual({ reason: 'no_thread_id' });
+      expect(mockAgent.runAgent).not.toHaveBeenCalled();
+
+      // toolMessages are still returned (one per item) even on skip.
+      expect(response.toolMessages).toHaveLength(2);
+      expect(response.toolMessages[0]).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'tool',
+        content: 'a',
+        toolCallId: 'tool-A',
+      });
+      expect(response.toolMessages[1]).toEqual({
+        id: expect.stringMatching(/^msg-\d+-[a-z0-9]{9}$/),
+        role: 'tool',
+        content: 'b',
+        toolCallId: 'tool-B',
+      });
+    });
+
+
+    it('should include full history and skip the sync wait when includeFullHistory is true', async () => {
+      const mockObservable = new Observable<BaseEvent>();
+      mockAgent.runAgent.mockReturnValue(mockObservable);
+
+      // includeFullHistory true: messages are passed directly so no sync poll is needed.
+      mockCoreChatService.getMemoryProvider = jest
+        .fn()
+        .mockReturnValue({ includeFullHistory: true });
+
+      // getConversation should NOT be consulted when full history is included.
+      chatService.conversationHistoryService.getConversation = jest.fn();
+
+      const messages: Message[] = [{ id: 'msg-1', role: 'user', content: 'Previous message' }];
+      const items = [
+        { toolCallId: 'tool-A', result: { ok: 1 } },
+        { toolCallId: 'tool-B', result: 'txt' },
+      ];
+
+      const response = await chatService.sendToolResults(items, messages);
+
+      expect(chatService.conversationHistoryService.getConversation).not.toHaveBeenCalled();
+      expect(response.skipped).toBeUndefined();
+      expect(response.toolMessages).toHaveLength(2);
+
+      // messages = [...messages, ...toolMessages] when includeFullHistory is true.
+      expect(mockAgent.runAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messages: [...messages, response.toolMessages[0], response.toolMessages[1]],
+        }),
+        undefined
+      );
     });
   });
 

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -866,13 +866,17 @@ export class ChatService {
       } as ToolCallEndEvent);
     }
 
-    // Return: events before snapshot + patched snapshot + events after snapshot + synthetic events
-    return [
+    // Tool call events belong BEFORE the run ends, as they do in a live stream: RUN_FINISHED clears
+    // the handler's active-message map, so a tool call replayed after it can no longer resolve its
+    // parent and would spawn a second assistant message instead of attaching to the restored one.
+    const rebuilt = [
       ...events.slice(0, snapshotIndex),
       patchedSnapshot,
       ...events.slice(snapshotIndex + 1),
-      ...syntheticEvents,
     ];
+    const runFinishedIndex = rebuilt.findIndex((e) => e.type === EventType.RUN_FINISHED);
+    const insertAt = runFinishedIndex === -1 ? rebuilt.length : runFinishedIndex;
+    return [...rebuilt.slice(0, insertAt), ...syntheticEvents, ...rebuilt.slice(insertAt)];
   }
 
   /**

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -708,6 +708,10 @@ export class ChatService {
       forwardedProps: {},
     };
 
+    // Abort the halted main run before the sync-poll window (not just at runAgent dispatch),
+    // so the two runs never overlap while waitForToolCallSync polls for up to 15s.
+    this.agent.abort();
+
     // Wait for tool call result to be synced to agentic memory only when not including full history
     // (when full history is included, messages are passed directly so no sync wait needed)
     if (!includeFullHistory) {

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -41,6 +41,13 @@ export interface CurrentChatState {
   messages: Message[];
 }
 
+/**
+ * How long a frontend-tool continuation waits before dispatch, so the tool-result write is visible
+ * to a backend that does not reconcile it server-side (ml-commons). See
+ * {@link ChatService.waitBeforeContinuation}.
+ */
+export const CONTINUATION_DISPATCH_DELAY_MS = 3000;
+
 export class ChatService {
   private agent: AgUiAgent;
   public availableTools: ToolDefinition[] = [];
@@ -567,7 +574,7 @@ export class ChatService {
     // The tool result is dispatched directly; the server reconciles it into the persisted
     // placeholder via its {wire tool_call_id -> native toolUseId} map (ag_ui_strands
     // session_reconcile), which is idempotent and cross-process.
-    if (signal?.aborted) return skip('aborted');
+    if (!(await this.waitBeforeContinuation(signal))) return skip('aborted');
 
     // Fix #11881: wait for the previous run (e.g. the one that requested this
     // frontend tool) to finish before dispatching this tool-result run.
@@ -584,6 +591,32 @@ export class ChatService {
     this.events$ = trackedObservable;
 
     return { observable: trackedObservable, toolMessage };
+  }
+
+  /**
+   * Wait before dispatching a frontend-tool continuation.
+   *
+   * The agent server reconciles a tool result into its persisted placeholder through the
+   * ag_ui_strands wire->native map, so it needs no delay. ml-commons has no such reconciliation and
+   * no backend polling, so a continuation that arrives before the placeholder write is visible can
+   * miss it. This delay keeps that path working while both backends are supported.
+   *
+   * Resolves false when the caller aborts during the wait, so the dispatch is skipped rather than
+   * firing seconds after cancellation.
+   */
+  private waitBeforeContinuation(signal?: AbortSignal): Promise<boolean> {
+    if (signal?.aborted) return Promise.resolve(false);
+    return new Promise((resolve) => {
+      const onAbort = () => {
+        clearTimeout(timer);
+        resolve(false);
+      };
+      const timer = setTimeout(() => {
+        signal?.removeEventListener('abort', onAbort);
+        resolve(true);
+      }, CONTINUATION_DISPATCH_DELAY_MS);
+      signal?.addEventListener('abort', onAbort, { once: true });
+    });
   }
 
   /**
@@ -717,7 +750,7 @@ export class ChatService {
 
     // Each result is dispatched directly; the server reconciles it via its wire->native map
     // (see sendToolResult), which is idempotent and cross-process.
-    if (signal?.aborted) return skip('aborted');
+    if (!(await this.waitBeforeContinuation(signal))) return skip('aborted');
 
     const observable = this.agent.runAgent(runInput, dataSourceId);
     const trackedObservable = this.buildTrackedRunObservable(observable, requestId, signal);

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -483,153 +483,6 @@ export class ChatService {
     return { observable: trackedObservable, userMessage };
   }
 
-  /**
-   * Number of consecutive polls in which the tool call id must be observed
-   * in history before we treat it as stably synced. Any pending observation
-   * or error resets the streak. This guards against transient snapshots
-   * where the id briefly appears then disappears as memory is rewritten.
-   */
-  private readonly TOOL_CALL_SYNC_MATURITY_THRESHOLD = 3;
-
-  /**
-   * Sleep for `ms` milliseconds, bailing out early if `signal` aborts.
-   * Returns true if the sleep was interrupted by the signal, false if the
-   * timer completed normally.
-   */
-  private interruptibleSleep(ms: number, signal?: AbortSignal): Promise<boolean> {
-    if (signal?.aborted) return Promise.resolve(true);
-
-    return new Promise<boolean>((resolve) => {
-      const onAbort = () => {
-        clearTimeout(timeoutId);
-        resolve(true);
-      };
-      const timeoutId = setTimeout(() => {
-        signal?.removeEventListener('abort', onAbort);
-        resolve(false);
-      }, ms);
-      signal?.addEventListener('abort', onAbort, { once: true });
-    });
-  }
-
-  /**
-   * Wait for tool call to be synced to agentic memory.
-   *
-   * Polls conversation history up to `maxAttempts` times, waiting `intervalMs`
-   * between polls. Returns one of:
-   * - `{ shouldSend: true,  reason: 'synced' }`              — tool call is in
-   *   history, caller may dispatch the tool result.
-   * - `{ shouldSend: false, reason: 'result_already_exists' }` — another
-   *   window persisted a tool result first; caller should skip dispatch.
-   * - `{ shouldSend: false, reason: 'sync_timeout' }`        — polling
-   *   exhausted without observing sync; caller should skip dispatch and
-   *   surface a resendable failure to the user.
-   * - `{ shouldSend: false, reason: 'no_thread_id' }`        — no thread id
-   *   available; caller should skip dispatch.
-   * - `{ shouldSend: false, reason: 'aborted' }`             — caller-supplied
-   *   abort signal fired; caller should skip dispatch.
-   *
-   * Note: exhausted attempts no longer silently proceed — the caller must
-   * decide whether to resend.
-   */
-  private async waitForToolCallSync(
-    toolCallId: string,
-    maxAttempts: number = 15,
-    intervalMs: number = 1000,
-    signal?: AbortSignal
-  ): Promise<{
-    shouldSend: boolean;
-    reason: 'synced' | 'no_thread_id' | 'result_already_exists' | 'sync_timeout' | 'aborted';
-  }> {
-    if (signal?.aborted) return { shouldSend: false, reason: 'aborted' };
-
-    const threadId = this.getThreadId();
-    if (!threadId) return { shouldSend: false, reason: 'no_thread_id' };
-
-    const checkSyncStatus = async (): Promise<'result_already_exists' | 'synced' | 'pending'> => {
-      const events = await this.conversationHistoryService.getConversation(threadId);
-      if (!events) return 'pending';
-
-      const hasToolResult = events.some((event) => {
-        if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
-          const messages = (event as any).messages as Message[];
-          return messages.some(
-            (msg) =>
-              msg.role === 'tool' && 'toolCallId' in msg && (msg as any).toolCallId === toolCallId
-          );
-        }
-        return false;
-      });
-      if (hasToolResult) return 'result_already_exists';
-
-      const hasToolCall = events.some((event) => {
-        if (event.type === EventType.MESSAGES_SNAPSHOT && 'messages' in event) {
-          const messages = (event as any).messages as Message[];
-          return messages.some(
-            (msg) =>
-              msg.role === 'assistant' &&
-              'toolCalls' in msg &&
-              Array.isArray((msg as any).toolCalls) &&
-              (msg as any).toolCalls.some((tc: any) => tc.id === toolCallId)
-          );
-        }
-        return false;
-      });
-      return hasToolCall ? 'synced' : 'pending';
-    };
-
-    let consecutiveSyncedPolls = 0;
-
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      if (signal?.aborted) return { shouldSend: false, reason: 'aborted' };
-
-      try {
-        const status = await checkSyncStatus();
-        if (signal?.aborted) return { shouldSend: false, reason: 'aborted' };
-
-        if (status === 'result_already_exists') {
-          return { shouldSend: false, reason: 'result_already_exists' };
-        }
-        if (status === 'synced') {
-          // Require `TOOL_CALL_SYNC_MATURITY_THRESHOLD` consecutive synced
-          // observations before treating the tool call as stably synced.
-          // This guards against transient snapshots where the id appears
-          // briefly before being rewritten.
-          consecutiveSyncedPolls += 1;
-          if (consecutiveSyncedPolls >= this.TOOL_CALL_SYNC_MATURITY_THRESHOLD) {
-            return { shouldSend: true, reason: 'synced' };
-          }
-        } else {
-          // Pending — id not yet in snapshot. Reset the streak so the
-          // maturity guarantee is "consecutive", not "cumulative".
-          consecutiveSyncedPolls = 0;
-        }
-      } catch (error) {
-        // Reset the streak on any error — maturity requires uninterrupted
-        // successful observations.
-        consecutiveSyncedPolls = 0;
-        // eslint-disable-next-line no-console
-        console.warn(`Failed to check tool call sync status (attempt ${attempt + 1}):`, error);
-      }
-
-      // Wait before next attempt (skip the wait after the final attempt).
-      // The sleep is interruptible so `cancelToolResultDispatch` aborts
-      // immediately rather than waiting for the next tick.
-      if (attempt < maxAttempts - 1) {
-        const interrupted = await this.interruptibleSleep(intervalMs, signal);
-        if (interrupted) return { shouldSend: false, reason: 'aborted' };
-      }
-    }
-
-    // Exhausted attempts without observing sync — do NOT silently dispatch.
-    // Surface the failure so the caller can show a system message and let the
-    // user decide whether to resend.
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Tool call sync check timed out after ${maxAttempts} attempts for toolCallId: ${toolCallId}`
-    );
-    return { shouldSend: false, reason: 'sync_timeout' };
-  }
 
   public async sendToolResult(
     toolCallId: string,
@@ -708,27 +561,12 @@ export class ChatService {
       forwardedProps: {},
     };
 
-    // Abort the halted main run before the sync-poll window (not just at runAgent dispatch),
-    // so the two runs never overlap while waitForToolCallSync polls for up to 15s.
+    // Abort the halted main run so it does not overlap the continuation.
     this.agent.abort();
 
-    // Wait for tool call result to be synced to agentic memory only when not including full history
-    // (when full history is included, messages are passed directly so no sync wait needed)
-    if (!includeFullHistory) {
-      const syncResult = await this.waitForToolCallSync(toolCallId, undefined, undefined, signal);
-
-      // Sync check returned a reason to skip dispatch:
-      // - `result_already_exists`: another window already persisted a tool
-      //   result. Skip to avoid a duplicate.
-      // - `sync_timeout`: polling exhausted. Skip and surface the failure so
-      //   the user can resend.
-      // - `aborted`: caller cancelled via the AbortSignal. Skip silently.
-      if (!syncResult.shouldSend) {
-        return skip(syncResult.reason as Exclude<typeof syncResult.reason, 'synced'>);
-      }
-    }
-
-    // If the signal fired between sync completion and dispatch, bail out.
+    // The tool result is dispatched directly; the server reconciles it into the persisted
+    // placeholder via its {wire tool_call_id -> native toolUseId} map (ag_ui_strands
+    // session_reconcile), which is idempotent and cross-process.
     if (signal?.aborted) return skip('aborted');
 
     // Fix #11881: wait for the previous run (e.g. the one that requested this
@@ -741,12 +579,26 @@ export class ChatService {
 
     // Continue the conversation with the tool result
     const observable = this.agent.runAgent(runInput, dataSourceId);
+    const trackedObservable = this.buildTrackedRunObservable(observable, requestId, signal);
 
-    // Wrap observable to track completion and honor the caller's abort
-    // signal. When the signal fires, we abort the underlying agent fetch and
-    // surface an AbortError to subscribers so they can distinguish a
-    // cancellation from a real stream error.
-    const trackedObservable = new Observable((subscriber: any) => {
+    this.events$ = trackedObservable;
+
+    return { observable: trackedObservable, toolMessage };
+  }
+
+  /**
+   * Wrap a run observable to track completion and honor the caller's abort
+   * signal. When the signal fires, we abort the underlying agent fetch and
+   * surface an AbortError to subscribers so they can distinguish a
+   * cancellation from a real stream error. Shared by the single- and
+   * batched-tool-result dispatch paths.
+   */
+  private buildTrackedRunObservable(
+    observable: any,
+    requestId: string,
+    signal?: AbortSignal
+  ): Observable<any> {
+    return new Observable((subscriber: any) => {
       // `settled` guards against emitting twice when the abort handler races
       // with the inner subscription's error/complete (aborting the agent
       // typically triggers both paths).
@@ -790,10 +642,89 @@ export class ChatService {
         subscription.unsubscribe();
       };
     });
+  }
+
+  /**
+   * Batched sibling of {@link sendToolResult}: sends several parallel frontend
+   * tool results in one continuation run (one `role=tool` message per
+   * `toolCallId`), keeping each `toolUse` adjacent to its `toolResult` and
+   * matching the memory store's fan-out shape. Since all calls belong to one
+   * assistant message, a single `abort()` + one sync-poll (on the last id)
+   * covers the batch.
+   */
+  public async sendToolResults(
+    items: Array<{ toolCallId: string; result: any }>,
+    messages: Message[],
+    signal?: AbortSignal
+  ): Promise<{
+    observable: any;
+    toolMessages: ToolMessage[];
+    skipped?: {
+      reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted';
+    };
+  }> {
+    const requestId = this.generateRequestId();
+    this.addActiveRequest(requestId);
+
+    const toolMessages: ToolMessage[] = items.map((item) => ({
+      id: this.generateMessageId(),
+      role: 'tool',
+      content: typeof item.result === 'string' ? item.result : JSON.stringify(item.result),
+      toolCallId: item.toolCallId,
+    }));
+
+    const skip = (
+      reason: 'result_already_exists' | 'sync_timeout' | 'no_thread_id' | 'aborted'
+    ) => {
+      this.removeActiveRequest(requestId);
+      return {
+        observable: new Observable((subscriber) => subscriber.complete()),
+        toolMessages,
+        skipped: { reason },
+      };
+    };
+
+    if (signal?.aborted) return skip('aborted');
+
+    const dataSourceId = await this.getWorkspaceAwareDataSourceId();
+
+    const contextStore = (window as any).assistantContextStore;
+    const allContexts = contextStore ? contextStore.getAllContexts() : [];
+    const context = allContexts.map((ctx: any) => ({
+      description: ctx.description,
+      value: typeof ctx.value === 'string' ? ctx.value : JSON.stringify(ctx.value),
+    }));
+
+    const includeFullHistory = this.conversationHistoryService.getMemoryProvider()
+      .includeFullHistory;
+    const mappedMessages = includeFullHistory ? [...messages, ...toolMessages] : [...toolMessages];
+
+    const threadId = this.getThreadId();
+    if (!threadId) return skip('no_thread_id');
+
+    const runInput: RunAgentInput = {
+      threadId,
+      runId: this.generateRunId(),
+      messages: mappedMessages,
+      tools: this.availableTools || [],
+      context,
+      state: {},
+      forwardedProps: {},
+    };
+
+    // Abort the halted main run so it does not overlap the continuation.
+    this.agent.abort();
+
+    // Each result is dispatched directly; the server reconciles it via its wire->native map
+    // (see sendToolResult), which is idempotent and cross-process.
+    if (signal?.aborted) return skip('aborted');
+
+    const observable = this.agent.runAgent(runInput, dataSourceId);
+    const trackedObservable = this.buildTrackedRunObservable(observable, requestId, signal);
 
     this.events$ = trackedObservable;
 
-    return { observable: trackedObservable, toolMessage };
+    return { observable: trackedObservable, toolMessages };
   }
 
   public abort(): void {

--- a/src/plugins/chat/public/services/chat_service.ts
+++ b/src/plugins/chat/public/services/chat_service.ts
@@ -490,7 +490,6 @@ export class ChatService {
     return { observable: trackedObservable, userMessage };
   }
 
-
   public async sendToolResult(
     toolCallId: string,
     result: any,
@@ -728,8 +727,8 @@ export class ChatService {
       value: typeof ctx.value === 'string' ? ctx.value : JSON.stringify(ctx.value),
     }));
 
-    const includeFullHistory = this.conversationHistoryService.getMemoryProvider()
-      .includeFullHistory;
+    const includeFullHistory =
+      this.conversationHistoryService.getMemoryProvider().includeFullHistory;
     const mappedMessages = includeFullHistory ? [...messages, ...toolMessages] : [...toolMessages];
 
     const threadId = this.getThreadId();

--- a/src/plugins/chat/public/services/human_input_service.ts
+++ b/src/plugins/chat/public/services/human_input_service.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BehaviorSubject, Observable } from 'rxjs';
+
+/**
+ * The kind of answer the assistant is asking the user for.
+ * - `select`  — pick one of `options`.
+ * - `confirm` — a yes/no decision (rendered as two buttons).
+ * - `text`    — free-form text input.
+ */
+export type AskUserInputType = 'select' | 'confirm' | 'text';
+
+export interface AskUserOption {
+  /** Human-readable label shown on the choice control. */
+  label: string;
+  /** Value sent back to the assistant when this option is chosen. */
+  value: string;
+}
+
+export interface AskUserRequest {
+  /** Unique id for this pending request (toolCallId + timestamp). */
+  id: string;
+  /** The tool call that triggered the question, used to correlate the answer. */
+  toolCallId: string;
+  /** The question to show the user. */
+  prompt: string;
+  /** How the user should answer. Defaults to `text` when omitted. */
+  inputType: AskUserInputType;
+  /** Choices for `select` input types. */
+  options?: AskUserOption[];
+  /**
+   * For `select`: also offer a free-text field so the user can answer with
+   * something not in `options` (a "None of these / other" escape). Ignored for
+   * `confirm` and `text`.
+   */
+  allowFreeText?: boolean;
+  timestamp: number;
+}
+
+export interface AskUserResponse {
+  id: string;
+  /** The value the user provided / chose. Empty when cancelled or declined. */
+  answer: string;
+  /**
+   * True when the request was resolved by cleanup (e.g. unmount / new
+   * conversation) rather than a real user action. Callers should treat this
+   * like a cancellation, not an answer, and NOT send a tool result.
+   */
+  cancelled?: boolean;
+  /**
+   * True when the user explicitly chose to dismiss the question without
+   * answering. Unlike `cancelled`, this is a deliberate user action and
+   * SHOULD be reported back to the assistant so it can proceed without the
+   * answer.
+   */
+  declined?: boolean;
+}
+
+/**
+ * Service that lets an assistant tool ask the user a structured question and
+ * block until they answer.
+ *
+ * This is the mechanism behind the `ask_user` frontend tool: the tool's
+ * handler calls {@link ask}, which returns a promise that stays pending until
+ * the user responds via the UI (which calls {@link answer}). Because the tool
+ * handler is awaited inside the normal frontend-tool execution path, the run
+ * naturally pauses at the tool-use boundary and resumes — via a continuation
+ * run carrying the tool result — once the promise resolves. No protocol
+ * changes are needed.
+ *
+ * Modeled on {@link ConfirmationService}, which uses the same
+ * pending-promise pattern for tool confirmations.
+ */
+export class HumanInputService {
+  private pending$ = new BehaviorSubject<AskUserRequest[]>([]);
+  private responseCallbacks = new Map<string, (response: AskUserResponse) => void>();
+  // Answers recorded synchronously at click time (toolCallId → answer), so the
+  // UI can show "Your answer: X" immediately instead of waiting for the
+  // continuation run's tool result. Keyed by toolCallId — what the renderer has.
+  private answers$ = new BehaviorSubject<Map<string, string>>(new Map());
+
+  /** Observable of pending questions for the UI to render. */
+  getPending$(): Observable<AskUserRequest[]> {
+    return this.pending$.asObservable();
+  }
+
+  /** Current snapshot of pending questions. */
+  getPending(): AskUserRequest[] {
+    return this.pending$.getValue();
+  }
+
+  /** Observable of locally-recorded answers (toolCallId → answer). */
+  getAnswers$(): Observable<Map<string, string>> {
+    return this.answers$.asObservable();
+  }
+
+  /** Current snapshot of locally-recorded answers (toolCallId → answer). */
+  getAnswers(): Map<string, string> {
+    return this.answers$.getValue();
+  }
+
+  /**
+   * Ask the user a question and return a promise that resolves when they
+   * answer. The promise resolves with `{ cancelled: true }` if the request is
+   * torn down by {@link cleanAll} before the user responds.
+   */
+  ask(request: {
+    toolCallId: string;
+    prompt: string;
+    inputType?: AskUserInputType;
+    options?: AskUserOption[];
+    allowFreeText?: boolean;
+  }): Promise<AskUserResponse> {
+    const id = `${request.toolCallId}-${Date.now()}`;
+    const entry: AskUserRequest = {
+      id,
+      toolCallId: request.toolCallId,
+      prompt: request.prompt,
+      inputType: request.inputType ?? 'text',
+      options: request.options,
+      allowFreeText: request.allowFreeText,
+      timestamp: Date.now(),
+    };
+
+    this.pending$.next([...this.pending$.getValue(), entry]);
+
+    return new Promise<AskUserResponse>((resolve) => {
+      this.responseCallbacks.set(id, resolve);
+    });
+  }
+
+  /**
+   * Deliver the user's answer for a pending question, resolving the promise
+   * returned by {@link ask} and removing the request from the pending list.
+   */
+  answer(id: string, value: string): void {
+    const callback = this.responseCallbacks.get(id);
+    if (callback) {
+      // Record the answer against its toolCallId before resolving, so the UI can
+      // show it immediately (the continuation run's tool result arrives later).
+      const request = this.pending$.getValue().find((req) => req.id === id);
+      if (request) {
+        const next = new Map(this.answers$.getValue());
+        next.set(request.toolCallId, value);
+        this.answers$.next(next);
+      }
+      callback({ id, answer: value });
+      this.cleanup(id);
+    }
+  }
+
+  /**
+   * Record that the user explicitly declined to answer a pending question.
+   * Resolves the promise with `declined: true` so the assistant is told the
+   * user chose not to answer (distinct from {@link cleanAll}'s teardown
+   * cancellation, which suppresses any tool result).
+   */
+  decline(id: string): void {
+    const callback = this.responseCallbacks.get(id);
+    if (callback) {
+      callback({ id, answer: '', declined: true });
+      this.cleanup(id);
+    }
+  }
+
+  /**
+   * Resolve all pending questions as cancelled (e.g. on unmount or when
+   * switching conversations) so the awaiting tool handlers unblock instead of
+   * leaking promises.
+   */
+  cleanAll(): void {
+    this.pending$.getValue().forEach((request) => {
+      const callback = this.responseCallbacks.get(request.id);
+      if (callback) {
+        callback({ id: request.id, answer: '', cancelled: true });
+      }
+    });
+    this.pending$.next([]);
+    this.responseCallbacks.clear();
+    // Drop recorded answers — a reloaded conversation restores them from results.
+    if (this.answers$.getValue().size > 0) {
+      this.answers$.next(new Map());
+    }
+  }
+
+  private cleanup(id: string): void {
+    this.responseCallbacks.delete(id);
+    this.pending$.next(this.pending$.getValue().filter((req) => req.id !== id));
+  }
+}

--- a/src/plugins/chat/public/services/tool_executor.test.ts
+++ b/src/plugins/chat/public/services/tool_executor.test.ts
@@ -33,9 +33,27 @@ describe('ToolExecutor', () => {
       expect(result.success).toBe(true);
       expect(result.data).toEqual({ result: 'success' });
       expect(result.source).toBe('registered_action');
-      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('testTool', {
-        param: 'value',
-      });
+      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith(
+        'testTool',
+        {
+          param: 'value',
+        },
+        'call-123'
+      );
+    });
+
+    it('should propagate cancellation when a registered handler returns cancelled', async () => {
+      // A handler (e.g. ask_user) returning { cancelled: true } means it was
+      // torn down while pending; executeTool must surface cancelled so the
+      // caller short-circuits without dispatching a tool result.
+      mockAssistantActionService.isUserConfirmRequired.mockReturnValue(false);
+      mockAssistantActionService.executeAction.mockResolvedValue({ cancelled: true });
+
+      const result = await toolExecutor.executeTool('ask_user', { prompt: 'x' }, 'call-123');
+
+      expect(result.cancelled).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.source).toBe('registered_action');
     });
 
     it('should handle agent tool when action not found', async () => {
@@ -58,11 +76,15 @@ describe('ToolExecutor', () => {
         title: 'Datasource 1',
       });
 
-      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('testTool', {
-        param: 'value',
-        datasourceId: 'datasource-1',
-        datasourceTitle: 'Datasource 1',
-      });
+      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith(
+        'testTool',
+        {
+          param: 'value',
+          datasourceId: 'datasource-1',
+          datasourceTitle: 'Datasource 1',
+        },
+        'call-123'
+      );
     });
   });
 
@@ -87,10 +109,14 @@ describe('ToolExecutor', () => {
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual({ result: 'confirmed' });
-      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('confirmTool', {
-        param: 'value',
-        confirmed: true,
-      });
+      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith(
+        'confirmTool',
+        {
+          param: 'value',
+          confirmed: true,
+        },
+        'call-123'
+      );
     });
 
     it('should reject execution when user rejects confirmation', async () => {
@@ -132,12 +158,16 @@ describe('ToolExecutor', () => {
 
       await executionPromise;
 
-      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith('confirmTool', {
-        param: 'value',
-        confirmed: true,
-        datasourceId: 'datasource-1',
-        datasourceTitle: 'Datasource 1',
-      });
+      expect(mockAssistantActionService.executeAction).toHaveBeenCalledWith(
+        'confirmTool',
+        {
+          param: 'value',
+          confirmed: true,
+          datasourceId: 'datasource-1',
+          datasourceTitle: 'Datasource 1',
+        },
+        'call-123'
+      );
     });
   });
 

--- a/src/plugins/chat/public/services/tool_executor.ts
+++ b/src/plugins/chat/public/services/tool_executor.ts
@@ -95,7 +95,11 @@ export class ToolExecutor {
       }
 
       // First, check if this is a registered assistant action
-      const registeredAction = await this.tryExecuteRegisteredAction(toolName, enrichedToolArgs);
+      const registeredAction = await this.tryExecuteRegisteredAction(
+        toolName,
+        enrichedToolArgs,
+        toolCallId
+      );
       if (registeredAction.handled && registeredAction.result) {
         return registeredAction.result;
       }
@@ -116,11 +120,29 @@ export class ToolExecutor {
    */
   private async tryExecuteRegisteredAction(
     toolName: string,
-    toolArgs: any
+    toolArgs: any,
+    toolCallId?: string
   ): Promise<{ handled: boolean; result?: ToolResult }> {
     try {
-      // Use the assistantActionService to execute the action
-      const result = await this.assistantActionService.executeAction(toolName, toolArgs);
+      // toolCallId lets handlers (e.g. ask_user) correlate the answer to this call.
+      const result = await this.assistantActionService.executeAction(
+        toolName,
+        toolArgs,
+        toolCallId
+      );
+
+      // A handler returning { cancelled: true } (e.g. ask_user torn down mid-question)
+      // short-circuits without dispatching a stray result on a dead thread.
+      if (result && typeof result === 'object' && (result as any).cancelled === true) {
+        return {
+          handled: true,
+          result: {
+            success: false,
+            cancelled: true,
+            source: 'registered_action',
+          },
+        };
+      }
 
       return {
         handled: true,

--- a/src/plugins/chat/server/routes/index.test.ts
+++ b/src/plugins/chat/server/routes/index.test.ts
@@ -124,6 +124,7 @@ describe('Chat Proxy Routes', () => {
           Accept: 'text/event-stream',
         },
         body: JSON.stringify(validRequest),
+        signal: expect.any(AbortSignal),
       });
 
       // Verify response headers for SSE
@@ -305,6 +306,7 @@ describe('Chat Proxy Routes', () => {
             Accept: 'text/event-stream',
           },
           body: JSON.stringify(validRequest),
+          signal: expect.any(AbortSignal),
         });
       });
 
@@ -349,6 +351,7 @@ describe('Chat Proxy Routes', () => {
             Accept: 'text/event-stream',
           },
           body: JSON.stringify(validRequest),
+          signal: expect.any(AbortSignal),
         });
       });
 

--- a/src/plugins/chat/server/routes/index.ts
+++ b/src/plugins/chat/server/routes/index.ts
@@ -139,18 +139,42 @@ async function forwardToAgUI(
 
   logger?.debug('Forwarding to external AG-UI', { agUiUrl, dataSourceId });
 
-  // Forward the request to AG-UI server using native fetch (Node 18+)
-  const agUiResponse = await fetch(agUiUrl, {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Accept: 'text/event-stream',
-      ...(oboToken ? { Authorization: `Bearer ${oboToken}` } : {}),
-    },
-    body: JSON.stringify(requestBody),
+  // Propagate a client disconnect upstream. Otherwise only the browser-to-Dashboards
+  // connection drops: this fetch stays open, so the agent never sees the disconnect and
+  // keeps streaming to Bedrock, running tools and persisting an answer nobody is reading.
+  // Cancelling lands on the task actually running the agent, so it needs no shared state.
+  // A disconnect is deliberately not distinguished from a stop: a refresh therefore loses
+  // the in-flight answer (it is only persisted once fully generated), which is preferred
+  // over paying for a run whose client has gone.
+  const upstreamAbort = new AbortController();
+  const abortSubscription = request.events.aborted$.subscribe(() => {
+    logger?.info('Client disconnected; aborting AG-UI request');
+    upstreamAbort.abort();
   });
 
+  // Forward the request to AG-UI server using native fetch (Node 18+).
+  // Wrapped so the aborted$ subscription is released even if fetch itself rejects — e.g. a network
+  // error, or the upstream abort firing before the response resolves. The cleanup below only runs
+  // once a response/stream exists, so without this the subscription would leak on that path.
+  let agUiResponse: Awaited<ReturnType<typeof fetch>>;
+  try {
+    agUiResponse = await fetch(agUiUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        ...(oboToken ? { Authorization: `Bearer ${oboToken}` } : {}),
+      },
+      body: JSON.stringify(requestBody),
+      signal: upstreamAbort.signal,
+    });
+  } catch (error) {
+    abortSubscription.unsubscribe();
+    throw error;
+  }
+
   if (!agUiResponse.ok) {
+    abortSubscription.unsubscribe();
     return response.customError({
       statusCode: agUiResponse.status,
       body: {
@@ -159,8 +183,18 @@ async function forwardToAgUI(
     });
   }
 
+  // An ok response with no body would throw on getReader() before the Readable (whose destroy/end
+  // hooks own the unsubscribe) exists, leaking the subscription. Release it here instead.
+  if (!agUiResponse.body) {
+    abortSubscription.unsubscribe();
+    return response.customError({
+      statusCode: 502,
+      body: { message: 'AG-UI server returned no response body' },
+    });
+  }
+
   // Convert Web ReadableStream to Node.js Readable stream
-  const reader = agUiResponse.body!.getReader();
+  const reader = agUiResponse.body.getReader();
   const stream = new Readable({
     async read() {
       try {
@@ -171,10 +205,21 @@ async function forwardToAgUI(
           this.push(Buffer.from(value)); // Push as Buffer for binary mode
         }
       } catch (error) {
-        this.destroy(error as Error);
+        // An aborted upstream fetch lands here; end the stream rather than erroring,
+        // since the client that would have seen the error is already gone.
+        if ((error as Error)?.name === 'AbortError') {
+          this.push(null);
+        } else {
+          this.destroy(error as Error);
+        }
       }
     },
+    destroy(error, callback) {
+      abortSubscription.unsubscribe();
+      callback(error);
+    },
   });
+  stream.on('end', () => abortSubscription.unsubscribe());
 
   return response.ok({
     headers: {

--- a/src/plugins/context_provider/public/contexts/assistant_action_context.tsx
+++ b/src/plugins/context_provider/public/contexts/assistant_action_context.tsx
@@ -31,11 +31,12 @@ export interface AssistantActionContextValue {
   toolCallStates: Map<string, ToolCallState>;
   registerAction: (action: AssistantAction) => void;
   unregisterAction: (name: string) => void;
-  executeAction: (name: string, args: any) => Promise<any>;
+  executeAction: (name: string, args: any, toolCallId?: string) => Promise<any>;
   getToolDefinitions: () => ToolDefinition[];
   updateToolCallState: (id: string, state: Partial<ToolCallState>) => void;
   getActionRenderer: (name: string) => AssistantAction['render'] | undefined;
   shouldUseCustomRenderer: (name: string) => boolean;
+  getRenderPlacement: (name: string) => 'above' | 'below';
 }
 
 export const AssistantActionContext = createContext<AssistantActionContextValue | null>(null);
@@ -112,7 +113,10 @@ export function AssistantActionProvider({
   );
 
   const executeAction = useCallback(
-    async (name: string, args: any) => {
+    // toolCallId is forwarded to the handler so this path stays equivalent to
+    // AssistantActionService.executeAction; handlers that correlate by tool call id (ask_user)
+    // depend on it.
+    async (name: string, args: any, toolCallId?: string) => {
       const action = actions.get(name);
       if (!action) {
         throw new Error(`Action ${name} not found`);
@@ -120,7 +124,7 @@ export function AssistantActionProvider({
       if (!action.handler) {
         throw new Error(`Action ${name} has no handler`);
       }
-      return action.handler(args);
+      return action.handler(args, toolCallId);
     },
     [actions]
   );
@@ -158,6 +162,14 @@ export function AssistantActionProvider({
     [actions]
   );
 
+  const getRenderPlacement = useCallback(
+    (name: string): 'above' | 'below' => {
+      const action = actions.get(name);
+      return action?.renderPlacement ?? 'above';
+    },
+    [actions]
+  );
+
   const getToolDefinitions = useCallback(() => {
     return Array.from(actions.values())
       .filter((action) => action.available !== 'disabled')
@@ -180,6 +192,7 @@ export function AssistantActionProvider({
         updateToolCallState,
         getActionRenderer,
         shouldUseCustomRenderer,
+        getRenderPlacement,
       }}
     >
       {children}

--- a/src/plugins/context_provider/public/hooks/use_assistant_action.ts
+++ b/src/plugins/context_provider/public/hooks/use_assistant_action.ts
@@ -13,6 +13,8 @@ export interface RenderProps<T = any> {
   args?: T;
   result?: any;
   error?: Error;
+  /** The id of the tool call being rendered, for renderers that correlate to external state. */
+  toolCallId?: string;
   onApprove?: () => void;
   onReject?: () => void;
 }
@@ -25,13 +27,14 @@ export interface AssistantAction<T = any> {
     properties: Record<string, any>;
     required: string[];
   };
-  handler?: (args: T) => Promise<any>;
+  handler?: (args: T, toolCallId?: string) => Promise<any>;
   render?: (props: RenderProps<T>) => ReactNode;
   available?: 'enabled' | 'disabled'; // 'disabled' for render-only actions
   enabled?: boolean;
   deps?: any[];
   requiresConfirmation?: boolean; // Whether this action requires user confirmation
   useCustomRenderer?: boolean; // Whether to use custom render method for tool results
+  renderPlacement?: 'above' | 'below'; // Custom-rendered row's position vs the assistant message (default 'above')
 }
 
 export function useAssistantAction<T = any>(action: AssistantAction<T>) {

--- a/src/plugins/context_provider/public/services/assistant_action_service.test.ts
+++ b/src/plugins/context_provider/public/services/assistant_action_service.test.ts
@@ -258,9 +258,9 @@ describe('AssistantActionService', () => {
       service.registerAction(action);
 
       const args = { param1: 'value1' };
-      const result = await service.executeAction('test-action', args);
+      const result = await service.executeAction('test-action', args, 'call-1');
 
-      expect(mockHandler).toHaveBeenCalledWith(args);
+      expect(mockHandler).toHaveBeenCalledWith(args, 'call-1');
       expect(result).toBe('test-result');
     });
 
@@ -334,7 +334,7 @@ describe('AssistantActionService', () => {
       // Should execute and return the stop instruction
       const result = await service.executeAction('disabled-action', { test: 'arg' });
 
-      expect(mockHandler).toHaveBeenCalledWith({ test: 'arg' });
+      expect(mockHandler).toHaveBeenCalledWith({ test: 'arg' }, undefined);
       expect(result).toEqual({
         success: false,
         error: 'STOP: Tool not available - context has changed',

--- a/src/plugins/context_provider/public/services/assistant_action_service.ts
+++ b/src/plugins/context_provider/public/services/assistant_action_service.ts
@@ -110,7 +110,7 @@ export class AssistantActionService {
     }
   };
 
-  executeAction = async (name: string, args: any) => {
+  executeAction = async (name: string, args: any, toolCallId?: string) => {
     const currentState = this.state$.getValue();
     const action = currentState.actions.get(name);
     if (!action) {
@@ -119,7 +119,11 @@ export class AssistantActionService {
     if (!action.handler) {
       throw new Error(`Action ${name} has no handler`);
     }
-    return action.handler(args);
+    // toolCallId is forwarded so handlers that correlate an out-of-band UI
+    // interaction back to the originating tool call (e.g. the `ask_user`
+    // human-in-the-loop tool) can key on it. Existing handlers ignore the
+    // extra argument.
+    return action.handler(args, toolCallId);
   };
 
   updateToolCallState = (id: string, state: Partial<ToolCallState>) => {
@@ -192,6 +196,16 @@ export class AssistantActionService {
     const action = currentState.actions.get(name);
 
     return action?.useCustomRenderer === true;
+  };
+
+  /**
+   * Get where an action's custom-rendered row sits relative to the assistant message
+   */
+  getRenderPlacement = (name: string): 'above' | 'below' => {
+    const currentState = this.state$.getValue();
+    const action = currentState.actions.get(name);
+
+    return action?.renderPlacement ?? 'above';
   };
 
   /**

--- a/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/explore/public/actions/ask_ai_embeddable_action.tsx
@@ -137,32 +137,19 @@ export class AskAIEmbeddableAction implements Action<EmbeddableContext> {
 
       // Send visualization screenshot to chat
       if (this.core.chat) {
+        // Merge the image INTO the user message content (a multimodal message) rather than
+        // sending it as a separate message. A separate message is dropped on the delta-only
+        // send path and never renders in the user bubble; carrying it in the message content
+        // makes it both visible in the bubble and delivered to the agent.
         await this.core.chat.sendMessageWithWindow(
           [
-            // TODO adapt type image when strands is introduced
-            // {
-            //   type: 'image',
-            //   source: {
-            //     type: 'data',
-            //     value: visualizationBase64,
-            //     mimeType: 'image/jpeg',
-            //   },
-            // },
-
+            { type: 'binary' as const, mimeType: 'image/jpeg', data: visualizationBase64 },
             {
-              type: 'binary' as const,
-              mimeType: 'image/jpeg',
-              data: visualizationBase64,
-            },
-            {
-              type: 'text',
+              type: 'text' as const,
               text: visualizationContextText,
               name: 'visualization_context',
             },
-            {
-              type: 'text',
-              text: 'Give me a summary for the selected visualization',
-            },
+            { type: 'text' as const, text: 'Give me a summary for the selected visualization' },
           ],
           []
         );

--- a/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
+++ b/src/plugins/visualizations/public/actions/ask_ai_embeddable_action.tsx
@@ -170,28 +170,14 @@ export class AskAIVisualizeEmbeddableAction implements Action<EmbeddableContext>
 
       // Send visualization screenshot to chat
       if (this.core.chat) {
+        // Merge the image INTO the user message content (a multimodal message) rather than
+        // sending it as a separate message. A separate message is dropped on the delta-only
+        // send path and never renders in the user bubble; carrying it in the message content
+        // makes it both visible in the bubble and delivered to the agent.
         await this.core.chat.sendMessageWithWindow(
           [
-            // TODO adapt type image when strands is introduced
-            // {
-            //   type: 'image',
-            //   source: {
-            //     type: 'data',
-            //     value: visualizationBase64,
-            //     mimeType: 'image/jpeg',
-            //   },
-            // },
-
-            {
-              type: 'binary' as const,
-              mimeType: 'image/jpeg',
-              data: visualizationBase64,
-            },
-
-            {
-              type: 'text',
-              text: 'Give me a summary for the selected visualization',
-            },
+            { type: 'binary' as const, mimeType: 'image/jpeg', data: visualizationBase64 },
+            { type: 'text' as const, text: 'Give me a summary for the selected visualization' },
           ],
           []
         );


### PR DESCRIPTION
### Description

Adds an `ask_user tool` so the agent can pause a run and ask the user a question instead of guessing, plus a set of related chat fixes:
- ask_user HITL tool — new HumanInputService owns pending-question state; questions render as an AskUserCard in the timeline with free-text and option answers. The action is registered eagerly in plugin start so a question replayed on reload isn't lost to an effect-ordering race. Also supports several frontend tool calls in flight at once, dispatching their results as one batched continuation.
- Abort the upstream agent run on client disconnect — previously only the browser connection dropped; the proxy's fetch to the AG-UI server stayed open, so the agent kept streaming and persisting an answer nobody would read.
- Keep image context from the Ask AI action — a screenshot attached from a dashboard panel never reached the agent.
- No duplicate tool calls when replaying an unfinished tool use — reloading mid-tool-call rendered the card twice and could re-dispatch the tool.
- Send frontend tool definitions unserialized instead of stringify/parse round-tripping them.


### Issues Resolved

NA

## Screenshot


## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
