### PR TITLE
Fix data sources in custom security tenants

### DIFF
--- a/src/plugins/data_source/server/plugin.test.ts
+++ b/src/plugins/data_source/server/plugin.test.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock, httpServerMock, savedObjectsRepositoryMock } from '../../../core/server/mocks';
+import { DATA_SOURCE_SAVED_OBJECT_TYPE } from '../common';
+import { DataSourcePlugin } from './plugin';
+
+describe('DataSourcePlugin', () => {
+  const createRouteContext = async () => {
+    const initializerContext = coreMock.createPluginInitializerContext();
+    const plugin = new DataSourcePlugin(initializerContext);
+    const coreStart = coreMock.createStart();
+    const request = httpServerMock.createOpenSearchDashboardsRequest();
+    const scopedRepository = savedObjectsRepositoryMock.create();
+    const dataSourceService = {
+      getDataSourceClient: jest.fn().mockResolvedValue({}),
+      getDataSourceLegacyClient: jest.fn().mockReturnValue({ callAPI: jest.fn() }),
+    };
+    const auditor = { add: jest.fn() };
+
+    coreStart.savedObjects.createScopedRepository.mockReturnValue(scopedRepository);
+    plugin.start(coreStart);
+
+    const contextProvider = (plugin as any).createDataSourceRouteHandlerContext(
+      dataSourceService,
+      {},
+      initializerContext.logger.get(),
+      Promise.resolve({ asScoped: jest.fn().mockReturnValue(auditor) }),
+      Promise.resolve({}),
+      Promise.resolve({})
+    );
+    const routeContext = await contextProvider(coreMock.createRequestHandlerContext(), request);
+
+    return { coreStart, dataSourceService, request, routeContext, scopedRepository };
+  };
+
+  it('uses a request-scoped raw repository for modern data source clients', async () => {
+    const { coreStart, dataSourceService, request, routeContext, scopedRepository } =
+      await createRouteContext();
+
+    await routeContext.opensearch.getClient('data-source-id');
+
+    expect(coreStart.savedObjects.createScopedRepository).toHaveBeenCalledWith(request, [
+      DATA_SOURCE_SAVED_OBJECT_TYPE,
+    ]);
+    expect(dataSourceService.getDataSourceClient).toHaveBeenCalledWith(
+      expect.objectContaining({ internalSavedObjects: scopedRepository, request })
+    );
+  });
+
+  it('uses a request-scoped raw repository for legacy data source clients', async () => {
+    const { coreStart, dataSourceService, request, routeContext, scopedRepository } =
+      await createRouteContext();
+
+    routeContext.opensearch.legacy.getClient('data-source-id');
+
+    expect(coreStart.savedObjects.createScopedRepository).toHaveBeenCalledWith(request, [
+      DATA_SOURCE_SAVED_OBJECT_TYPE,
+    ]);
+    expect(dataSourceService.getDataSourceLegacyClient).toHaveBeenCalledWith(
+      expect.objectContaining({ internalSavedObjects: scopedRepository, request })
+    );
+  });
+});

--- a/src/plugins/data_source/server/plugin.ts
+++ b/src/plugins/data_source/server/plugin.ts
@@ -43,7 +43,9 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
   private started = false;
   private authMethodsRegistry = new AuthenticationMethodRegistry();
   private customApiSchemaRegistry = new CustomApiSchemaRegistry();
-  private internalSavedObjects: ISavedObjectsRepository | undefined;
+  private scopedSavedObjectsRepositoryFactory:
+    | ((request: OpenSearchDashboardsRequest) => ISavedObjectsRepository)
+    | undefined;
 
   constructor(private initializerContext: PluginInitializerContext<DataSourcePluginConfigType>) {
     this.logger = this.initializerContext.logger.get();
@@ -150,7 +152,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       this.logger.get('test-connection'),
       endpointDeniedIPs,
       config.endpointAllowlistedSuffixes,
-      () => this.internalSavedObjects
+      (request) => this.scopedSavedObjectsRepositoryFactory?.(request)
     );
     registerFetchDataSourceMetaDataRoute(
       router,
@@ -161,7 +163,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
       this.logger.get('fetch-data-source-metadata'),
       endpointDeniedIPs,
       config.endpointAllowlistedSuffixes,
-      () => this.internalSavedObjects
+      (request) => this.scopedSavedObjectsRepositoryFactory?.(request)
     );
 
     const registerCredentialProvider = (method: AuthenticationMethod) => {
@@ -183,12 +185,10 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
   public start(core: CoreStart) {
     this.logger.debug('dataSource: Started');
     this.started = true;
-    // Create an internal repository that bypasses the credential-stripping SavedObjects wrapper.
-    // Used exclusively by getClient / getLegacyClient to read encrypted credentials after the
-    // scoped client has already confirmed the calling user has access to the data source.
-    this.internalSavedObjects = core.savedObjects.createInternalRepository([
-      DATA_SOURCE_SAVED_OBJECT_TYPE,
-    ]);
+    // Create a request-scoped raw repository that bypasses the credential-stripping SavedObjects
+    // wrapper while preserving the active security tenant.
+    this.scopedSavedObjectsRepositoryFactory = (request) =>
+      core.savedObjects.createScopedRepository(request, [DATA_SOURCE_SAVED_OBJECT_TYPE]);
     // backendCompatibility (when enabled) registers a custom Transport on core's client.
     // Apply the same Transport to modern data-source clients so legacy ES (6.x/7.x)
     // connections get identical request/response interception (e.g. /_resolve/index
@@ -225,7 +225,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
             return dataSourceService.getDataSourceClient({
               dataSourceId,
               savedObjects: context.core.savedObjects.client,
-              internalSavedObjects: this.internalSavedObjects,
+              internalSavedObjects: this.scopedSavedObjectsRepositoryFactory?.(req),
               cryptography,
               customApiSchemaRegistryPromise,
               request: req,
@@ -237,7 +237,7 @@ export class DataSourcePlugin implements Plugin<DataSourcePluginSetup, DataSourc
               return dataSourceService.getDataSourceLegacyClient({
                 dataSourceId,
                 savedObjects: context.core.savedObjects.client,
-                internalSavedObjects: this.internalSavedObjects,
+                internalSavedObjects: this.scopedSavedObjectsRepositoryFactory?.(req),
                 cryptography,
                 customApiSchemaRegistryPromise,
                 request: req,

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.test.ts
@@ -580,7 +580,9 @@ describe(`Fetch DataSource MetaData ${URL} — internalSavedObjects forwarding`,
   };
 
   const setupRoute = async (
-    getInternalSavedObjects?: () => ReturnType<typeof savedObjectsRepositoryMock.create> | undefined
+    getInternalSavedObjects?: (
+      request: unknown
+    ) => ReturnType<typeof savedObjectsRepositoryMock.create> | undefined
   ) => {
     ({ server, httpSetup } = await setupServer());
     dataSourceClient = opensearchClientMock.createInternalClient();
@@ -623,7 +625,8 @@ describe(`Fetch DataSource MetaData ${URL} — internalSavedObjects forwarding`,
 
   it('forwards internalSavedObjects when editing non-credential fields with stored password (username_password reuse flow)', async () => {
     const internalRepo = savedObjectsRepositoryMock.create();
-    await setupRoute(() => internalRepo);
+    const getInternalSavedObjects = jest.fn(() => internalRepo);
+    await setupRoute(getInternalSavedObjects);
 
     await supertest(httpSetup.server.listener)
       .post(URL)
@@ -638,6 +641,7 @@ describe(`Fetch DataSource MetaData ${URL} — internalSavedObjects forwarding`,
         internalSavedObjects: internalRepo,
       })
     );
+    expect(getInternalSavedObjects).toHaveBeenCalledWith(expect.anything());
   });
 
   it('forwards internalSavedObjects when editing non-credential fields with stored SigV4 keys (sigv4 reuse flow)', async () => {

--- a/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
+++ b/src/plugins/data_source/server/routes/fetch_data_source_metadata.ts
@@ -9,6 +9,7 @@ import {
   ISavedObjectsRepository,
   Logger,
   OpenSearchClient,
+  OpenSearchDashboardsRequest,
 } from 'opensearch-dashboards/server';
 import { AuthType, DataSourceAttributes, SigV4ServiceName } from '../../common/data_sources';
 import { DataSourceConnectionValidator } from './data_source_connection_validator';
@@ -27,7 +28,9 @@ export const registerFetchDataSourceMetaDataRoute = async (
   logger: Logger,
   endpointDeniedIPs?: string[],
   endpointAllowlistedSuffixes?: string[],
-  getInternalSavedObjects?: () => ISavedObjectsRepository | undefined
+  getInternalSavedObjects?: (
+    request: OpenSearchDashboardsRequest
+  ) => ISavedObjectsRepository | undefined
 ) => {
   const authRegistry = await authRegistryPromise;
   router.post(
@@ -110,7 +113,7 @@ export const registerFetchDataSourceMetaDataRoute = async (
         const dataSourceClient: OpenSearchClient = await dataSourceServiceSetup.getDataSourceClient(
           {
             savedObjects: context.core.savedObjects.client,
-            internalSavedObjects: getInternalSavedObjects?.(),
+            internalSavedObjects: getInternalSavedObjects?.(request),
             cryptography,
             dataSourceId,
             testClientDataSourceAttr: dataSourceAttr as DataSourceAttributes,

--- a/src/plugins/data_source/server/routes/test_connection.test.ts
+++ b/src/plugins/data_source/server/routes/test_connection.test.ts
@@ -493,7 +493,9 @@ describe(`Test connection ${URL} — internalSavedObjects forwarding`, () => {
   };
 
   const setupRoute = async (
-    getInternalSavedObjects?: () => ReturnType<typeof savedObjectsRepositoryMock.create> | undefined
+    getInternalSavedObjects?: (
+      request: unknown
+    ) => ReturnType<typeof savedObjectsRepositoryMock.create> | undefined
   ) => {
     ({ server, httpSetup } = await setupServer());
     dataSourceClient = opensearchClientMock.createInternalClient();
@@ -530,7 +532,8 @@ describe(`Test connection ${URL} — internalSavedObjects forwarding`, () => {
 
   it('forwards internalSavedObjects when editing non-credential fields with stored password (username_password reuse flow)', async () => {
     const internalRepo = savedObjectsRepositoryMock.create();
-    await setupRoute(() => internalRepo);
+    const getInternalSavedObjects = jest.fn(() => internalRepo);
+    await setupRoute(getInternalSavedObjects);
 
     await supertest(httpSetup.server.listener)
       .post(URL)
@@ -545,6 +548,7 @@ describe(`Test connection ${URL} — internalSavedObjects forwarding`, () => {
         internalSavedObjects: internalRepo,
       })
     );
+    expect(getInternalSavedObjects).toHaveBeenCalledWith(expect.anything());
   });
 
   it('forwards internalSavedObjects when editing non-credential fields with stored SigV4 keys (sigv4 reuse flow)', async () => {

--- a/src/plugins/data_source/server/routes/test_connection.ts
+++ b/src/plugins/data_source/server/routes/test_connection.ts
@@ -9,6 +9,7 @@ import {
   ISavedObjectsRepository,
   Logger,
   OpenSearchClient,
+  OpenSearchDashboardsRequest,
 } from 'opensearch-dashboards/server';
 import { AuthType, DataSourceAttributes, SigV4ServiceName } from '../../common/data_sources';
 import { DataSourceConnectionValidator } from './data_source_connection_validator';
@@ -27,7 +28,9 @@ export const registerTestConnectionRoute = async (
   logger: Logger,
   endpointDeniedIPs?: string[],
   endpointAllowlistedSuffixes?: string[],
-  getInternalSavedObjects?: () => ISavedObjectsRepository | undefined
+  getInternalSavedObjects?: (
+    request: OpenSearchDashboardsRequest
+  ) => ISavedObjectsRepository | undefined
 ) => {
   const authRegistry = await authRegistryPromise;
   router.post(
@@ -111,7 +114,7 @@ export const registerTestConnectionRoute = async (
         const dataSourceClient: OpenSearchClient = await dataSourceServiceSetup.getDataSourceClient(
           {
             savedObjects: context.core.savedObjects.client,
-            internalSavedObjects: getInternalSavedObjects?.(),
+            internalSavedObjects: getInternalSavedObjects?.(request),
             cryptography,
             dataSourceId,
             testClientDataSourceAttr: dataSourceAttr as DataSourceAttributes,


### PR DESCRIPTION
### Description

Use a request-scoped raw Saved Objects repository when data source clients re-fetch encrypted credentials.

The scoped Saved Objects client still performs the initial authorization check. The raw repository then bypasses the credential-stripping wrapper while retaining the incoming request, including the active OpenSearch Security tenant. This prevents the second lookup from falling back to the Global tenant.

The same repository factory is used for:

- modern data source clients;
- legacy data source clients;
- test connection requests that reuse stored credentials;
- metadata requests that reuse stored credentials.

### Issues Resolved

Fixes #12680

## Screenshot

Not applicable; this is a server-side fix with no UI changes.

## Testing the changes

- Added unit coverage that verifies modern and legacy clients create the raw repository with the incoming request.
- Updated route tests to verify that validate and metadata routes forward their incoming request to the repository factory.
- Ran Prettier 3.5.3 on all changed files.
- Validated the equivalent compiled-code patch in a deployed OpenSearch Dashboards 3.8.0 custom image: data sources in custom Security tenants resolve successfully, while the unpatched image reports `Saved object [data-source/<id>] not found`.

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest` (the local sparse checkout does not contain the full bootstrapped monorepo; added focused tests are expected to run in CI)
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] Documentation is not required because this restores existing custom-tenant behavior.
- [x] Commits are signed per the DCO using `--signoff`.
