### PR TITLE
Standardise copy icon and add tooltip to recent queries copy button

### DIFF
--- a/src/plugins/data/public/query/query_string/language_service/lib/recent_query.tsx
+++ b/src/plugins/data/public/query/query_string/language_service/lib/recent_query.tsx
@@ -61,12 +61,13 @@ export function RecentQueriesTable({
         },
         {
           render: (item: RecentQueryTableItem) => (
-            <EuiCopy textToCopy={item.query as string}>
+            <EuiCopy beforeMessage="Copy recent query" textToCopy={item.query as string}>
               {(copy) => (
                 <EuiButtonIcon
                   onClick={copy}
-                  iconType="copyClipboard"
+                  iconType="copy"
                   aria-label="Copy recent query"
+                  data-test-subj="action-copy"
                 />
               )}
             </EuiCopy>

--- a/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_tabs/span_overview_tab.tsx
+++ b/src/plugins/explore/public/application/pages/traces/trace_details/public/traces/span_tabs/span_overview_tab.tsx
@@ -62,7 +62,7 @@ const OverviewField: React.FC<OverviewFieldProps> = ({
                   defaultMessage: 'Copy to clipboard',
                 })}
                 onClick={copy}
-                iconType="copyClipboard"
+                iconType="copy"
               />
             )}
           </EuiCopy>
@@ -236,7 +236,7 @@ export const SpanOverviewTab: React.FC<SpanOverviewTabProps> = ({
                           defaultMessage: 'Copy to clipboard',
                         })}
                         onClick={copy}
-                        iconType="copyClipboard"
+                        iconType="copy"
                       />
                     )}
                   </EuiCopy>


### PR DESCRIPTION
### Description

Standardises the copy-to-clipboard icon on `copy` instead of `copyClipboard`. The former is more commonly used in this repo and looks more like a copy icon, whereas the latter looks kinda like a paste icon.

Also adds a `beforeMessage` to the recent queries copy button so it shows a "Copy recent query" tooltip on hover, similar to the Run action's tooltip.

`span_overview_tab.tsx` is the only other place that used this `copyClipboard` icon.

### Issues Resolved

N/A

## Screenshot

### Before

<img width="174" height="118" alt="copy-before" src="https://github.com/user-attachments/assets/e0945239-7041-45bb-ba89-8d60ba57cb4a" />

### After

<img width="174" height="118" alt="copy-after" src="https://github.com/user-attachments/assets/c1518fdc-60b4-4ecc-8218-e6bca1165b75" />

## Testing the changes

- `yarn test:jest src/plugins/data/public/query/query_string/language_service/lib/recent_query.test.tsx`
- Manual: open the recent queries popover in Explore, hover over the copy icon to confirm the "Copy recent query" tooltip appears, click it, and confirm the tooltip flips to "Copied" and the query is copied to the clipboard

### Check List

- [X] All tests pass
  - [X] `yarn test:jest`
  - [X] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using --signoff