### PR TITLE
Fix invisible histogram tooltip value text in light mode

### DIFF
--- a/src/core/public/styles/_base.scss
+++ b/src/core/public/styles/_base.scss
@@ -11,7 +11,6 @@
 
 // Charts themes available app-wide
 @import "@elastic/charts/dist/theme";
-@import "@elastic/eui/src/themes/charts/theme";
 
 // Application Layout
 $euiCollapsibleNavWidth: $euiSize * 20;


### PR DESCRIPTION
### Description

`src/core/public/styles/_base.scss` imports both the current `@elastic/charts` theme and a stale OUI-vendored copy of it (`@elastic/eui/src/themes/charts/theme`, last synced against charts 30.2.0). Both define `.echTooltip`, and the stale copy wins the cascade, leaving the tooltip's count text white-on-white in light mode.

I believe this only broke with #12434 (charts 31.1.0 → 71.8.1) - before that upgrade the two copies were structurally identical, so the duplicate import was redundant but harmless. 71.8.1 changed the tooltip's theme/DOM structure but the vendored copy wasn't updated. As far as I can tell, nothing inside OUI itself imports this file, and the only customisation vs upstream is a Dart Sass compile fix, not a design change, so I think we're good to remove it.
### Issues Resolved

Fixes #12670

## Screenshot

### Before

<img width="1074" height="255" alt="histogram-count-before" src="https://github.com/user-attachments/assets/e88492ce-9736-4513-a430-cf2b4578e071" />

### After

<img width="1074" height="255" alt="histogram-count-after" src="https://github.com/user-attachments/assets/10fc9c08-d087-44d5-870c-d9819857364e" />

## Testing the changes

- In light mode, hover over a histogram bar and confirm the tooltip shows both the bucket date and a legible count value.
- Repeat in dark mode to confirm no regression

### Check List

- [X] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
