### PR TITLE
fix(tsvb): format date histogram tooltip timestamps

### DIFF
--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.js
@@ -39,6 +39,7 @@ import {
   Settings,
   AnnotationDomainType,
   LineAnnotation,
+  Tooltip,
   TooltipType,
   StackMode,
   LegendValue,
@@ -150,12 +151,12 @@ export const TimeSeries = ({
           },
         ]}
         baseTheme={baseTheme}
-        tooltip={{
-          snap: true,
-          type: tooltipMode === 'show_focused' ? TooltipType.Follow : TooltipType.VerticalCursor,
-          headerFormatter: tooltipFormatter,
-        }}
         externalPointerEvents={{ tooltip: { visible: false } }}
+      />
+      <Tooltip
+        snap={true}
+        type={tooltipMode === 'show_focused' ? TooltipType.Follow : TooltipType.VerticalCursor}
+        headerFormatter={tooltipFormatter}
       />
 
       {annotations.map(({ id, data, icon, color }) => {

--- a/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.test.js
+++ b/src/plugins/vis_type_timeseries/public/application/visualizations/views/timeseries/index.test.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { shallow } from 'enzyme';
+import { Settings, Tooltip, TooltipType } from '@elastic/charts';
+import { getChartsSetup, getUISettings } from '../../../../services';
+import { TimeSeries } from './index';
+
+jest.unmock('@elastic/charts');
+
+jest.mock('../../../lib/get_timezone', () => ({
+  getTimezone: jest.fn(() => 'UTC'),
+}));
+
+jest.mock('../../../../services', () => ({
+  getChartsSetup: jest.fn(),
+  getUISettings: jest.fn(),
+}));
+
+describe('TSVB TimeSeries', () => {
+  const timestamp = 1782856800000;
+  const xAxisFormatter = jest.fn((value) => `formatted-${value}`);
+
+  beforeEach(() => {
+    getUISettings.mockReturnValue({});
+    getChartsSetup.mockReturnValue({
+      colors: {
+        mappedColors: {
+          mapKeys: jest.fn(),
+          mapping: {},
+        },
+      },
+      theme: {
+        useChartsBaseTheme: jest.fn(() => ({})),
+      },
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('registers the date formatter with the tooltip spec', () => {
+    const wrapper = shallow(
+      <TimeSeries
+        series={[]}
+        yAxis={[]}
+        annotations={[]}
+        onBrush={jest.fn()}
+        tooltipMode="show_all"
+        xAxisFormatter={xAxisFormatter}
+      />
+    );
+
+    const tooltip = wrapper.find(Tooltip);
+
+    expect(tooltip).toHaveLength(1);
+    expect(tooltip.props()).toMatchObject({
+      snap: true,
+      type: TooltipType.VerticalCursor,
+    });
+    expect(tooltip.prop('headerFormatter')({ value: timestamp })).toBe(`formatted-${timestamp}`);
+    expect(wrapper.find(Settings).prop('tooltip')).toBeUndefined();
+  });
+});


### PR DESCRIPTION
### Description
Fixes TSVB date histogram tooltips displaying raw epoch milliseconds instead of formatted dates.
<!-- Describe what this change achieves-->

### Issues Resolved
Closed #12669
<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<img width="462" height="300" alt="Screenshot 2026-09-01 at 10 39 45" src="https://github.com/user-attachments/assets/3f95bfba-9230-4a61-a6ed-9a54f7253249" />

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
