### PR TITLE
fix(metrics): keep prometheus series distinct by metric name

### DIFF
--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.test.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.test.ts
@@ -361,6 +361,56 @@ describe('promqlSearchStrategy', () => {
       expect(new Set(seriesField?.values).size).toBe(2);
     });
 
+    it('keeps series distinct by __name__ when a legendFormat template collapses them to one name', async () => {
+      const mockPrometheusResponse = {
+        queryId: 'query-1',
+        sessionId: 'session-1',
+        results: {
+          'dataset-1': {
+            resultType: 'matrix',
+            result: [
+              {
+                metric: { __name__: 'http_requests_total', job: 'api' },
+                values: [[1638316800, 1]],
+              },
+              { metric: { __name__: 'http_errors_total', job: 'api' }, values: [[1638316800, 2]] },
+            ],
+          },
+        },
+      };
+
+      mockPrometheusManagerQuery(mockPrometheusResponse);
+      const strategy = promqlSearchStrategyProvider(config$, logger, usage);
+      const result = await strategy.search(
+        emptyRequestHandlerContext,
+        {
+          body: {
+            query: {
+              query: '{job="api"}',
+              dataset: { id: 'dataset-1' },
+              language: 'PROMQL',
+            },
+            options: {
+              perQueryOptions: [{ legendFormat: '{{job}}' }],
+            },
+            timeRange: {
+              from: '2021-12-01T00:00:00.000Z',
+              to: '2021-12-01T01:00:00.000Z',
+            },
+          },
+        } as unknown as IOpenSearchDashboardsSearchRequest<unknown>,
+        {}
+      );
+
+      // @ts-expect-error TS2339, TS7006 TODO(ts-error): fixme
+      const seriesField = result.body.fields.find((f) => f.name === 'Series');
+      expect(seriesField?.values).toEqual([
+        'api {__name__="http_requests_total"}',
+        'api {__name__="http_errors_total"}',
+      ]);
+      expect(new Set(seriesField?.values).size).toBe(2);
+    });
+
     it('should create instant schema with all label keys', async () => {
       const mockPrometheusResponse = {
         queryId: 'query-1',

--- a/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/promql_search_strategy.ts
@@ -297,11 +297,9 @@ function distinguishingLabelKeysByTemplatedName(
     if (seriesIndex >= MAX_SERIES_TABLE) return;
     const name = interpolateLegendFormat(legendTemplate, metricResult.metric).trim();
     if (!name) return;
-    const labels = { ...metricResult.metric };
-    delete labels.__name__;
     const group = groups.get(name);
-    if (group) group.push(labels);
-    else groups.set(name, [labels]);
+    if (group) group.push(metricResult.metric);
+    else groups.set(name, [metricResult.metric]);
   });
 
   const distinguishing = new Map<string, string[]>();
@@ -395,7 +393,8 @@ function createDataFrame(
         if (differing?.length) {
           const distinguishing: Record<string, string> = {};
           differing.forEach((key) => {
-            if (labelsWithoutName[key] !== undefined) distinguishing[key] = labelsWithoutName[key];
+            if (metricResult.metric[key] !== undefined)
+              distinguishing[key] = metricResult.metric[key];
           });
           baseName = `${templatedName} ${formatMetricLabels(distinguishing)}`;
         } else {


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12644#discussion_r3892105481

### Issues Resolved

https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12644#discussion_r3892105481

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
