### PR TITLE
[Explore] Skip query execution for a blank SQL query

### DIFF
--- a/changelogs/fragments/12664.yml
+++ b/changelogs/fragments/12664.yml
@@ -1,0 +1,2 @@
+fix:
+- Skip query execution for a blank SQL query in Explore ([#12664](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12664))

--- a/changelogs/fragments/12664.yml
+++ b/changelogs/fragments/12664.yml
@@ -1,2 +1,0 @@
-fix:
-- Skip query execution for a blank SQL query in Explore ([#12664](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12664))

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -1208,6 +1208,61 @@ describe('Query Actions - Comprehensive Test Suite', () => {
       expect(mockServices.tabRegistry.getTab).toHaveBeenCalledWith('explore_visualization_tab');
     });
 
+    it('runs nothing at all for a blank SQL query', async () => {
+      mockDispatch.mockClear();
+
+      const mockState = {
+        query: { query: '   ', language: 'SQL', dataset: null },
+        ui: { activeTabId: 'logs' },
+        results: {},
+        legacy: { interval: '1h' },
+        queryEditor: { breakdownField: undefined, queryStatusMap: {} },
+      };
+
+      mockGetState.mockReturnValue(mockState);
+      (mockServices.tabRegistry.getTab as jest.Mock).mockReturnValue({
+        prepareQuery: jest.fn().mockReturnValue(''),
+      });
+
+      const thunk = executeQueries({ services: mockServices });
+      await thunk(mockDispatch, mockGetState, undefined);
+
+      // No inner thunk is dispatched, so the cluster never sees the empty query
+      // itself, nor the `FROM ()` the histogram would have wrapped it in.
+      const dispatchedThunks = mockDispatch.mock.calls.filter(
+        (call) => typeof call[0] === 'function'
+      );
+      expect(dispatchedThunks).toHaveLength(0);
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'query/executeQueries/fulfilled' })
+      );
+    });
+
+    it('still runs a non-empty SQL query', async () => {
+      mockDispatch.mockClear();
+
+      const mockState = {
+        query: { query: 'SELECT * FROM logs', language: 'SQL', dataset: null },
+        ui: { activeTabId: 'logs' },
+        results: {},
+        legacy: { interval: '1h' },
+        queryEditor: { breakdownField: undefined, queryStatusMap: {} },
+      };
+
+      mockGetState.mockReturnValue(mockState);
+      (mockServices.tabRegistry.getTab as jest.Mock).mockReturnValue({
+        prepareQuery: jest.fn().mockReturnValue('SELECT * FROM logs'),
+      });
+
+      const thunk = executeQueries({ services: mockServices });
+      await thunk(mockDispatch, mockGetState, undefined);
+
+      const dispatchedThunks = mockDispatch.mock.calls.filter(
+        (call) => typeof call[0] === 'function'
+      );
+      expect(dispatchedThunks.length).toBeGreaterThanOrEqual(1);
+    });
+
     it('should skip histogram query when language is PROMQL', async () => {
       mockDispatch.mockClear();
 

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -63,6 +63,7 @@ import {
   executeHistogramQuery,
   executeTabQuery,
   executeDataTableQuery,
+  shouldSkipQueryExecution,
 } from './query_actions';
 import { QueryExecutionStatus } from '../types';
 import { setResults } from '../slices';
@@ -2321,6 +2322,44 @@ describe('Query Actions - Comprehensive Test Suite', () => {
 
       expect(results).toHaveLength(3);
       expect(mockSearchSource.fetch).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('shouldSkipQueryExecution', () => {
+    const queryFor = (language: string, queryText: unknown): Query =>
+      ({
+        language,
+        query: queryText,
+        dataset: { id: 'd', title: 't', type: 'INDEX_PATTERN' },
+      }) as Query;
+
+    // Selecting a dataset resets the editor to EMPTY_QUERY.QUERY (''), and a blank
+    // SQL query used to be sent verbatim: the data table asked the cluster to run
+    // '', and the histogram wrapped it into `FROM ()`, which does not parse.
+    it.each([
+      ['', 'empty'],
+      ['   ', 'whitespace only'],
+    ])('skips a %s SQL query (%s)', (queryText) => {
+      expect(shouldSkipQueryExecution(queryFor('SQL', queryText))).toBe(true);
+    });
+
+    it('skips a SQL query whose text is not a string', () => {
+      expect(shouldSkipQueryExecution(queryFor('SQL', undefined))).toBe(true);
+    });
+
+    it('runs a non-empty SQL query', () => {
+      expect(shouldSkipQueryExecution(queryFor('SQL', 'SELECT * FROM idx'))).toBe(false);
+    });
+
+    it('still skips a blank PromQL query', () => {
+      expect(shouldSkipQueryExecution(queryFor('PROMQL', ''))).toBe(true);
+      expect(shouldSkipQueryExecution(queryFor('PROMQL', 'up'))).toBe(false);
+    });
+
+    // PPL must not be skipped: defaultPreparePplQuery turns a blank editor into
+    // `source = <table>`, so an empty PPL query is still runnable.
+    it('runs a blank PPL query', () => {
+      expect(shouldSkipQueryExecution(queryFor('PPL', ''))).toBe(false);
     });
   });
 });

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.test.ts
@@ -1227,8 +1227,7 @@ describe('Query Actions - Comprehensive Test Suite', () => {
       const thunk = executeQueries({ services: mockServices });
       await thunk(mockDispatch, mockGetState, undefined);
 
-      // No inner thunk is dispatched, so the cluster never sees the empty query
-      // itself, nor the `FROM ()` the histogram would have wrapped it in.
+      // Neither the empty query nor the histogram's `FROM ()` reaches the cluster.
       const dispatchedThunks = mockDispatch.mock.calls.filter(
         (call) => typeof call[0] === 'function'
       );
@@ -2388,9 +2387,7 @@ describe('Query Actions - Comprehensive Test Suite', () => {
         dataset: { id: 'd', title: 't', type: 'INDEX_PATTERN' },
       }) as Query;
 
-    // Selecting a dataset resets the editor to EMPTY_QUERY.QUERY (''), and a blank
-    // SQL query used to be sent verbatim: the data table asked the cluster to run
-    // '', and the histogram wrapped it into `FROM ()`, which does not parse.
+    // Selecting a dataset resets the editor to EMPTY_QUERY.QUERY ('').
     it.each([
       ['', 'empty'],
       ['   ', 'whitespace only'],
@@ -2411,8 +2408,7 @@ describe('Query Actions - Comprehensive Test Suite', () => {
       expect(shouldSkipQueryExecution(queryFor('PROMQL', 'up'))).toBe(false);
     });
 
-    // PPL must not be skipped: defaultPreparePplQuery turns a blank editor into
-    // `source = <table>`, so an empty PPL query is still runnable.
+    // defaultPreparePplQuery turns a blank PPL editor into `source = <table>`.
     it('runs a blank PPL query', () => {
       expect(shouldSkipQueryExecution(queryFor('PPL', ''))).toBe(false);
     });

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -99,14 +99,8 @@ export const defaultPrepareQueryString = (query: Query): string => {
  */
 export const shouldSkipQueryExecution = (query: Query): boolean => {
   switch (query.language) {
-    // PPL is deliberately absent: `defaultPreparePplQuery` fills a blank editor
-    // in with `source = <table>`, so an empty PPL query is still a runnable one.
-    // SQL and PromQL are sent to the cluster verbatim, and a blank one is not a
-    // query at all. Selecting a dataset resets the editor to `EMPTY_QUERY.QUERY`
-    // (the empty string), so without this a freshly picked dataset fired two
-    // failing requests: the data table's empty query, and — when the dataset has
-    // a time field — the histogram, which wraps the base query as a derived
-    // table and so asked the cluster to parse `FROM ()`.
+    // PPL is absent on purpose: `defaultPreparePplQuery` fills a blank editor in
+    // with `source = <table>`, so an empty PPL query is still runnable.
     case 'PROMQL':
     case 'SQL':
       const queryValue = query.query;

--- a/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
+++ b/src/plugins/explore/public/application/utils/state_management/actions/query_actions.ts
@@ -99,7 +99,16 @@ export const defaultPrepareQueryString = (query: Query): string => {
  */
 export const shouldSkipQueryExecution = (query: Query): boolean => {
   switch (query.language) {
+    // PPL is deliberately absent: `defaultPreparePplQuery` fills a blank editor
+    // in with `source = <table>`, so an empty PPL query is still a runnable one.
+    // SQL and PromQL are sent to the cluster verbatim, and a blank one is not a
+    // query at all. Selecting a dataset resets the editor to `EMPTY_QUERY.QUERY`
+    // (the empty string), so without this a freshly picked dataset fired two
+    // failing requests: the data table's empty query, and — when the dataset has
+    // a time field — the histogram, which wraps the base query as a derived
+    // table and so asked the cluster to parse `FROM ()`.
     case 'PROMQL':
+    case 'SQL':
       const queryValue = query.query;
       return typeof queryValue !== 'string' || !queryValue.trim();
     default:


### PR DESCRIPTION
### Description

Picking a dataset in Explore resets the editor to `EMPTY_QUERY.QUERY` — the empty string. PPL survives that, because `defaultPreparePplQuery` fills a blank editor in with `source = <table>`, so an empty PPL query is still a runnable one. SQL is sent to the cluster verbatim, and `shouldSkipQueryExecution` only gated PromQL on a blank query, so a freshly picked dataset fired two failing requests:

- the data table's query, which is the empty string; and
- when the dataset carries a time field, the histogram, which wraps the base query as a derived table and so asked the cluster to parse `FROM ()`.

This adds SQL to the same case PromQL was already in. PPL deliberately stays out of it.

### Reproducing it

Pick or create a dataset with a time field, switch the language to SQL, and leave the editor empty. Before this change, both requests go out and fail; the browser surfaces

```
Cannot invoke "org.opensearch.sql.ast.statement.Statement.accept(...)" because "statement" is null
```

and the cluster logs a `ParserException: ERROR. token : EQ, pos : 86` from the legacy parser.

The logged parser error is a red herring worth calling out, since it cost some time to chase. The V2 engine fails first (that is the null statement), the request then falls back to the legacy Druid-based parser, and *that* parser reports the `EQ` — pointing at the `=` in `date_histogram(field=…, interval='30d')`. Named arguments are syntax the legacy parser can never read, so it emits that error whenever the fallback runs, whatever the real cause. The actual query sent was:

```sql
SELECT time_bucket, COUNT(*) FROM (SELECT date_histogram(field=`timestamp`, interval='30d') AS time_bucket FROM () sub_inner) sub GROUP BY time_bucket ORDER BY time_bucket
```

`FROM ()` is the whole problem. Running the same statement against a 3.9.0 cluster with a real inner query returns buckets normally, so neither the bucket-function grammar nor the time-filter insertion is at fault.

## Screenshot

https://github.com/user-attachments/assets/16571c8d-6954-4e8e-930a-1b1cca495572



### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
