### PR TITLE
Saved object annotation

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -377,6 +377,12 @@
 # if the security plugin is not installed and this config is true, permission control takes no effect.
 # savedObjects.permission.enabled: true
 
+# Enable the saved object annotation framework.
+# savedObjects.annotations.enabled: true
+
+# Enable saved object tags. This also requires savedObjects.annotations.enabled.
+# savedObjectTags.enabled: true
+
 # uiSettings:
 #   overrides:
 #     "home:useNewHomePage": true

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -369,6 +369,20 @@ export interface CoreStart {
 }
 
 export {
+  AddSavedObjectAnnotationToObjectInput,
+  CreateSavedObjectAnnotationInput,
+  DeleteSavedObjectAnnotationInput,
+  FindSavedObjectAnnotationsOptions,
+  GetSavedObjectAnnotationsForObjectInput,
+  RemoveSavedObjectAnnotationFromObjectInput,
+  SavedObjectAnnotation,
+  SavedObjectAnnotationService,
+  SavedObjectAnnotationTarget,
+  SAVED_OBJECT_ANNOTATION_TYPE,
+  UpdateSavedObjectAnnotationInput,
+} from '../types';
+
+export {
   Capabilities,
   ChromeBadge,
   ChromeBreadcrumb,

--- a/src/core/public/index.ts
+++ b/src/core/public/index.ts
@@ -379,6 +379,7 @@ export {
   SavedObjectAnnotationService,
   SavedObjectAnnotationTarget,
   SAVED_OBJECT_ANNOTATION_TYPE,
+  SetSavedObjectAnnotationsForObjectInput,
   UpdateSavedObjectAnnotationInput,
 } from '../types';
 

--- a/src/core/public/saved_objects/index.ts
+++ b/src/core/public/saved_objects/index.ts
@@ -41,6 +41,7 @@ export {
   SavedObjectsBulkUpdateOptions,
 } from './saved_objects_client';
 export { SimpleSavedObject } from './simple_saved_object';
+export { SavedObjectAnnotationClient } from './saved_object_annotation_client';
 export { SavedObjectsStart, SavedObjectsService } from './saved_objects_service';
 export {
   SavedObjectsBaseOptions,

--- a/src/core/public/saved_objects/saved_object_annotation_client.test.ts
+++ b/src/core/public/saved_objects/saved_object_annotation_client.test.ts
@@ -37,4 +37,24 @@ describe('SavedObjectAnnotationClient', () => {
       query: { type: 'tag' },
     });
   });
+
+  it('replaces object annotations through the set transport', async () => {
+    const http = httpServiceMock.createStartContract();
+    const client = new SavedObjectAnnotationClient(http);
+    const input = {
+      annotationIds: ['tag-1', 'tag-2'],
+      type: 'tag',
+      target: {
+        objectType: 'dashboard',
+        objectId: 'dashboard-1',
+      },
+    };
+
+    await client.setAnnotationsForObject(input);
+
+    expect(http.fetch).toHaveBeenCalledWith('/internal/saved_object_annotations/_set_for_object', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  });
 });

--- a/src/core/public/saved_objects/saved_object_annotation_client.test.ts
+++ b/src/core/public/saved_objects/saved_object_annotation_client.test.ts
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { httpServiceMock } from '../http/http_service.mock';
+import { SavedObjectAnnotationClient } from './saved_object_annotation_client';
+
+describe('SavedObjectAnnotationClient', () => {
+  it('uses the internal annotation transport', async () => {
+    const http = httpServiceMock.createStartContract();
+    http.fetch.mockResolvedValue([]);
+    const client = new SavedObjectAnnotationClient(http);
+
+    await client.findAnnotations({ type: 'tag' });
+
+    expect(http.fetch).toHaveBeenCalledWith('/internal/saved_object_annotations/_find', {
+      method: 'POST',
+      body: JSON.stringify({ type: 'tag' }),
+    });
+  });
+
+  it('encodes annotation IDs when deleting', async () => {
+    const http = httpServiceMock.createStartContract();
+    const client = new SavedObjectAnnotationClient(http);
+
+    await client.deleteAnnotation({ type: 'tag', annotationId: 'tag/1' });
+
+    expect(http.fetch).toHaveBeenCalledWith('/internal/saved_object_annotations/tag%2F1', {
+      method: 'DELETE',
+      query: { type: 'tag' },
+    });
+  });
+});

--- a/src/core/public/saved_objects/saved_object_annotation_client.ts
+++ b/src/core/public/saved_objects/saved_object_annotation_client.ts
@@ -18,6 +18,7 @@ import {
   RemoveSavedObjectAnnotationFromObjectInput,
   SavedObjectAnnotation,
   SavedObjectAnnotationService,
+  SetSavedObjectAnnotationsForObjectInput,
   UpdateSavedObjectAnnotationInput,
 } from '../../types';
 import { HttpSetup } from '../http';
@@ -74,6 +75,15 @@ export class SavedObjectAnnotationClient implements SavedObjectAnnotationService
     input: RemoveSavedObjectAnnotationFromObjectInput
   ): Promise<void> {
     await this.http.fetch(`${API_BASE_URL}/_detach`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  public async setAnnotationsForObject(
+    input: SetSavedObjectAnnotationsForObjectInput
+  ): Promise<void> {
+    await this.http.fetch(`${API_BASE_URL}/_set_for_object`, {
       method: 'POST',
       body: JSON.stringify(input),
     });

--- a/src/core/public/saved_objects/saved_object_annotation_client.ts
+++ b/src/core/public/saved_objects/saved_object_annotation_client.ts
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  AddSavedObjectAnnotationToObjectInput,
+  CreateSavedObjectAnnotationInput,
+  DeleteSavedObjectAnnotationInput,
+  FindSavedObjectAnnotationsOptions,
+  GetSavedObjectAnnotationsForObjectInput,
+  RemoveSavedObjectAnnotationFromObjectInput,
+  SavedObjectAnnotation,
+  SavedObjectAnnotationService,
+  UpdateSavedObjectAnnotationInput,
+} from '../../types';
+import { HttpSetup } from '../http';
+
+const API_BASE_URL = '/internal/saved_object_annotations';
+
+export class SavedObjectAnnotationClient implements SavedObjectAnnotationService {
+  constructor(private readonly http: HttpSetup) {}
+
+  public createAnnotation(input: CreateSavedObjectAnnotationInput): Promise<SavedObjectAnnotation> {
+    return this.http.fetch(API_BASE_URL, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  public updateAnnotation({
+    annotationId,
+    ...input
+  }: UpdateSavedObjectAnnotationInput): Promise<SavedObjectAnnotation> {
+    return this.http.fetch(`${API_BASE_URL}/${encodeURIComponent(annotationId)}`, {
+      method: 'PUT',
+      body: JSON.stringify(input),
+    });
+  }
+
+  public async deleteAnnotation({
+    annotationId,
+    type,
+  }: DeleteSavedObjectAnnotationInput): Promise<void> {
+    await this.http.fetch(`${API_BASE_URL}/${encodeURIComponent(annotationId)}`, {
+      method: 'DELETE',
+      query: { type },
+    });
+  }
+
+  public findAnnotations(
+    options: FindSavedObjectAnnotationsOptions
+  ): Promise<SavedObjectAnnotation[]> {
+    return this.http.fetch(`${API_BASE_URL}/_find`, {
+      method: 'POST',
+      body: JSON.stringify(options),
+    });
+  }
+
+  public async addAnnotationToObject(input: AddSavedObjectAnnotationToObjectInput): Promise<void> {
+    await this.http.fetch(`${API_BASE_URL}/_attach`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  public async removeAnnotationFromObject(
+    input: RemoveSavedObjectAnnotationFromObjectInput
+  ): Promise<void> {
+    await this.http.fetch(`${API_BASE_URL}/_detach`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+
+  public getAnnotationsForObject(
+    input: GetSavedObjectAnnotationsForObjectInput
+  ): Promise<SavedObjectAnnotation[]> {
+    return this.http.fetch(`${API_BASE_URL}/_get_for_object`, {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  }
+}

--- a/src/core/public/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/public/saved_objects/saved_objects_service.mock.ts
@@ -32,6 +32,15 @@ import { SavedObjectsService, SavedObjectsStart } from './saved_objects_service'
 
 const createStartContractMock = () => {
   const mock: jest.Mocked<SavedObjectsStart> = {
+    annotations: {
+      createAnnotation: jest.fn(),
+      updateAnnotation: jest.fn(),
+      deleteAnnotation: jest.fn(),
+      findAnnotations: jest.fn(),
+      addAnnotationToObject: jest.fn(),
+      removeAnnotationFromObject: jest.fn(),
+      getAnnotationsForObject: jest.fn(),
+    },
     client: {
       create: jest.fn(),
       bulkCreate: jest.fn(),

--- a/src/core/public/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/public/saved_objects/saved_objects_service.mock.ts
@@ -39,6 +39,7 @@ const createStartContractMock = () => {
       findAnnotations: jest.fn(),
       addAnnotationToObject: jest.fn(),
       removeAnnotationFromObject: jest.fn(),
+      setAnnotationsForObject: jest.fn(),
       getAnnotationsForObject: jest.fn(),
     },
     client: {

--- a/src/core/public/saved_objects/saved_objects_service.ts
+++ b/src/core/public/saved_objects/saved_objects_service.ts
@@ -31,6 +31,8 @@
 import { CoreService } from 'src/core/types';
 import { CoreStart } from 'src/core/public';
 import { SavedObjectsClient, SavedObjectsClientContract } from './saved_objects_client';
+import { SavedObjectAnnotationService } from '../../types';
+import { SavedObjectAnnotationClient } from './saved_object_annotation_client';
 
 /**
  * @public
@@ -38,12 +40,16 @@ import { SavedObjectsClient, SavedObjectsClientContract } from './saved_objects_
 export interface SavedObjectsStart {
   /** {@link SavedObjectsClient} */
   client: SavedObjectsClientContract;
+  annotations: SavedObjectAnnotationService;
 }
 
 export class SavedObjectsService implements CoreService<void, SavedObjectsStart> {
   public async setup() {}
   public async start({ http }: { http: CoreStart['http'] }): Promise<SavedObjectsStart> {
-    return { client: new SavedObjectsClient(http) };
+    return {
+      client: new SavedObjectsClient(http),
+      annotations: new SavedObjectAnnotationClient(http),
+    };
   }
   public async stop() {}
 }

--- a/src/core/server/core_route_handler_context.test.ts
+++ b/src/core/server/core_route_handler_context.test.ts
@@ -182,9 +182,10 @@ describe('#savedObjects', () => {
       const request = httpServerMock.createOpenSearchDashboardsRequest();
       const coreStart = coreMock.createInternalStart();
       const context = new CoreRouteHandlerContext(coreStart, request);
+      const getAnnotationClient = jest.mocked(coreStart.savedObjects.annotations.getClient);
 
       const annotations = context.savedObjects.annotations;
-      expect(annotations).toBe(coreStart.savedObjects.annotations.getClient.mock.results[0].value);
+      expect(annotations).toBe(getAnnotationClient.mock.results[0].value);
     });
 
     test('lazily created', () => {
@@ -202,11 +203,12 @@ describe('#savedObjects', () => {
       const request = httpServerMock.createOpenSearchDashboardsRequest();
       const coreStart = coreMock.createInternalStart();
       const context = new CoreRouteHandlerContext(coreStart, request);
+      const getAnnotationClient = jest.mocked(coreStart.savedObjects.annotations.getClient);
 
       const annotations1 = context.savedObjects.annotations;
       const annotations2 = context.savedObjects.annotations;
       expect(coreStart.savedObjects.annotations.getClient).toHaveBeenCalledTimes(1);
-      const mockResult = coreStart.savedObjects.annotations.getClient.mock.results[0].value;
+      const mockResult = getAnnotationClient.mock.results[0].value;
       expect(annotations1).toBe(mockResult);
       expect(annotations2).toBe(mockResult);
     });

--- a/src/core/server/core_route_handler_context.test.ts
+++ b/src/core/server/core_route_handler_context.test.ts
@@ -177,6 +177,41 @@ describe('#savedObjects', () => {
     });
   });
 
+  describe('#annotations', () => {
+    test('returns the results of coreStart.savedObjects.annotations.getClient', () => {
+      const request = httpServerMock.createOpenSearchDashboardsRequest();
+      const coreStart = coreMock.createInternalStart();
+      const context = new CoreRouteHandlerContext(coreStart, request);
+
+      const annotations = context.savedObjects.annotations;
+      expect(annotations).toBe(coreStart.savedObjects.annotations.getClient.mock.results[0].value);
+    });
+
+    test('lazily created', () => {
+      const request = httpServerMock.createOpenSearchDashboardsRequest();
+      const coreStart = coreMock.createInternalStart();
+      const context = new CoreRouteHandlerContext(coreStart, request);
+
+      expect(coreStart.savedObjects.annotations.getClient).not.toHaveBeenCalled();
+      const annotations = context.savedObjects.annotations;
+      expect(coreStart.savedObjects.annotations.getClient).toHaveBeenCalledWith(request);
+      expect(annotations).toBeDefined();
+    });
+
+    test('only creates one instance', () => {
+      const request = httpServerMock.createOpenSearchDashboardsRequest();
+      const coreStart = coreMock.createInternalStart();
+      const context = new CoreRouteHandlerContext(coreStart, request);
+
+      const annotations1 = context.savedObjects.annotations;
+      const annotations2 = context.savedObjects.annotations;
+      expect(coreStart.savedObjects.annotations.getClient).toHaveBeenCalledTimes(1);
+      const mockResult = coreStart.savedObjects.annotations.getClient.mock.results[0].value;
+      expect(annotations1).toBe(mockResult);
+      expect(annotations2).toBe(mockResult);
+    });
+  });
+
   describe('#typeRegistry', () => {
     test('returns the results of coreStart.savedObjects.getTypeRegistry', () => {
       const request = httpServerMock.createOpenSearchDashboardsRequest();

--- a/src/core/server/core_route_handler_context.ts
+++ b/src/core/server/core_route_handler_context.ts
@@ -33,6 +33,7 @@ import { InternalCoreStart } from './internal_types';
 import { OpenSearchDashboardsRequest } from './http/router';
 import { SavedObjectsClientContract } from './saved_objects/types';
 import { InternalSavedObjectsServiceStart, ISavedObjectTypeRegistry } from './saved_objects';
+import { SavedObjectAnnotationService } from '../types';
 import {
   InternalOpenSearchServiceStart,
   IScopedClusterClient,
@@ -80,6 +81,7 @@ class CoreSavedObjectsRouteHandlerContext {
     private readonly request: OpenSearchDashboardsRequest
   ) {}
   #scopedSavedObjectsClient?: SavedObjectsClientContract;
+  #scopedSavedObjectAnnotationClient?: SavedObjectAnnotationService;
   #typeRegistry?: ISavedObjectTypeRegistry;
 
   public get client() {
@@ -87,6 +89,15 @@ class CoreSavedObjectsRouteHandlerContext {
       this.#scopedSavedObjectsClient = this.savedObjectsStart.getScopedClient(this.request);
     }
     return this.#scopedSavedObjectsClient;
+  }
+
+  public get annotations() {
+    if (this.#scopedSavedObjectAnnotationClient == null) {
+      this.#scopedSavedObjectAnnotationClient = this.savedObjectsStart.annotations.getClient(
+        this.request
+      );
+    }
+    return this.#scopedSavedObjectAnnotationClient;
   }
 
   public get typeRegistry() {

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -389,6 +389,7 @@ export {
   SavedObjectAnnotationService,
   SavedObjectAnnotationTarget,
   SAVED_OBJECT_ANNOTATION_TYPE,
+  SetSavedObjectAnnotationsForObjectInput,
   UpdateSavedObjectAnnotationInput,
   WorkspaceFindOptions,
   WorkspacePermissionMode,

--- a/src/core/server/index.ts
+++ b/src/core/server/index.ts
@@ -84,6 +84,7 @@ import { AppenderConfigType, appendersSchema, LoggingServiceSetup } from './logg
 import { CoreUsageDataStart } from './core_usage_data';
 import { SecurityServiceSetup } from './security/types';
 import { CrossCompatibilityServiceStart } from './cross_compatibility/types';
+import { SavedObjectAnnotationService } from '../types';
 
 // Because of #79265 we need to explicity import, then export these types for
 // scripts/telemetry_check.js to work as expected
@@ -374,10 +375,21 @@ export {
 } from './metrics';
 
 export {
+  AddSavedObjectAnnotationToObjectInput,
   AppCategory,
+  CreateSavedObjectAnnotationInput,
+  DeleteSavedObjectAnnotationInput,
+  FindSavedObjectAnnotationsOptions,
+  GetSavedObjectAnnotationsForObjectInput,
   WorkspaceAttribute,
   WorkspaceCreateResult,
   PermissionModeId,
+  RemoveSavedObjectAnnotationFromObjectInput,
+  SavedObjectAnnotation,
+  SavedObjectAnnotationService,
+  SavedObjectAnnotationTarget,
+  SAVED_OBJECT_ANNOTATION_TYPE,
+  UpdateSavedObjectAnnotationInput,
   WorkspaceFindOptions,
   WorkspacePermissionMode,
 } from '../types';
@@ -438,6 +450,7 @@ export interface RequestHandlerContext {
   core: {
     savedObjects: {
       client: SavedObjectsClientContract;
+      annotations: SavedObjectAnnotationService;
       typeRegistry: ISavedObjectTypeRegistry;
     };
     opensearch: {

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -283,6 +283,7 @@ export class LegacyService implements CoreService {
         getOpsMetrics$: setupDeps.core.metrics.getOpsMetrics$,
       },
       savedObjects: {
+        annotations: setupDeps.core.savedObjects.annotations,
         setClientFactoryProvider: setupDeps.core.savedObjects.setClientFactoryProvider,
         addClientWrapper: setupDeps.core.savedObjects.addClientWrapper,
         registerType: setupDeps.core.savedObjects.registerType,

--- a/src/core/server/legacy/legacy_service.ts
+++ b/src/core/server/legacy/legacy_service.ts
@@ -218,6 +218,7 @@ export class LegacyService implements CoreService {
         getServerInfo: startDeps.core.http.getServerInfo,
       },
       savedObjects: {
+        annotations: startDeps.core.savedObjects.annotations,
         getScopedClient: startDeps.core.savedObjects.getScopedClient,
         createScopedRepository: startDeps.core.savedObjects.createScopedRepository,
         createInternalRepository: startDeps.core.savedObjects.createInternalRepository,

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -246,6 +246,7 @@ function createCoreRequestHandlerContextMock() {
         findAnnotations: jest.fn(),
         addAnnotationToObject: jest.fn(),
         removeAnnotationFromObject: jest.fn(),
+        setAnnotationsForObject: jest.fn(),
         getAnnotationsForObject: jest.fn(),
       },
       typeRegistry: savedObjectsTypeRegistryMock.create(),

--- a/src/core/server/mocks.ts
+++ b/src/core/server/mocks.ts
@@ -239,6 +239,15 @@ function createCoreRequestHandlerContextMock() {
   return {
     savedObjects: {
       client: savedObjectsClientMock.create(),
+      annotations: {
+        createAnnotation: jest.fn(),
+        updateAnnotation: jest.fn(),
+        deleteAnnotation: jest.fn(),
+        findAnnotations: jest.fn(),
+        addAnnotationToObject: jest.fn(),
+        removeAnnotationFromObject: jest.fn(),
+        getAnnotationsForObject: jest.fn(),
+      },
       typeRegistry: savedObjectsTypeRegistryMock.create(),
     },
     opensearch: {

--- a/src/core/server/plugins/plugin_context.ts
+++ b/src/core/server/plugins/plugin_context.ts
@@ -203,6 +203,7 @@ export function createPluginSetupContext<TPlugin, TPluginDependencies>(
       getOpsMetrics$: deps.metrics.getOpsMetrics$,
     },
     savedObjects: {
+      annotations: deps.savedObjects.annotations,
       setClientFactoryProvider: deps.savedObjects.setClientFactoryProvider,
       addClientWrapper: deps.savedObjects.addClientWrapper,
       registerType: deps.savedObjects.registerType,
@@ -267,6 +268,7 @@ export function createPluginStartContext<TPlugin, TPluginDependencies>(
       getServerInfo: deps.http.getServerInfo,
     },
     savedObjects: {
+      annotations: deps.savedObjects.annotations,
       getScopedClient: deps.savedObjects.getScopedClient,
       createInternalRepository: deps.savedObjects.createInternalRepository,
       createScopedRepository: deps.savedObjects.createScopedRepository,

--- a/src/core/server/saved_objects/annotations/index.ts
+++ b/src/core/server/saved_objects/annotations/index.ts
@@ -1,0 +1,24 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+export {
+  SavedObjectAnnotationsSetup,
+  SavedObjectAnnotationTypeRegistration,
+  SavedObjectAnnotationTypeRegistry,
+} from './registry';
+export { SavedObjectAnnotationServiceImpl } from './service';
+export { savedObjectAnnotationType, SavedObjectAnnotationAttributes } from './saved_object_type';
+export {
+  ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+  ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+  annotationReferencePreservationWrapper,
+} from './reference_preservation_wrapper';
+export { registerSavedObjectAnnotationRoutes } from './routes';

--- a/src/core/server/saved_objects/annotations/reference_preservation_wrapper.test.ts
+++ b/src/core/server/saved_objects/annotations/reference_preservation_wrapper.test.ts
@@ -10,10 +10,161 @@
  */
 
 import { savedObjectsClientMock } from '../service/saved_objects_client.mock';
+import { SavedObjectsErrorHelpers } from '../service/lib/errors';
 import { SAVED_OBJECT_ANNOTATION_TYPE } from '../../../types';
 import { annotationReferencePreservationWrapper } from './reference_preservation_wrapper';
 
 describe('annotationReferencePreservationWrapper', () => {
+  it('keeps persisted annotation references on overwrite create', async () => {
+    const client = savedObjectsClientMock.create();
+    client.get.mockResolvedValue({
+      id: 'dashboard-1',
+      type: 'dashboard',
+      attributes: {},
+      references: [
+        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+        { name: 'panel_0', type: 'visualization', id: 'old-vis' },
+      ],
+    });
+    client.create.mockResolvedValue({} as any);
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    await wrapper.create(
+      'dashboard',
+      { title: 'Updated' },
+      {
+        id: 'dashboard-1',
+        overwrite: true,
+        references: [{ name: 'panel_0', type: 'visualization', id: 'new-vis' }],
+      }
+    );
+
+    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
+    expect(client.create).toHaveBeenCalledWith(
+      'dashboard',
+      { title: 'Updated' },
+      {
+        id: 'dashboard-1',
+        overwrite: true,
+        references: [
+          { name: 'panel_0', type: 'visualization', id: 'new-vis' },
+          { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+        ],
+      }
+    );
+  });
+
+  it('allows overwrite create when the saved object does not exist', async () => {
+    const client = savedObjectsClientMock.create();
+    client.get.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError('dashboard', 'dashboard-1')
+    );
+    client.create.mockResolvedValue({} as any);
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+    const references = [{ name: 'panel_0', type: 'visualization', id: 'vis-1' }];
+
+    await wrapper.create(
+      'dashboard',
+      { title: 'New dashboard' },
+      {
+        id: 'dashboard-1',
+        overwrite: true,
+        references,
+      }
+    );
+
+    expect(client.create).toHaveBeenCalledWith(
+      'dashboard',
+      { title: 'New dashboard' },
+      {
+        id: 'dashboard-1',
+        overwrite: true,
+        references,
+      }
+    );
+  });
+
+  it('does not read the persisted object for a non-overwrite create', async () => {
+    const client = savedObjectsClientMock.create();
+    client.create.mockResolvedValue({} as any);
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    await wrapper.create(
+      'dashboard',
+      { title: 'New dashboard' },
+      {
+        id: 'dashboard-1',
+        references: [{ name: 'panel_0', type: 'visualization', id: 'vis-1' }],
+      }
+    );
+
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('keeps persisted annotation references on bulk overwrite create', async () => {
+    const client = savedObjectsClientMock.create();
+    client.get.mockResolvedValue({
+      id: 'dashboard-1',
+      type: 'dashboard',
+      attributes: {},
+      references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' }],
+    });
+    client.bulkCreate.mockResolvedValue({ saved_objects: [] });
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    await wrapper.bulkCreate(
+      [
+        {
+          type: 'dashboard',
+          id: 'dashboard-1',
+          attributes: { title: 'Updated' },
+          references: [{ name: 'panel_0', type: 'visualization', id: 'vis-1' }],
+        },
+        {
+          type: 'visualization',
+          attributes: { title: 'New visualization' },
+        },
+      ],
+      { overwrite: true }
+    );
+
+    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
+    expect(client.bulkCreate).toHaveBeenCalledWith(
+      [
+        {
+          type: 'dashboard',
+          id: 'dashboard-1',
+          attributes: { title: 'Updated' },
+          references: [
+            { name: 'panel_0', type: 'visualization', id: 'vis-1' },
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+          ],
+        },
+        {
+          type: 'visualization',
+          attributes: { title: 'New visualization' },
+        },
+      ],
+      { overwrite: true }
+    );
+  });
+
   it('keeps persisted annotation references on update', async () => {
     const client = savedObjectsClientMock.create();
     client.get.mockResolvedValue({
@@ -44,6 +195,7 @@ describe('annotationReferencePreservationWrapper', () => {
       }
     );
 
+    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
     expect(client.update).toHaveBeenCalledWith(
       'dashboard',
       'dashboard-1',
@@ -106,7 +258,7 @@ describe('annotationReferencePreservationWrapper', () => {
       },
     ]);
 
-    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
     expect(client.bulkUpdate).toHaveBeenCalledWith(
       [
         {

--- a/src/core/server/saved_objects/annotations/reference_preservation_wrapper.test.ts
+++ b/src/core/server/saved_objects/annotations/reference_preservation_wrapper.test.ts
@@ -10,20 +10,23 @@
  */
 
 import { savedObjectsClientMock } from '../service/saved_objects_client.mock';
-import { SavedObjectsErrorHelpers } from '../service/lib/errors';
 import { SAVED_OBJECT_ANNOTATION_TYPE } from '../../../types';
 import { annotationReferencePreservationWrapper } from './reference_preservation_wrapper';
 
 describe('annotationReferencePreservationWrapper', () => {
   it('keeps persisted annotation references on overwrite create', async () => {
     const client = savedObjectsClientMock.create();
-    client.get.mockResolvedValue({
-      id: 'dashboard-1',
-      type: 'dashboard',
-      attributes: {},
-      references: [
-        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
-        { name: 'panel_0', type: 'visualization', id: 'old-vis' },
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          attributes: {},
+          references: [
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+            { name: 'panel_0', type: 'visualization', id: 'old-vis' },
+          ],
+        },
       ],
     });
     client.create.mockResolvedValue({} as any);
@@ -43,7 +46,7 @@ describe('annotationReferencePreservationWrapper', () => {
       }
     );
 
-    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
+    expect(client.bulkGet).toHaveBeenCalledWith([{ type: 'dashboard', id: 'dashboard-1' }]);
     expect(client.create).toHaveBeenCalledWith(
       'dashboard',
       { title: 'Updated' },
@@ -60,9 +63,19 @@ describe('annotationReferencePreservationWrapper', () => {
 
   it('allows overwrite create when the saved object does not exist', async () => {
     const client = savedObjectsClientMock.create();
-    client.get.mockRejectedValue(
-      SavedObjectsErrorHelpers.createGenericNotFoundError('dashboard', 'dashboard-1')
-    );
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          error: {
+            error: 'Not Found',
+            message: 'Saved object [dashboard/dashboard-1] not found',
+            statusCode: 404,
+          },
+        } as any,
+      ],
+    });
     client.create.mockResolvedValue({} as any);
     const wrapper = annotationReferencePreservationWrapper({
       client,
@@ -81,6 +94,7 @@ describe('annotationReferencePreservationWrapper', () => {
       }
     );
 
+    expect(client.bulkGet).toHaveBeenCalledWith([{ type: 'dashboard', id: 'dashboard-1' }]);
     expect(client.create).toHaveBeenCalledWith(
       'dashboard',
       { title: 'New dashboard' },
@@ -110,16 +124,26 @@ describe('annotationReferencePreservationWrapper', () => {
       }
     );
 
-    expect(client.get).not.toHaveBeenCalled();
+    expect(client.bulkGet).not.toHaveBeenCalled();
   });
 
-  it('keeps persisted annotation references on bulk overwrite create', async () => {
+  it('uses one read to keep persisted annotation references on bulk overwrite create', async () => {
     const client = savedObjectsClientMock.create();
-    client.get.mockResolvedValue({
-      id: 'dashboard-1',
-      type: 'dashboard',
-      attributes: {},
-      references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' }],
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          attributes: {},
+          references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' }],
+        },
+        {
+          id: 'visualization-1',
+          type: 'visualization',
+          attributes: {},
+          references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' }],
+        },
+      ],
     });
     client.bulkCreate.mockResolvedValue({ saved_objects: [] });
     const wrapper = annotationReferencePreservationWrapper({
@@ -138,13 +162,23 @@ describe('annotationReferencePreservationWrapper', () => {
         },
         {
           type: 'visualization',
-          attributes: { title: 'New visualization' },
+          id: 'visualization-1',
+          attributes: { title: 'Updated visualization' },
+          references: [{ name: 'data_0', type: 'index-pattern', id: 'index-pattern-1' }],
+        },
+        {
+          type: 'search',
+          attributes: { title: 'New search' },
         },
       ],
       { overwrite: true }
     );
 
-    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
+    expect(client.bulkGet).toHaveBeenCalledTimes(1);
+    expect(client.bulkGet).toHaveBeenCalledWith([
+      { type: 'dashboard', id: 'dashboard-1' },
+      { type: 'visualization', id: 'visualization-1' },
+    ]);
     expect(client.bulkCreate).toHaveBeenCalledWith(
       [
         {
@@ -158,7 +192,16 @@ describe('annotationReferencePreservationWrapper', () => {
         },
         {
           type: 'visualization',
-          attributes: { title: 'New visualization' },
+          id: 'visualization-1',
+          attributes: { title: 'Updated visualization' },
+          references: [
+            { name: 'data_0', type: 'index-pattern', id: 'index-pattern-1' },
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' },
+          ],
+        },
+        {
+          type: 'search',
+          attributes: { title: 'New search' },
         },
       ],
       { overwrite: true }
@@ -167,13 +210,17 @@ describe('annotationReferencePreservationWrapper', () => {
 
   it('keeps persisted annotation references on update', async () => {
     const client = savedObjectsClientMock.create();
-    client.get.mockResolvedValue({
-      id: 'dashboard-1',
-      type: 'dashboard',
-      attributes: {},
-      references: [
-        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
-        { name: 'panel_0', type: 'visualization', id: 'old-vis' },
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          attributes: {},
+          references: [
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+            { name: 'panel_0', type: 'visualization', id: 'old-vis' },
+          ],
+        },
       ],
     });
     client.update.mockResolvedValue({} as any);
@@ -195,7 +242,7 @@ describe('annotationReferencePreservationWrapper', () => {
       }
     );
 
-    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
+    expect(client.bulkGet).toHaveBeenCalledWith([{ type: 'dashboard', id: 'dashboard-1' }]);
     expect(client.update).toHaveBeenCalledWith(
       'dashboard',
       'dashboard-1',
@@ -220,7 +267,7 @@ describe('annotationReferencePreservationWrapper', () => {
 
     await wrapper.update('dashboard', 'dashboard-1', { title: 'Updated' });
 
-    expect(client.get).not.toHaveBeenCalled();
+    expect(client.bulkGet).not.toHaveBeenCalled();
     expect(client.update).toHaveBeenCalledWith(
       'dashboard',
       'dashboard-1',
@@ -229,13 +276,23 @@ describe('annotationReferencePreservationWrapper', () => {
     );
   });
 
-  it('keeps persisted annotation references on bulk update', async () => {
+  it('uses one read to keep persisted annotation references on bulk update', async () => {
     const client = savedObjectsClientMock.create();
-    client.get.mockResolvedValue({
-      id: 'dashboard-1',
-      type: 'dashboard',
-      attributes: {},
-      references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' }],
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          attributes: {},
+          references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' }],
+        },
+        {
+          id: 'search-1',
+          type: 'search',
+          attributes: {},
+          references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' }],
+        },
+      ],
     });
     client.bulkUpdate.mockResolvedValue({ saved_objects: [] });
     const wrapper = annotationReferencePreservationWrapper({
@@ -256,9 +313,19 @@ describe('annotationReferencePreservationWrapper', () => {
         id: 'visualization-1',
         attributes: { title: 'Updated' },
       },
+      {
+        type: 'search',
+        id: 'search-1',
+        attributes: { title: 'Updated search' },
+        references: [{ name: 'data_0', type: 'index-pattern', id: 'index-pattern-1' }],
+      },
     ]);
 
-    expect(client.get).toHaveBeenCalledWith('dashboard', 'dashboard-1');
+    expect(client.bulkGet).toHaveBeenCalledTimes(1);
+    expect(client.bulkGet).toHaveBeenCalledWith([
+      { type: 'dashboard', id: 'dashboard-1' },
+      { type: 'search', id: 'search-1' },
+    ]);
     expect(client.bulkUpdate).toHaveBeenCalledWith(
       [
         {
@@ -275,8 +342,86 @@ describe('annotationReferencePreservationWrapper', () => {
           id: 'visualization-1',
           attributes: { title: 'Updated' },
         },
+        {
+          type: 'search',
+          id: 'search-1',
+          attributes: { title: 'Updated search' },
+          references: [
+            { name: 'data_0', type: 'index-pattern', id: 'index-pattern-1' },
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' },
+          ],
+        },
       ],
       {}
     );
+  });
+
+  it('lets bulk update report a missing target without blocking valid updates', async () => {
+    const client = savedObjectsClientMock.create();
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          attributes: {},
+          references: [],
+        },
+        {
+          id: 'dashboard-2',
+          type: 'dashboard',
+          error: {
+            error: 'Not Found',
+            message: 'Saved object [dashboard/dashboard-2] not found',
+            statusCode: 404,
+          },
+        } as any,
+      ],
+    });
+    client.bulkUpdate.mockResolvedValue({
+      saved_objects: [
+        {
+          id: 'dashboard-1',
+          type: 'dashboard',
+          attributes: { title: 'First dashboard' },
+          references: [],
+        },
+        {
+          id: 'dashboard-2',
+          type: 'dashboard',
+          attributes: { title: 'Second dashboard' },
+          references: [],
+          error: {
+            error: 'Not Found',
+            message: 'Saved object [dashboard/dashboard-2] not found',
+            statusCode: 404,
+          },
+        },
+      ],
+    });
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    const objects = [
+      {
+        type: 'dashboard',
+        id: 'dashboard-1',
+        attributes: { title: 'First dashboard' },
+        references: [],
+      },
+      {
+        type: 'dashboard',
+        id: 'dashboard-2',
+        attributes: { title: 'Second dashboard' },
+        references: [],
+      },
+    ];
+
+    const result = await wrapper.bulkUpdate(objects);
+
+    expect(client.bulkUpdate).toHaveBeenCalledWith(objects, {});
+    expect(result.saved_objects[1].error?.statusCode).toBe(404);
   });
 });

--- a/src/core/server/saved_objects/annotations/reference_preservation_wrapper.test.ts
+++ b/src/core/server/saved_objects/annotations/reference_preservation_wrapper.test.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { savedObjectsClientMock } from '../service/saved_objects_client.mock';
+import { SAVED_OBJECT_ANNOTATION_TYPE } from '../../../types';
+import { annotationReferencePreservationWrapper } from './reference_preservation_wrapper';
+
+describe('annotationReferencePreservationWrapper', () => {
+  it('keeps persisted annotation references on update', async () => {
+    const client = savedObjectsClientMock.create();
+    client.get.mockResolvedValue({
+      id: 'dashboard-1',
+      type: 'dashboard',
+      attributes: {},
+      references: [
+        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+        { name: 'panel_0', type: 'visualization', id: 'old-vis' },
+      ],
+    });
+    client.update.mockResolvedValue({} as any);
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    await wrapper.update(
+      'dashboard',
+      'dashboard-1',
+      { title: 'Updated' },
+      {
+        references: [
+          { name: 'panel_0', type: 'visualization', id: 'new-vis' },
+          { name: 'annotation_1', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' },
+        ],
+      }
+    );
+
+    expect(client.update).toHaveBeenCalledWith(
+      'dashboard',
+      'dashboard-1',
+      { title: 'Updated' },
+      {
+        references: [
+          { name: 'panel_0', type: 'visualization', id: 'new-vis' },
+          { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+        ],
+      }
+    );
+  });
+
+  it('does not read the persisted object when references are omitted', async () => {
+    const client = savedObjectsClientMock.create();
+    client.update.mockResolvedValue({} as any);
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    await wrapper.update('dashboard', 'dashboard-1', { title: 'Updated' });
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(client.update).toHaveBeenCalledWith(
+      'dashboard',
+      'dashboard-1',
+      { title: 'Updated' },
+      {}
+    );
+  });
+
+  it('keeps persisted annotation references on bulk update', async () => {
+    const client = savedObjectsClientMock.create();
+    client.get.mockResolvedValue({
+      id: 'dashboard-1',
+      type: 'dashboard',
+      attributes: {},
+      references: [{ name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' }],
+    });
+    client.bulkUpdate.mockResolvedValue({ saved_objects: [] });
+    const wrapper = annotationReferencePreservationWrapper({
+      client,
+      request: {} as any,
+      typeRegistry: {} as any,
+    });
+
+    await wrapper.bulkUpdate([
+      {
+        type: 'dashboard',
+        id: 'dashboard-1',
+        attributes: { title: 'Updated' },
+        references: [{ name: 'panel_0', type: 'visualization', id: 'vis-1' }],
+      },
+      {
+        type: 'visualization',
+        id: 'visualization-1',
+        attributes: { title: 'Updated' },
+      },
+    ]);
+
+    expect(client.get).toHaveBeenCalledTimes(1);
+    expect(client.bulkUpdate).toHaveBeenCalledWith(
+      [
+        {
+          type: 'dashboard',
+          id: 'dashboard-1',
+          attributes: { title: 'Updated' },
+          references: [
+            { name: 'panel_0', type: 'visualization', id: 'vis-1' },
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+          ],
+        },
+        {
+          type: 'visualization',
+          id: 'visualization-1',
+          attributes: { title: 'Updated' },
+        },
+      ],
+      {}
+    );
+  });
+});

--- a/src/core/server/saved_objects/annotations/reference_preservation_wrapper.ts
+++ b/src/core/server/saved_objects/annotations/reference_preservation_wrapper.ts
@@ -10,8 +10,11 @@
  */
 
 import {
+  SavedObjectsBulkCreateObject,
   SavedObjectsBulkUpdateObject,
   SavedObjectsClientWrapperFactory,
+  SavedObjectsCreateOptions,
+  SavedObjectsErrorHelpers,
   SavedObjectsUpdateOptions,
 } from '../service';
 import { preserveSavedObjectAnnotationReferences } from './reference_utils';
@@ -23,6 +26,64 @@ export const ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY = Number.MIN_SAF
 export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFactory = ({
   client,
 }) => {
+  const preserveReferences = async (
+    type: string,
+    id: string,
+    incomingReferences: NonNullable<SavedObjectsCreateOptions['references']>
+  ) => {
+    try {
+      const persistedObject = await client.get(type, id);
+      return preserveSavedObjectAnnotationReferences(
+        persistedObject.references,
+        incomingReferences
+      );
+    } catch (error) {
+      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
+        return incomingReferences;
+      }
+      throw error;
+    }
+  };
+
+  const create: typeof client.create = async (
+    type,
+    attributes,
+    options: SavedObjectsCreateOptions = {}
+  ) => {
+    if (!options.overwrite || !options.id || !Array.isArray(options.references)) {
+      return client.create(type, attributes, options);
+    }
+
+    return client.create(type, attributes, {
+      ...options,
+      references: await preserveReferences(type, options.id, options.references),
+    });
+  };
+
+  const bulkCreate: typeof client.bulkCreate = async <T = unknown>(
+    objects: Array<SavedObjectsBulkCreateObject<T>>,
+    options: SavedObjectsCreateOptions = {}
+  ) => {
+    if (!options.overwrite) {
+      return client.bulkCreate(objects, options);
+    }
+
+    const objectsWithPreservedReferences = await Promise.all(
+      objects.map(async (object) => {
+        if (!object.id || !Array.isArray(object.references)) {
+          return object;
+        }
+
+        return {
+          ...object,
+          references: await preserveReferences(object.type, object.id, object.references),
+        };
+      })
+    );
+
+    return client.bulkCreate(objectsWithPreservedReferences, options);
+  };
+
   const update: typeof client.update = async (
     type,
     id,
@@ -33,10 +94,7 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
       return client.update(type, id, attributes, options);
     }
 
-    const persistedObject = await client.get(type, id, {
-      namespace: options.namespace,
-      workspaces: options.workspaces,
-    });
+    const persistedObject = await client.get(type, id);
     return client.update(type, id, attributes, {
       ...options,
       references: preserveSavedObjectAnnotationReferences(
@@ -56,10 +114,7 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
           return object;
         }
 
-        const persistedObject = await client.get(object.type, object.id, {
-          namespace: object.namespace ?? options.namespace,
-          workspaces: object.workspaces,
-        });
+        const persistedObject = await client.get(object.type, object.id);
         return {
           ...object,
           references: preserveSavedObjectAnnotationReferences(
@@ -74,6 +129,8 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
   };
 
   return Object.assign(Object.create(client), {
+    create,
+    bulkCreate,
     update,
     bulkUpdate,
   });

--- a/src/core/server/saved_objects/annotations/reference_preservation_wrapper.ts
+++ b/src/core/server/saved_objects/annotations/reference_preservation_wrapper.ts
@@ -14,7 +14,6 @@ import {
   SavedObjectsBulkUpdateObject,
   SavedObjectsClientWrapperFactory,
   SavedObjectsCreateOptions,
-  SavedObjectsErrorHelpers,
   SavedObjectsUpdateOptions,
 } from '../service';
 import { preserveSavedObjectAnnotationReferences } from './reference_utils';
@@ -26,23 +25,65 @@ export const ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY = Number.MIN_SAF
 export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFactory = ({
   client,
 }) => {
-  const preserveReferences = async (
-    type: string,
-    id: string,
-    incomingReferences: NonNullable<SavedObjectsCreateOptions['references']>
-  ) => {
-    try {
-      const persistedObject = await client.get(type, id);
-      return preserveSavedObjectAnnotationReferences(
-        persistedObject.references,
-        incomingReferences
-      );
-    } catch (error) {
-      if (SavedObjectsErrorHelpers.isNotFoundError(error)) {
-        return incomingReferences;
+  const preserveReferences = async <
+    T extends {
+      type: string;
+      id?: string;
+      references?: SavedObjectsCreateOptions['references'];
+    },
+  >(
+    objects: T[]
+  ): Promise<T[]> => {
+    // Only writes with an ID and an explicit references array can replace existing
+    // annotation references, so objects without either value do not need to be read.
+    const objectIndexesToResolve = objects.reduce<number[]>((indexes, object, index) => {
+      if (object.id && Array.isArray(object.references)) {
+        indexes.push(index);
       }
-      throw error;
+      return indexes;
+    }, []);
+
+    if (!objectIndexesToResolve.length) {
+      return objects;
     }
+
+    // Resolve all target objects in one request so bulk writes do not issue one read
+    // per object. bulkGet returns results in the same order as the requested objects.
+    const { saved_objects: persistedObjects } = await client.bulkGet(
+      objectIndexesToResolve.map((index) => ({
+        type: objects[index].type,
+        id: objects[index].id!,
+      }))
+    );
+    const objectsWithPreservedReferences = [...objects];
+
+    objectIndexesToResolve.forEach((objectIndex, persistedObjectIndex) => {
+      const object = objects[objectIndex];
+      const persistedObject = persistedObjects[persistedObjectIndex];
+
+      if (persistedObject.error) {
+        // A missing target has no annotation references to preserve. Leave it unchanged
+        // and let create, update, or bulkUpdate apply its normal not-found behavior.
+        if (persistedObject.error.statusCode === 404) {
+          return;
+        }
+        // Other lookup errors may hide an existing target, so stop instead of risking
+        // an update that unintentionally removes its annotation references.
+        throw new Error(persistedObject.error.message);
+      }
+
+      // Incoming non-annotation references remain authoritative while persisted
+      // annotation attachments are restored to prevent ordinary saves from removing them.
+      objectsWithPreservedReferences[objectIndex] = {
+        ...object,
+        references: preserveSavedObjectAnnotationReferences(
+          persistedObject.references,
+          object.references!
+        ),
+      };
+    });
+
+    return objectsWithPreservedReferences;
   };
 
   const create: typeof client.create = async (
@@ -54,9 +95,13 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
       return client.create(type, attributes, options);
     }
 
+    const [objectWithPreservedReferences] = await preserveReferences([
+      { type, id: options.id, references: options.references },
+    ]);
+
     return client.create(type, attributes, {
       ...options,
-      references: await preserveReferences(type, options.id, options.references),
+      references: objectWithPreservedReferences.references,
     });
   };
 
@@ -68,18 +113,7 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
       return client.bulkCreate(objects, options);
     }
 
-    const objectsWithPreservedReferences = await Promise.all(
-      objects.map(async (object) => {
-        if (!object.id || !Array.isArray(object.references)) {
-          return object;
-        }
-
-        return {
-          ...object,
-          references: await preserveReferences(object.type, object.id, object.references),
-        };
-      })
-    );
+    const objectsWithPreservedReferences = await preserveReferences(objects);
 
     return client.bulkCreate(objectsWithPreservedReferences, options);
   };
@@ -94,13 +128,13 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
       return client.update(type, id, attributes, options);
     }
 
-    const persistedObject = await client.get(type, id);
+    const [objectWithPreservedReferences] = await preserveReferences([
+      { type, id, references: options.references },
+    ]);
+
     return client.update(type, id, attributes, {
       ...options,
-      references: preserveSavedObjectAnnotationReferences(
-        persistedObject.references,
-        options.references
-      ),
+      references: objectWithPreservedReferences.references,
     });
   };
 
@@ -108,22 +142,7 @@ export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFa
     objects: SavedObjectsBulkUpdateObject[] = [],
     options = {}
   ) => {
-    const objectsWithPreservedReferences = await Promise.all(
-      objects.map(async (object) => {
-        if (!Array.isArray(object.references)) {
-          return object;
-        }
-
-        const persistedObject = await client.get(object.type, object.id);
-        return {
-          ...object,
-          references: preserveSavedObjectAnnotationReferences(
-            persistedObject.references,
-            object.references
-          ),
-        };
-      })
-    );
+    const objectsWithPreservedReferences = await preserveReferences(objects);
 
     return client.bulkUpdate(objectsWithPreservedReferences, options);
   };

--- a/src/core/server/saved_objects/annotations/reference_preservation_wrapper.ts
+++ b/src/core/server/saved_objects/annotations/reference_preservation_wrapper.ts
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  SavedObjectsBulkUpdateObject,
+  SavedObjectsClientWrapperFactory,
+  SavedObjectsUpdateOptions,
+} from '../service';
+import { preserveSavedObjectAnnotationReferences } from './reference_utils';
+
+export const ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID =
+  'saved-object-annotation-reference-preservation';
+export const ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY = Number.MIN_SAFE_INTEGER;
+
+export const annotationReferencePreservationWrapper: SavedObjectsClientWrapperFactory = ({
+  client,
+}) => {
+  const update: typeof client.update = async (
+    type,
+    id,
+    attributes,
+    options: SavedObjectsUpdateOptions = {}
+  ) => {
+    if (!Array.isArray(options.references)) {
+      return client.update(type, id, attributes, options);
+    }
+
+    const persistedObject = await client.get(type, id, {
+      namespace: options.namespace,
+      workspaces: options.workspaces,
+    });
+    return client.update(type, id, attributes, {
+      ...options,
+      references: preserveSavedObjectAnnotationReferences(
+        persistedObject.references,
+        options.references
+      ),
+    });
+  };
+
+  const bulkUpdate: typeof client.bulkUpdate = async (
+    objects: SavedObjectsBulkUpdateObject[] = [],
+    options = {}
+  ) => {
+    const objectsWithPreservedReferences = await Promise.all(
+      objects.map(async (object) => {
+        if (!Array.isArray(object.references)) {
+          return object;
+        }
+
+        const persistedObject = await client.get(object.type, object.id, {
+          namespace: object.namespace ?? options.namespace,
+          workspaces: object.workspaces,
+        });
+        return {
+          ...object,
+          references: preserveSavedObjectAnnotationReferences(
+            persistedObject.references,
+            object.references
+          ),
+        };
+      })
+    );
+
+    return client.bulkUpdate(objectsWithPreservedReferences, options);
+  };
+
+  return Object.assign(Object.create(client), {
+    update,
+    bulkUpdate,
+  });
+};

--- a/src/core/server/saved_objects/annotations/reference_utils.ts
+++ b/src/core/server/saved_objects/annotations/reference_utils.ts
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { SavedObjectReference, SAVED_OBJECT_ANNOTATION_TYPE } from '../../../types';
+
+export const isSavedObjectAnnotationReference = (reference: SavedObjectReference) =>
+  reference.type === SAVED_OBJECT_ANNOTATION_TYPE;
+
+export const preserveSavedObjectAnnotationReferences = (
+  persistedReferences: SavedObjectReference[],
+  incomingReferences: SavedObjectReference[]
+) => [
+  ...incomingReferences.filter((reference) => !isSavedObjectAnnotationReference(reference)),
+  ...persistedReferences.filter(isSavedObjectAnnotationReference),
+];
+
+export const createSavedObjectAnnotationReferenceName = (
+  references: SavedObjectReference[]
+): string => {
+  const referenceNames = new Set(references.map(({ name }) => name));
+  let index = 0;
+  while (referenceNames.has(`annotation_${index}`)) {
+    index += 1;
+  }
+  return `annotation_${index}`;
+};

--- a/src/core/server/saved_objects/annotations/registry.test.ts
+++ b/src/core/server/saved_objects/annotations/registry.test.ts
@@ -17,11 +17,13 @@ describe('SavedObjectAnnotationTypeRegistry', () => {
     registry.register({
       type: 'tag',
       supportedObjectTypes: ['dashboard', 'dashboard', 'visualization'],
+      uniqueName: true,
     });
 
     expect(registry.get('tag')).toEqual({
       type: 'tag',
       supportedObjectTypes: ['dashboard', 'visualization'],
+      uniqueName: true,
     });
   });
 

--- a/src/core/server/saved_objects/annotations/registry.test.ts
+++ b/src/core/server/saved_objects/annotations/registry.test.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { SavedObjectAnnotationTypeRegistry } from './registry';
+
+describe('SavedObjectAnnotationTypeRegistry', () => {
+  it('registers and returns annotation types', () => {
+    const registry = new SavedObjectAnnotationTypeRegistry();
+    registry.register({
+      type: 'tag',
+      supportedObjectTypes: ['dashboard', 'dashboard', 'visualization'],
+    });
+
+    expect(registry.get('tag')).toEqual({
+      type: 'tag',
+      supportedObjectTypes: ['dashboard', 'visualization'],
+    });
+  });
+
+  it('rejects duplicate annotation types', () => {
+    const registry = new SavedObjectAnnotationTypeRegistry();
+    registry.register({ type: 'tag', supportedObjectTypes: ['dashboard'] });
+
+    expect(() =>
+      registry.register({ type: 'tag', supportedObjectTypes: ['visualization'] })
+    ).toThrow("Annotation type 'tag' is already registered");
+  });
+
+  it('rejects unregistered annotation types', () => {
+    const registry = new SavedObjectAnnotationTypeRegistry();
+
+    expect(() => registry.get('tag')).toThrow("Annotation type 'tag' is not registered");
+  });
+});

--- a/src/core/server/saved_objects/annotations/registry.ts
+++ b/src/core/server/saved_objects/annotations/registry.ts
@@ -22,6 +22,7 @@ export interface SavedObjectAnnotationTypeRegistration {
 }
 
 export interface SavedObjectAnnotationsSetup {
+  enabled: boolean;
   registerAnnotationType(registration: SavedObjectAnnotationTypeRegistration): void;
 }
 

--- a/src/core/server/saved_objects/annotations/registry.ts
+++ b/src/core/server/saved_objects/annotations/registry.ts
@@ -14,6 +14,11 @@ import { SavedObjectsErrorHelpers } from '../service/lib/errors';
 export interface SavedObjectAnnotationTypeRegistration {
   type: string;
   supportedObjectTypes: string[];
+  /**
+   * Reject names that match an existing annotation of this type after trimming
+   * whitespace and applying case-insensitive comparison.
+   */
+  uniqueName?: boolean;
 }
 
 export interface SavedObjectAnnotationsSetup {
@@ -24,7 +29,7 @@ export class SavedObjectAnnotationTypeRegistry {
   private readonly registrations = new Map<string, SavedObjectAnnotationTypeRegistration>();
 
   public register(registration: SavedObjectAnnotationTypeRegistration) {
-    const { type, supportedObjectTypes } = registration;
+    const { type, supportedObjectTypes, uniqueName } = registration;
     if (!type) {
       throw new Error('Annotation type must be a non-empty string');
     }
@@ -38,6 +43,7 @@ export class SavedObjectAnnotationTypeRegistry {
     this.registrations.set(type, {
       type,
       supportedObjectTypes: Array.from(new Set(supportedObjectTypes)),
+      ...(uniqueName && { uniqueName }),
     });
   }
 

--- a/src/core/server/saved_objects/annotations/registry.ts
+++ b/src/core/server/saved_objects/annotations/registry.ts
@@ -1,0 +1,53 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { SavedObjectsErrorHelpers } from '../service/lib/errors';
+
+export interface SavedObjectAnnotationTypeRegistration {
+  type: string;
+  supportedObjectTypes: string[];
+}
+
+export interface SavedObjectAnnotationsSetup {
+  registerAnnotationType(registration: SavedObjectAnnotationTypeRegistration): void;
+}
+
+export class SavedObjectAnnotationTypeRegistry {
+  private readonly registrations = new Map<string, SavedObjectAnnotationTypeRegistration>();
+
+  public register(registration: SavedObjectAnnotationTypeRegistration) {
+    const { type, supportedObjectTypes } = registration;
+    if (!type) {
+      throw new Error('Annotation type must be a non-empty string');
+    }
+    if (this.registrations.has(type)) {
+      throw new Error(`Annotation type '${type}' is already registered`);
+    }
+    if (!supportedObjectTypes.length) {
+      throw new Error(`Annotation type '${type}' must support at least one saved object type`);
+    }
+
+    this.registrations.set(type, {
+      type,
+      supportedObjectTypes: Array.from(new Set(supportedObjectTypes)),
+    });
+  }
+
+  public get(type: string): SavedObjectAnnotationTypeRegistration {
+    const registration = this.registrations.get(type);
+    if (!registration) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        `Annotation type '${type}' is not registered`
+      );
+    }
+    return registration;
+  }
+}

--- a/src/core/server/saved_objects/annotations/routes.test.ts
+++ b/src/core/server/saved_objects/annotations/routes.test.ts
@@ -1,0 +1,163 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { httpServerMock } from '../../mocks';
+import { mockRouter } from '../../http/router/router.mock';
+import { registerSavedObjectAnnotationRoutes } from './routes';
+
+describe('saved object annotation routes', () => {
+  const annotation = {
+    id: 'tag-1',
+    type: 'tag',
+    name: 'Production',
+  };
+
+  let annotationService: {
+    createAnnotation: jest.Mock;
+    updateAnnotation: jest.Mock;
+    deleteAnnotation: jest.Mock;
+    findAnnotations: jest.Mock;
+    addAnnotationToObject: jest.Mock;
+    removeAnnotationFromObject: jest.Mock;
+    getAnnotationsForObject: jest.Mock;
+  };
+  let router: ReturnType<typeof mockRouter.create>;
+  let context: any;
+  let response: ReturnType<typeof httpServerMock.createResponseFactory>;
+
+  beforeEach(() => {
+    annotationService = {
+      createAnnotation: jest.fn(),
+      updateAnnotation: jest.fn(),
+      deleteAnnotation: jest.fn(),
+      findAnnotations: jest.fn(),
+      addAnnotationToObject: jest.fn(),
+      removeAnnotationFromObject: jest.fn(),
+      getAnnotationsForObject: jest.fn(),
+    };
+    router = mockRouter.create();
+    context = {
+      core: {
+        savedObjects: {
+          annotations: annotationService,
+        },
+      },
+    };
+    response = httpServerMock.createResponseFactory();
+
+    registerSavedObjectAnnotationRoutes({
+      createRouter: jest.fn().mockReturnValue(router),
+    } as any);
+  });
+
+  const getHandler = (method: 'post' | 'put' | 'delete', path: string) => {
+    const call = router[method].mock.calls.find(([config]) => config.path === path);
+    if (!call) {
+      throw new Error(`Route ${method.toUpperCase()} ${path} was not registered`);
+    }
+    return call[1];
+  };
+
+  it('registers the annotation operation routes', () => {
+    expect(router.post.mock.calls.map(([config]) => config.path)).toEqual([
+      '',
+      '/_find',
+      '/_attach',
+      '/_detach',
+      '/_get_for_object',
+    ]);
+    expect(router.put.mock.calls.map(([config]) => config.path)).toEqual(['/{annotationId}']);
+    expect(router.delete.mock.calls.map(([config]) => config.path)).toEqual(['/{annotationId}']);
+  });
+
+  it('delegates definition operations to the request-scoped annotation service', async () => {
+    annotationService.createAnnotation.mockResolvedValue(annotation);
+    annotationService.updateAnnotation.mockResolvedValue({
+      ...annotation,
+      name: 'Production systems',
+    });
+    annotationService.findAnnotations.mockResolvedValue([annotation]);
+
+    await getHandler('post', '')(
+      context,
+      { body: { type: 'tag', name: 'Production' } } as any,
+      response
+    );
+    await getHandler('put', '/{annotationId}')(
+      context,
+      {
+        params: { annotationId: 'tag-1' },
+        body: { type: 'tag', name: 'Production systems' },
+      } as any,
+      response
+    );
+    await getHandler('post', '/_find')(context, { body: { type: 'tag' } } as any, response);
+    await getHandler('delete', '/{annotationId}')(
+      context,
+      {
+        params: { annotationId: 'tag-1' },
+        query: { type: 'tag' },
+      } as any,
+      response
+    );
+
+    expect(annotationService.createAnnotation).toHaveBeenCalledWith({
+      type: 'tag',
+      name: 'Production',
+    });
+    expect(annotationService.updateAnnotation).toHaveBeenCalledWith({
+      annotationId: 'tag-1',
+      type: 'tag',
+      name: 'Production systems',
+    });
+    expect(annotationService.findAnnotations).toHaveBeenCalledWith({ type: 'tag' });
+    expect(annotationService.deleteAnnotation).toHaveBeenCalledWith({
+      annotationId: 'tag-1',
+      type: 'tag',
+    });
+  });
+
+  it('delegates attachment operations to the request-scoped annotation service', async () => {
+    const target = { objectType: 'dashboard', objectId: 'dashboard-1' };
+    annotationService.getAnnotationsForObject.mockResolvedValue([annotation]);
+
+    await getHandler('post', '/_attach')(
+      context,
+      { body: { annotationId: 'tag-1', type: 'tag', target } } as any,
+      response
+    );
+    await getHandler('post', '/_detach')(
+      context,
+      { body: { annotationId: 'tag-1', type: 'tag', target } } as any,
+      response
+    );
+    await getHandler('post', '/_get_for_object')(
+      context,
+      { body: { type: 'tag', target } } as any,
+      response
+    );
+
+    expect(annotationService.addAnnotationToObject).toHaveBeenCalledWith({
+      annotationId: 'tag-1',
+      type: 'tag',
+      target,
+    });
+    expect(annotationService.removeAnnotationFromObject).toHaveBeenCalledWith({
+      annotationId: 'tag-1',
+      type: 'tag',
+      target,
+    });
+    expect(annotationService.getAnnotationsForObject).toHaveBeenCalledWith({
+      type: 'tag',
+      target,
+    });
+  });
+});

--- a/src/core/server/saved_objects/annotations/routes.test.ts
+++ b/src/core/server/saved_objects/annotations/routes.test.ts
@@ -27,6 +27,7 @@ describe('saved object annotation routes', () => {
     findAnnotations: jest.Mock;
     addAnnotationToObject: jest.Mock;
     removeAnnotationFromObject: jest.Mock;
+    setAnnotationsForObject: jest.Mock;
     getAnnotationsForObject: jest.Mock;
   };
   let router: ReturnType<typeof mockRouter.create>;
@@ -41,6 +42,7 @@ describe('saved object annotation routes', () => {
       findAnnotations: jest.fn(),
       addAnnotationToObject: jest.fn(),
       removeAnnotationFromObject: jest.fn(),
+      setAnnotationsForObject: jest.fn(),
       getAnnotationsForObject: jest.fn(),
     };
     router = mockRouter.create();
@@ -72,6 +74,7 @@ describe('saved object annotation routes', () => {
       '/_find',
       '/_attach',
       '/_detach',
+      '/_set_for_object',
       '/_get_for_object',
     ]);
     expect(router.put.mock.calls.map(([config]) => config.path)).toEqual(['/{annotationId}']);
@@ -139,6 +142,11 @@ describe('saved object annotation routes', () => {
       { body: { annotationId: 'tag-1', type: 'tag', target } } as any,
       response
     );
+    await getHandler('post', '/_set_for_object')(
+      context,
+      { body: { annotationIds: ['tag-1'], type: 'tag', target } } as any,
+      response
+    );
     await getHandler('post', '/_get_for_object')(
       context,
       { body: { type: 'tag', target } } as any,
@@ -152,6 +160,11 @@ describe('saved object annotation routes', () => {
     });
     expect(annotationService.removeAnnotationFromObject).toHaveBeenCalledWith({
       annotationId: 'tag-1',
+      type: 'tag',
+      target,
+    });
+    expect(annotationService.setAnnotationsForObject).toHaveBeenCalledWith({
+      annotationIds: ['tag-1'],
       type: 'tag',
       target,
     });

--- a/src/core/server/saved_objects/annotations/routes.ts
+++ b/src/core/server/saved_objects/annotations/routes.ts
@@ -135,6 +135,23 @@ export const registerSavedObjectAnnotationRoutes = (http: InternalHttpServiceSet
 
   router.post(
     {
+      path: '/_set_for_object',
+      validate: {
+        body: schema.object({
+          annotationIds: schema.arrayOf(schema.string()),
+          type: schema.string(),
+          target: targetSchema,
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      await context.core.savedObjects.annotations.setAnnotationsForObject(request.body);
+      return response.ok();
+    })
+  );
+
+  router.post(
+    {
       path: '/_get_for_object',
       validate: {
         body: schema.object({

--- a/src/core/server/saved_objects/annotations/routes.ts
+++ b/src/core/server/saved_objects/annotations/routes.ts
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { schema } from '@osd/config-schema';
+import { InternalHttpServiceSetup } from '../../http';
+
+const payloadSchema = schema.recordOf(schema.string(), schema.any());
+const targetSchema = schema.object({
+  objectType: schema.string(),
+  objectId: schema.string(),
+});
+
+export const registerSavedObjectAnnotationRoutes = (http: InternalHttpServiceSetup) => {
+  const router = http.createRouter('/internal/saved_object_annotations');
+
+  router.post(
+    {
+      path: '',
+      validate: {
+        body: schema.object({
+          type: schema.string(),
+          name: schema.string(),
+          description: schema.maybe(schema.string()),
+          payload: schema.maybe(payloadSchema),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      const annotation = await context.core.savedObjects.annotations.createAnnotation(request.body);
+      return response.ok({ body: annotation });
+    })
+  );
+
+  router.put(
+    {
+      path: '/{annotationId}',
+      validate: {
+        params: schema.object({
+          annotationId: schema.string(),
+        }),
+        body: schema.object({
+          type: schema.string(),
+          name: schema.maybe(schema.string()),
+          description: schema.maybe(schema.string()),
+          payload: schema.maybe(payloadSchema),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      const annotation = await context.core.savedObjects.annotations.updateAnnotation({
+        annotationId: request.params.annotationId,
+        ...request.body,
+      });
+      return response.ok({ body: annotation });
+    })
+  );
+
+  router.delete(
+    {
+      path: '/{annotationId}',
+      validate: {
+        params: schema.object({
+          annotationId: schema.string(),
+        }),
+        query: schema.object({
+          type: schema.string(),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      await context.core.savedObjects.annotations.deleteAnnotation({
+        annotationId: request.params.annotationId,
+        type: request.query.type,
+      });
+      return response.ok();
+    })
+  );
+
+  router.post(
+    {
+      path: '/_find',
+      validate: {
+        body: schema.object({
+          type: schema.string(),
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      const annotations = await context.core.savedObjects.annotations.findAnnotations(request.body);
+      return response.ok({ body: annotations });
+    })
+  );
+
+  router.post(
+    {
+      path: '/_attach',
+      validate: {
+        body: schema.object({
+          annotationId: schema.string(),
+          type: schema.string(),
+          target: targetSchema,
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      await context.core.savedObjects.annotations.addAnnotationToObject(request.body);
+      return response.ok();
+    })
+  );
+
+  router.post(
+    {
+      path: '/_detach',
+      validate: {
+        body: schema.object({
+          annotationId: schema.string(),
+          type: schema.string(),
+          target: targetSchema,
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      await context.core.savedObjects.annotations.removeAnnotationFromObject(request.body);
+      return response.ok();
+    })
+  );
+
+  router.post(
+    {
+      path: '/_get_for_object',
+      validate: {
+        body: schema.object({
+          type: schema.string(),
+          target: targetSchema,
+        }),
+      },
+    },
+    router.handleLegacyErrors(async (context, request, response) => {
+      const annotations = await context.core.savedObjects.annotations.getAnnotationsForObject(
+        request.body
+      );
+      return response.ok({ body: annotations });
+    })
+  );
+};

--- a/src/core/server/saved_objects/annotations/saved_object_type.ts
+++ b/src/core/server/saved_objects/annotations/saved_object_type.ts
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { SavedObjectsType } from '../types';
+import { SAVED_OBJECT_ANNOTATION_TYPE } from '../../../types';
+
+export interface SavedObjectAnnotationAttributes {
+  type: string;
+  name: string;
+  description?: string;
+  payload?: string;
+}
+
+export const savedObjectAnnotationType: SavedObjectsType = {
+  name: SAVED_OBJECT_ANNOTATION_TYPE,
+  hidden: false,
+  namespaceType: 'single',
+  management: {
+    icon: 'tag',
+    defaultSearchField: 'name',
+    importableAndExportable: true,
+    getTitle(savedObject) {
+      return savedObject.attributes.name;
+    },
+  },
+  mappings: {
+    properties: {
+      type: { type: 'keyword' },
+      name: { type: 'text' },
+      description: { type: 'text' },
+      payload: { type: 'text', index: false },
+    },
+  },
+};

--- a/src/core/server/saved_objects/annotations/service.test.ts
+++ b/src/core/server/saved_objects/annotations/service.test.ts
@@ -1,0 +1,222 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import { SAVED_OBJECT_ANNOTATION_TYPE } from '../../../types';
+import { savedObjectsClientMock } from '../service/saved_objects_client.mock';
+import { SavedObjectsErrorHelpers } from '../service/lib/errors';
+import { SavedObjectAnnotationTypeRegistry } from './registry';
+import { SavedObjectAnnotationServiceImpl } from './service';
+
+const tag = {
+  id: 'tag-1',
+  type: SAVED_OBJECT_ANNOTATION_TYPE,
+  attributes: {
+    type: 'tag',
+    name: 'Production',
+    payload: '{"color":"#54B399"}',
+  },
+  references: [],
+};
+
+const dashboard = {
+  id: 'dashboard-1',
+  type: 'dashboard',
+  attributes: { title: 'Dashboard' },
+  references: [{ name: 'panel_0', type: 'visualization', id: 'vis-1' }],
+};
+
+describe('SavedObjectAnnotationServiceImpl', () => {
+  const registry = new SavedObjectAnnotationTypeRegistry();
+  registry.register({
+    type: 'tag',
+    supportedObjectTypes: ['dashboard', 'visualization'],
+  });
+
+  let client: ReturnType<typeof savedObjectsClientMock.create>;
+  let mutationClient: ReturnType<typeof savedObjectsClientMock.create>;
+  let service: SavedObjectAnnotationServiceImpl;
+
+  beforeEach(() => {
+    client = savedObjectsClientMock.create();
+    mutationClient = savedObjectsClientMock.create();
+    service = new SavedObjectAnnotationServiceImpl(client, mutationClient, registry);
+  });
+
+  it('creates and deserializes an annotation definition', async () => {
+    client.create.mockResolvedValue(tag);
+
+    await expect(
+      service.createAnnotation({
+        type: 'tag',
+        name: 'Production',
+        payload: { color: '#54B399' },
+      })
+    ).resolves.toEqual({
+      id: 'tag-1',
+      type: 'tag',
+      name: 'Production',
+      payload: { color: '#54B399' },
+    });
+    expect(client.create).toHaveBeenCalledWith(SAVED_OBJECT_ANNOTATION_TYPE, {
+      type: 'tag',
+      name: 'Production',
+      payload: '{"color":"#54B399"}',
+    });
+  });
+
+  it('attaches an annotation without replacing other references', async () => {
+    client.get.mockResolvedValue(tag);
+    mutationClient.get.mockResolvedValue(dashboard);
+    mutationClient.update.mockResolvedValue({} as any);
+
+    await service.addAnnotationToObject({
+      type: 'tag',
+      annotationId: 'tag-1',
+      target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+    });
+
+    expect(mutationClient.update).toHaveBeenCalledWith(
+      'dashboard',
+      'dashboard-1',
+      {},
+      {
+        references: [
+          ...dashboard.references,
+          {
+            name: 'annotation_0',
+            type: SAVED_OBJECT_ANNOTATION_TYPE,
+            id: 'tag-1',
+          },
+        ],
+      }
+    );
+  });
+
+  it('removes an unresolved annotation reference', async () => {
+    client.get.mockRejectedValue(
+      SavedObjectsErrorHelpers.createGenericNotFoundError(
+        SAVED_OBJECT_ANNOTATION_TYPE,
+        'missing-tag'
+      )
+    );
+    mutationClient.get.mockResolvedValue({
+      ...dashboard,
+      references: [
+        ...dashboard.references,
+        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'missing-tag' },
+      ],
+    });
+    mutationClient.update.mockResolvedValue({} as any);
+
+    await service.removeAnnotationFromObject({
+      type: 'tag',
+      annotationId: 'missing-tag',
+      target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+    });
+
+    expect(client.get).toHaveBeenCalledWith(SAVED_OBJECT_ANNOTATION_TYPE, 'missing-tag');
+    expect(mutationClient.update).toHaveBeenCalledWith(
+      'dashboard',
+      'dashboard-1',
+      {},
+      { references: dashboard.references }
+    );
+  });
+
+  it('rejects removal when the stored annotation type does not match', async () => {
+    client.get.mockResolvedValue({
+      ...tag,
+      attributes: {
+        ...tag.attributes,
+        type: 'note',
+      },
+    });
+
+    await expect(
+      service.removeAnnotationFromObject({
+        type: 'tag',
+        annotationId: 'tag-1',
+        target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+      })
+    ).rejects.toThrow("Annotation 'tag-1' is not of type 'tag'");
+    expect(mutationClient.get).not.toHaveBeenCalled();
+  });
+
+  it('returns resolved annotations in target reference order', async () => {
+    client.get.mockResolvedValue({
+      ...dashboard,
+      references: [
+        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' },
+        { name: 'annotation_1', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+      ],
+    });
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        tag,
+        {
+          ...tag,
+          id: 'tag-2',
+          attributes: { type: 'tag', name: 'Executive' },
+        },
+      ],
+    });
+
+    await expect(
+      service.getAnnotationsForObject({
+        type: 'tag',
+        target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+      })
+    ).resolves.toEqual([
+      { id: 'tag-2', type: 'tag', name: 'Executive' },
+      {
+        id: 'tag-1',
+        type: 'tag',
+        name: 'Production',
+        payload: { color: '#54B399' },
+      },
+    ]);
+  });
+
+  it('cleans target references before deleting a definition', async () => {
+    client.get.mockResolvedValue(tag);
+    client.find.mockResolvedValue({
+      saved_objects: [
+        {
+          ...dashboard,
+          references: [
+            ...dashboard.references,
+            { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+          ],
+          score: 1,
+        },
+      ],
+      total: 1,
+      page: 1,
+      per_page: 1000,
+    });
+    mutationClient.bulkUpdate.mockResolvedValue({
+      saved_objects: [],
+    });
+    client.delete.mockResolvedValue({});
+
+    await service.deleteAnnotation({ type: 'tag', annotationId: 'tag-1' });
+
+    expect(mutationClient.bulkUpdate).toHaveBeenCalledWith([
+      {
+        type: 'dashboard',
+        id: 'dashboard-1',
+        attributes: {},
+        references: dashboard.references,
+      },
+    ]);
+    expect(client.delete).toHaveBeenCalledWith(SAVED_OBJECT_ANNOTATION_TYPE, 'tag-1');
+  });
+});

--- a/src/core/server/saved_objects/annotations/service.test.ts
+++ b/src/core/server/saved_objects/annotations/service.test.ts
@@ -96,6 +96,21 @@ describe('SavedObjectAnnotationServiceImpl', () => {
     expect(client.create).not.toHaveBeenCalled();
   });
 
+  it('rejects creating an annotation with a blank name', async () => {
+    client.create.mockResolvedValue({
+      ...tag,
+      attributes: { ...tag.attributes, name: '   ' },
+    });
+
+    await expect(
+      service.createAnnotation({
+        type: 'tag',
+        name: '   ',
+      })
+    ).rejects.toThrow('Annotation name must be a non-empty string');
+    expect(client.create).not.toHaveBeenCalled();
+  });
+
   it('rejects renaming an annotation to an existing name', async () => {
     client.get.mockResolvedValue(tag);
     client.find.mockResolvedValue({
@@ -119,6 +134,23 @@ describe('SavedObjectAnnotationServiceImpl', () => {
         name: ' executive ',
       })
     ).rejects.toThrow("An annotation of type 'tag' named 'executive' already exists");
+    expect(client.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects renaming an annotation to a blank name', async () => {
+    client.get.mockResolvedValue(tag);
+    client.update.mockResolvedValue({
+      ...tag,
+      attributes: { ...tag.attributes, name: '   ' },
+    });
+
+    await expect(
+      service.updateAnnotation({
+        annotationId: 'tag-1',
+        type: 'tag',
+        name: '   ',
+      })
+    ).rejects.toThrow('Annotation name must be a non-empty string');
     expect(client.update).not.toHaveBeenCalled();
   });
 

--- a/src/core/server/saved_objects/annotations/service.test.ts
+++ b/src/core/server/saved_objects/annotations/service.test.ts
@@ -38,6 +38,7 @@ describe('SavedObjectAnnotationServiceImpl', () => {
   registry.register({
     type: 'tag',
     supportedObjectTypes: ['dashboard', 'visualization'],
+    uniqueName: true,
   });
 
   let client: ReturnType<typeof savedObjectsClientMock.create>;
@@ -47,6 +48,12 @@ describe('SavedObjectAnnotationServiceImpl', () => {
   beforeEach(() => {
     client = savedObjectsClientMock.create();
     mutationClient = savedObjectsClientMock.create();
+    client.find.mockResolvedValue({
+      saved_objects: [],
+      total: 0,
+      page: 1,
+      per_page: 1000,
+    });
     service = new SavedObjectAnnotationServiceImpl(client, mutationClient, registry);
   });
 
@@ -69,6 +76,79 @@ describe('SavedObjectAnnotationServiceImpl', () => {
       type: 'tag',
       name: 'Production',
       payload: '{"color":"#54B399"}',
+    });
+  });
+
+  it('rejects a duplicate annotation name ignoring case and surrounding whitespace', async () => {
+    client.find.mockResolvedValue({
+      saved_objects: [{ ...tag, score: 1 }],
+      total: 1,
+      page: 1,
+      per_page: 1000,
+    });
+
+    await expect(
+      service.createAnnotation({
+        type: 'tag',
+        name: ' production ',
+      })
+    ).rejects.toThrow("An annotation of type 'tag' named 'production' already exists");
+    expect(client.create).not.toHaveBeenCalled();
+  });
+
+  it('rejects renaming an annotation to an existing name', async () => {
+    client.get.mockResolvedValue(tag);
+    client.find.mockResolvedValue({
+      saved_objects: [
+        {
+          ...tag,
+          id: 'tag-2',
+          attributes: { type: 'tag', name: 'Executive' },
+          score: 1,
+        },
+      ],
+      total: 1,
+      page: 1,
+      per_page: 1000,
+    });
+
+    await expect(
+      service.updateAnnotation({
+        annotationId: 'tag-1',
+        type: 'tag',
+        name: ' executive ',
+      })
+    ).rejects.toThrow("An annotation of type 'tag' named 'executive' already exists");
+    expect(client.update).not.toHaveBeenCalled();
+  });
+
+  it('allows an annotation to retain its own normalized name', async () => {
+    client.get.mockResolvedValue(tag);
+    client.find.mockResolvedValue({
+      saved_objects: [{ ...tag, score: 1 }],
+      total: 1,
+      page: 1,
+      per_page: 1000,
+    });
+    client.update.mockResolvedValue({
+      ...tag,
+      attributes: {
+        ...tag.attributes,
+        name: ' production ',
+      },
+    });
+
+    await expect(
+      service.updateAnnotation({
+        annotationId: 'tag-1',
+        type: 'tag',
+        name: ' production ',
+      })
+    ).resolves.toEqual({
+      id: 'tag-1',
+      type: 'tag',
+      name: ' production ',
+      payload: { color: '#54B399' },
     });
   });
 

--- a/src/core/server/saved_objects/annotations/service.test.ts
+++ b/src/core/server/saved_objects/annotations/service.test.ts
@@ -211,6 +211,130 @@ describe('SavedObjectAnnotationServiceImpl', () => {
     );
   });
 
+  it('replaces annotations of one type while preserving other references', async () => {
+    const tag2 = {
+      ...tag,
+      id: 'tag-2',
+      attributes: {
+        ...tag.attributes,
+        name: 'Executive',
+      },
+    };
+    const tag3 = {
+      ...tag,
+      id: 'tag-3',
+      attributes: {
+        ...tag.attributes,
+        name: 'Operations',
+      },
+    };
+    const note = {
+      ...tag,
+      id: 'note-1',
+      attributes: {
+        type: 'note',
+        name: 'Reviewed',
+      },
+    };
+    const targetObject = {
+      ...dashboard,
+      references: [
+        ...dashboard.references,
+        { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+        { name: 'annotation_1', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' },
+        { name: 'annotation_2', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'note-1' },
+        { name: 'annotation_3', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'missing-tag' },
+        { name: 'annotation_4', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'restricted-note' },
+      ],
+    };
+    mutationClient.get.mockResolvedValue(targetObject);
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        tag,
+        tag2,
+        note,
+        {
+          id: 'missing-tag',
+          type: SAVED_OBJECT_ANNOTATION_TYPE,
+          attributes: {},
+          references: [],
+          error: {
+            statusCode: 404,
+            error: 'Not Found',
+            message: 'Saved object not found',
+          },
+        },
+        {
+          id: 'restricted-note',
+          type: SAVED_OBJECT_ANNOTATION_TYPE,
+          attributes: {},
+          references: [],
+          error: {
+            statusCode: 403,
+            error: 'Forbidden',
+            message: 'Unable to read annotation',
+          },
+        },
+        tag3,
+      ],
+    });
+    mutationClient.update.mockResolvedValue({} as any);
+
+    await service.setAnnotationsForObject({
+      annotationIds: ['tag-1', 'tag-3'],
+      type: 'tag',
+      target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+    });
+
+    expect(client.bulkGet).toHaveBeenCalledWith([
+      { type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+      { type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-2' },
+      { type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'note-1' },
+      { type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'missing-tag' },
+      { type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'restricted-note' },
+      { type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-3' },
+    ]);
+    expect(mutationClient.update).toHaveBeenCalledWith(
+      'dashboard',
+      'dashboard-1',
+      {},
+      {
+        references: [
+          ...dashboard.references,
+          { name: 'annotation_2', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'note-1' },
+          { name: 'annotation_4', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'restricted-note' },
+          { name: 'annotation_0', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-1' },
+          { name: 'annotation_1', type: SAVED_OBJECT_ANNOTATION_TYPE, id: 'tag-3' },
+        ],
+      }
+    );
+  });
+
+  it('rejects setting an annotation whose stored type does not match', async () => {
+    mutationClient.get.mockResolvedValue(dashboard);
+    client.bulkGet.mockResolvedValue({
+      saved_objects: [
+        {
+          ...tag,
+          id: 'note-1',
+          attributes: {
+            type: 'note',
+            name: 'Reviewed',
+          },
+        },
+      ],
+    });
+
+    await expect(
+      service.setAnnotationsForObject({
+        annotationIds: ['note-1'],
+        type: 'tag',
+        target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+      })
+    ).rejects.toThrow("Annotation 'note-1' is not of type 'tag'");
+    expect(mutationClient.update).not.toHaveBeenCalled();
+  });
+
   it('rejects removal when the stored annotation type does not match', async () => {
     client.get.mockResolvedValue({
       ...tag,

--- a/src/core/server/saved_objects/annotations/service.ts
+++ b/src/core/server/saved_objects/annotations/service.ts
@@ -41,6 +41,15 @@ const hasOwn = (object: object, property: string) =>
 
 const normalizeAnnotationName = (name: string) => name.trim().toLowerCase();
 
+const validateAnnotationName = (name: string) => {
+  // Preserve the original display name while requiring at least one non-whitespace character.
+  if (!name.trim()) {
+    throw SavedObjectsErrorHelpers.createBadRequestError(
+      'Annotation name must be a non-empty string'
+    );
+  }
+};
+
 export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationService {
   constructor(
     private readonly client: SavedObjectsClientContract,
@@ -52,6 +61,7 @@ export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationSe
     input: CreateSavedObjectAnnotationInput
   ): Promise<SavedObjectAnnotation> {
     const registration = this.registry.get(input.type);
+    validateAnnotationName(input.name);
     await this.ensureUniqueName(registration, input.name);
     const savedObject = await this.client.create<SavedObjectAnnotationAttributes>(
       SAVED_OBJECT_ANNOTATION_TYPE,
@@ -68,6 +78,7 @@ export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationSe
     const attributes: Partial<SavedObjectAnnotationAttributes> = {};
 
     if (hasOwn(input, 'name') && input.name !== undefined) {
+      validateAnnotationName(input.name);
       await this.ensureUniqueName(registration, input.name, input.annotationId);
       attributes.name = input.name;
     }

--- a/src/core/server/saved_objects/annotations/service.ts
+++ b/src/core/server/saved_objects/annotations/service.ts
@@ -19,6 +19,7 @@ import {
   SavedObjectAnnotation,
   SavedObjectAnnotationService,
   SAVED_OBJECT_ANNOTATION_TYPE,
+  SetSavedObjectAnnotationsForObjectInput,
   UpdateSavedObjectAnnotationInput,
 } from '../../../types';
 import { SavedObject, SavedObjectsClientContract } from '../types';
@@ -195,6 +196,93 @@ export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationSe
       return;
     }
 
+    await this.mutationClient.update(
+      target.objectType,
+      target.objectId,
+      {},
+      {
+        references,
+      }
+    );
+  }
+
+  public async setAnnotationsForObject({
+    annotationIds,
+    type,
+    target,
+  }: SetSavedObjectAnnotationsForObjectInput): Promise<void> {
+    // 1. Validate the target and load its current references.
+    this.validateTarget(type, target.objectType);
+    const targetObject = await this.mutationClient.get(target.objectType, target.objectId);
+    const selectedAnnotationIds = new Set(annotationIds);
+
+    // 2. Resolve current annotations to preserve other types and detect 404 orphan references,
+    // and resolve selected annotations so they can be validated.
+    const annotationIdsToResolve = new Set(
+      targetObject.references.filter(isSavedObjectAnnotationReference).map(({ id }) => id)
+    );
+    selectedAnnotationIds.forEach((annotationId) => annotationIdsToResolve.add(annotationId));
+    const annotations = annotationIdsToResolve.size
+      ? (
+          await this.client.bulkGet<SavedObjectAnnotationAttributes>(
+            Array.from(annotationIdsToResolve, (id) => ({
+              type: SAVED_OBJECT_ANNOTATION_TYPE,
+              id,
+            }))
+          )
+        ).saved_objects
+      : [];
+    const annotationsById = new Map(annotations.map((annotation) => [annotation.id, annotation]));
+
+    // 3. Validate that every selected annotation exists and belongs to the requested type.
+    selectedAnnotationIds.forEach((annotationId) => {
+      const annotation = annotationsById.get(annotationId);
+      if (!annotation || annotation.error?.statusCode === 404) {
+        throw SavedObjectsErrorHelpers.createGenericNotFoundError(
+          SAVED_OBJECT_ANNOTATION_TYPE,
+          annotationId
+        );
+      }
+      if (annotation.error) {
+        throw new Error(annotation.error.message);
+      }
+      if (annotation.attributes.type !== type) {
+        throw SavedObjectsErrorHelpers.createBadRequestError(
+          `Annotation '${annotationId}' is not of type '${type}'`
+        );
+      }
+    });
+
+    // 4. Preserve unrelated references while removing this type and missing annotations.
+    const references = targetObject.references.filter((reference) => {
+      if (!isSavedObjectAnnotationReference(reference)) {
+        return true;
+      }
+
+      const annotation = annotationsById.get(reference.id);
+      // Only missing definitions are orphaned; other lookup errors must not delete references.
+      if (!annotation || annotation.error?.statusCode === 404) {
+        return false;
+      }
+      if (annotation.error) {
+        return true;
+      }
+      if (annotation.attributes.type !== type) {
+        return true;
+      }
+      return false;
+    });
+
+    // 5. Add the complete selected annotation set with fresh reference names.
+    selectedAnnotationIds.forEach((annotationId) => {
+      references.push({
+        name: createSavedObjectAnnotationReferenceName(references),
+        type: SAVED_OBJECT_ANNOTATION_TYPE,
+        id: annotationId,
+      });
+    });
+
+    // 6. Persist the rebuilt references in one target update.
     await this.mutationClient.update(
       target.objectType,
       target.objectId,

--- a/src/core/server/saved_objects/annotations/service.ts
+++ b/src/core/server/saved_objects/annotations/service.ts
@@ -1,0 +1,298 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+import {
+  AddSavedObjectAnnotationToObjectInput,
+  CreateSavedObjectAnnotationInput,
+  DeleteSavedObjectAnnotationInput,
+  FindSavedObjectAnnotationsOptions,
+  GetSavedObjectAnnotationsForObjectInput,
+  RemoveSavedObjectAnnotationFromObjectInput,
+  SavedObjectAnnotation,
+  SavedObjectAnnotationService,
+  SAVED_OBJECT_ANNOTATION_TYPE,
+  UpdateSavedObjectAnnotationInput,
+} from '../../../types';
+import { SavedObject, SavedObjectsClientContract, SavedObjectsFindResponse } from '../types';
+import { SavedObjectsErrorHelpers } from '../service/lib/errors';
+import { SavedObjectAnnotationTypeRegistry } from './registry';
+import { SavedObjectAnnotationAttributes } from './saved_object_type';
+import {
+  createSavedObjectAnnotationReferenceName,
+  isSavedObjectAnnotationReference,
+} from './reference_utils';
+
+const FIND_PAGE_SIZE = 1000;
+
+const hasOwn = (object: object, property: string) =>
+  Object.prototype.hasOwnProperty.call(object, property);
+
+export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationService {
+  constructor(
+    private readonly client: SavedObjectsClientContract,
+    private readonly mutationClient: SavedObjectsClientContract,
+    private readonly registry: SavedObjectAnnotationTypeRegistry
+  ) {}
+
+  public async createAnnotation(
+    input: CreateSavedObjectAnnotationInput
+  ): Promise<SavedObjectAnnotation> {
+    this.registry.get(input.type);
+    const savedObject = await this.client.create<SavedObjectAnnotationAttributes>(
+      SAVED_OBJECT_ANNOTATION_TYPE,
+      this.serializeCreateInput(input)
+    );
+    return this.deserialize(savedObject);
+  }
+
+  public async updateAnnotation(
+    input: UpdateSavedObjectAnnotationInput
+  ): Promise<SavedObjectAnnotation> {
+    this.registry.get(input.type);
+    const existing = await this.getAndValidateAnnotation(input.annotationId, input.type);
+    const attributes: Partial<SavedObjectAnnotationAttributes> = {};
+
+    if (hasOwn(input, 'name')) {
+      attributes.name = input.name;
+    }
+    if (hasOwn(input, 'description')) {
+      attributes.description = input.description;
+    }
+    if (hasOwn(input, 'payload')) {
+      attributes.payload = JSON.stringify(input.payload);
+    }
+
+    const updated = await this.client.update<SavedObjectAnnotationAttributes>(
+      SAVED_OBJECT_ANNOTATION_TYPE,
+      input.annotationId,
+      attributes
+    );
+
+    return this.deserialize({
+      ...existing,
+      ...updated,
+      attributes: {
+        ...existing.attributes,
+        ...updated.attributes,
+      },
+      references: existing.references,
+    });
+  }
+
+  public async deleteAnnotation(input: DeleteSavedObjectAnnotationInput): Promise<void> {
+    const registration = this.registry.get(input.type);
+    await this.getAndValidateAnnotation(input.annotationId, input.type);
+
+    const targets = await this.findAll({
+      type: registration.supportedObjectTypes,
+      hasReference: {
+        type: SAVED_OBJECT_ANNOTATION_TYPE,
+        id: input.annotationId,
+      },
+    });
+
+    if (targets.length) {
+      const result = await this.mutationClient.bulkUpdate(
+        targets.map((target) => ({
+          type: target.type,
+          id: target.id,
+          attributes: {},
+          references: target.references.filter(
+            (reference) =>
+              !(isSavedObjectAnnotationReference(reference) && reference.id === input.annotationId)
+          ),
+        }))
+      );
+      const failedUpdate = result.saved_objects.find(({ error }) => error);
+      if (failedUpdate?.error) {
+        throw new Error(failedUpdate.error.message);
+      }
+    }
+
+    await this.client.delete(SAVED_OBJECT_ANNOTATION_TYPE, input.annotationId);
+  }
+
+  public async findAnnotations({
+    type,
+  }: FindSavedObjectAnnotationsOptions): Promise<SavedObjectAnnotation[]> {
+    this.registry.get(type);
+    const savedObjects = await this.findAll<SavedObjectAnnotationAttributes>({
+      type: SAVED_OBJECT_ANNOTATION_TYPE,
+      filter: `${SAVED_OBJECT_ANNOTATION_TYPE}.attributes.type: ${JSON.stringify(type)}`,
+    });
+    return savedObjects.map((savedObject) => this.deserialize(savedObject));
+  }
+
+  public async addAnnotationToObject({
+    annotationId,
+    type,
+    target,
+  }: AddSavedObjectAnnotationToObjectInput): Promise<void> {
+    this.validateTarget(type, target.objectType);
+    await this.getAndValidateAnnotation(annotationId, type);
+    const targetObject = await this.mutationClient.get(target.objectType, target.objectId);
+
+    if (
+      targetObject.references.some(
+        (reference) => isSavedObjectAnnotationReference(reference) && reference.id === annotationId
+      )
+    ) {
+      return;
+    }
+
+    await this.mutationClient.update(
+      target.objectType,
+      target.objectId,
+      {},
+      {
+        references: [
+          ...targetObject.references,
+          {
+            name: createSavedObjectAnnotationReferenceName(targetObject.references),
+            type: SAVED_OBJECT_ANNOTATION_TYPE,
+            id: annotationId,
+          },
+        ],
+      }
+    );
+  }
+
+  public async removeAnnotationFromObject({
+    annotationId,
+    type,
+    target,
+  }: RemoveSavedObjectAnnotationFromObjectInput): Promise<void> {
+    this.validateTarget(type, target.objectType);
+    try {
+      await this.getAndValidateAnnotation(annotationId, type);
+    } catch (error) {
+      if (!SavedObjectsErrorHelpers.isNotFoundError(error)) {
+        throw error;
+      }
+    }
+
+    const targetObject = await this.mutationClient.get(target.objectType, target.objectId);
+    const references = targetObject.references.filter(
+      (reference) => !(isSavedObjectAnnotationReference(reference) && reference.id === annotationId)
+    );
+
+    if (references.length === targetObject.references.length) {
+      return;
+    }
+
+    await this.mutationClient.update(
+      target.objectType,
+      target.objectId,
+      {},
+      {
+        references,
+      }
+    );
+  }
+
+  public async getAnnotationsForObject({
+    type,
+    target,
+  }: GetSavedObjectAnnotationsForObjectInput): Promise<SavedObjectAnnotation[]> {
+    this.validateTarget(type, target.objectType);
+    const targetObject = await this.client.get(target.objectType, target.objectId);
+    const annotationReferences = targetObject.references.filter(isSavedObjectAnnotationReference);
+
+    if (!annotationReferences.length) {
+      return [];
+    }
+
+    const response = await this.client.bulkGet<SavedObjectAnnotationAttributes>(
+      annotationReferences.map(({ id }) => ({
+        type: SAVED_OBJECT_ANNOTATION_TYPE,
+        id,
+      }))
+    );
+    const annotations = new Map(
+      response.saved_objects
+        .filter(
+          (savedObject): savedObject is SavedObject<SavedObjectAnnotationAttributes> =>
+            !savedObject.error && savedObject.attributes?.type === type
+        )
+        .map((savedObject) => [savedObject.id, this.deserialize(savedObject)])
+    );
+
+    return annotationReferences
+      .map(({ id }) => annotations.get(id))
+      .filter((annotation): annotation is SavedObjectAnnotation => annotation !== undefined);
+  }
+
+  private validateTarget(type: string, objectType: string) {
+    const registration = this.registry.get(type);
+    if (!registration.supportedObjectTypes.includes(objectType)) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        `Annotation type '${type}' does not support saved object type '${objectType}'`
+      );
+    }
+  }
+
+  private async getAndValidateAnnotation(annotationId: string, type: string) {
+    const savedObject = await this.client.get<SavedObjectAnnotationAttributes>(
+      SAVED_OBJECT_ANNOTATION_TYPE,
+      annotationId
+    );
+    if (savedObject.attributes.type !== type) {
+      throw SavedObjectsErrorHelpers.createBadRequestError(
+        `Annotation '${annotationId}' is not of type '${type}'`
+      );
+    }
+    return savedObject;
+  }
+
+  private serializeCreateInput(
+    input: CreateSavedObjectAnnotationInput
+  ): SavedObjectAnnotationAttributes {
+    return {
+      type: input.type,
+      name: input.name,
+      ...(input.description !== undefined && { description: input.description }),
+      ...(input.payload !== undefined && { payload: JSON.stringify(input.payload) }),
+    };
+  }
+
+  private deserialize(
+    savedObject: SavedObject<SavedObjectAnnotationAttributes>
+  ): SavedObjectAnnotation {
+    const { type, name, description, payload } = savedObject.attributes;
+    return {
+      id: savedObject.id,
+      type,
+      name,
+      ...(description !== undefined && { description }),
+      ...(payload !== undefined && { payload: JSON.parse(payload) }),
+    };
+  }
+
+  private async findAll<T = unknown>(
+    options: Omit<Parameters<SavedObjectsClientContract['find']>[0], 'page' | 'perPage'>
+  ): Promise<Array<SavedObject<T>>> {
+    const savedObjects: Array<SavedObject<T>> = [];
+    let page = 1;
+    let response: SavedObjectsFindResponse<T>;
+
+    do {
+      response = await this.client.find<T>({
+        ...options,
+        page,
+        perPage: FIND_PAGE_SIZE,
+      });
+      savedObjects.push(...response.saved_objects);
+      page += 1;
+    } while (savedObjects.length < response.total);
+
+    return savedObjects;
+  }
+}

--- a/src/core/server/saved_objects/annotations/service.ts
+++ b/src/core/server/saved_objects/annotations/service.ts
@@ -21,9 +21,12 @@ import {
   SAVED_OBJECT_ANNOTATION_TYPE,
   UpdateSavedObjectAnnotationInput,
 } from '../../../types';
-import { SavedObject, SavedObjectsClientContract, SavedObjectsFindResponse } from '../types';
-import { SavedObjectsErrorHelpers } from '../service/lib/errors';
-import { SavedObjectAnnotationTypeRegistry } from './registry';
+import { SavedObject, SavedObjectsClientContract } from '../types';
+import { SavedObjectsErrorHelpers, SavedObjectsFindResponse } from '../service';
+import {
+  SavedObjectAnnotationTypeRegistration,
+  SavedObjectAnnotationTypeRegistry,
+} from './registry';
 import { SavedObjectAnnotationAttributes } from './saved_object_type';
 import {
   createSavedObjectAnnotationReferenceName,
@@ -35,6 +38,8 @@ const FIND_PAGE_SIZE = 1000;
 const hasOwn = (object: object, property: string) =>
   Object.prototype.hasOwnProperty.call(object, property);
 
+const normalizeAnnotationName = (name: string) => name.trim().toLowerCase();
+
 export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationService {
   constructor(
     private readonly client: SavedObjectsClientContract,
@@ -45,7 +50,8 @@ export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationSe
   public async createAnnotation(
     input: CreateSavedObjectAnnotationInput
   ): Promise<SavedObjectAnnotation> {
-    this.registry.get(input.type);
+    const registration = this.registry.get(input.type);
+    await this.ensureUniqueName(registration, input.name);
     const savedObject = await this.client.create<SavedObjectAnnotationAttributes>(
       SAVED_OBJECT_ANNOTATION_TYPE,
       this.serializeCreateInput(input)
@@ -56,11 +62,12 @@ export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationSe
   public async updateAnnotation(
     input: UpdateSavedObjectAnnotationInput
   ): Promise<SavedObjectAnnotation> {
-    this.registry.get(input.type);
+    const registration = this.registry.get(input.type);
     const existing = await this.getAndValidateAnnotation(input.annotationId, input.type);
     const attributes: Partial<SavedObjectAnnotationAttributes> = {};
 
-    if (hasOwn(input, 'name')) {
+    if (hasOwn(input, 'name') && input.name !== undefined) {
+      await this.ensureUniqueName(registration, input.name, input.annotationId);
       attributes.name = input.name;
     }
     if (hasOwn(input, 'description')) {
@@ -274,6 +281,36 @@ export class SavedObjectAnnotationServiceImpl implements SavedObjectAnnotationSe
       ...(description !== undefined && { description }),
       ...(payload !== undefined && { payload: JSON.parse(payload) }),
     };
+  }
+
+  private async ensureUniqueName(
+    registration: SavedObjectAnnotationTypeRegistration,
+    name: string,
+    annotationId?: string
+  ) {
+    if (!registration.uniqueName) {
+      return;
+    }
+
+    const normalizedName = normalizeAnnotationName(name);
+    const annotations = await this.findAll<SavedObjectAnnotationAttributes>({
+      type: SAVED_OBJECT_ANNOTATION_TYPE,
+      filter: `${SAVED_OBJECT_ANNOTATION_TYPE}.attributes.type: ${JSON.stringify(
+        registration.type
+      )}`,
+    });
+    const duplicate = annotations.find(
+      (annotation) =>
+        annotation.id !== annotationId &&
+        normalizeAnnotationName(annotation.attributes.name) === normalizedName
+    );
+
+    if (duplicate) {
+      throw SavedObjectsErrorHelpers.decorateConflictError(
+        new Error('Conflict'),
+        `An annotation of type '${registration.type}' named '${name.trim()}' already exists`
+      );
+    }
   }
 
   private async findAll<T = unknown>(

--- a/src/core/server/saved_objects/index.ts
+++ b/src/core/server/saved_objects/index.ts
@@ -84,5 +84,19 @@ export {
 
 export { savedObjectsConfig, savedObjectsMigrationConfig } from './saved_objects_config';
 export { SavedObjectTypeRegistry, ISavedObjectTypeRegistry } from './saved_objects_type_registry';
+export { SavedObjectAnnotationsSetup, SavedObjectAnnotationTypeRegistration } from './annotations';
+export {
+  AddSavedObjectAnnotationToObjectInput,
+  CreateSavedObjectAnnotationInput,
+  DeleteSavedObjectAnnotationInput,
+  FindSavedObjectAnnotationsOptions,
+  GetSavedObjectAnnotationsForObjectInput,
+  RemoveSavedObjectAnnotationFromObjectInput,
+  SavedObjectAnnotation,
+  SavedObjectAnnotationService,
+  SavedObjectAnnotationTarget,
+  SAVED_OBJECT_ANNOTATION_TYPE,
+  UpdateSavedObjectAnnotationInput,
+} from '../../types';
 
 export { Permissions, ACL, Principals, PrincipalType } from './permission_control/acl';

--- a/src/core/server/saved_objects/index.ts
+++ b/src/core/server/saved_objects/index.ts
@@ -96,6 +96,7 @@ export {
   SavedObjectAnnotationService,
   SavedObjectAnnotationTarget,
   SAVED_OBJECT_ANNOTATION_TYPE,
+  SetSavedObjectAnnotationsForObjectInput,
   UpdateSavedObjectAnnotationInput,
 } from '../../types';
 

--- a/src/core/server/saved_objects/saved_objects_config.test.ts
+++ b/src/core/server/saved_objects/saved_objects_config.test.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { savedObjectsConfig } from './saved_objects_config';
+
+describe('savedObjectsConfig', () => {
+  it('disables annotations by default', () => {
+    expect(savedObjectsConfig.schema.validate({}).annotations.enabled).toBe(false);
+  });
+});

--- a/src/core/server/saved_objects/saved_objects_config.ts
+++ b/src/core/server/saved_objects/saved_objects_config.ts
@@ -65,6 +65,9 @@ export const savedObjectsConfig = {
     permission: schema.object({
       enabled: schema.boolean({ defaultValue: false }),
     }),
+    annotations: schema.object({
+      enabled: schema.boolean({ defaultValue: false }),
+    }),
     storage: schema.object({
       backend: schema.oneOf([schema.literal('opensearch'), schema.literal('sqlite')], {
         defaultValue: 'opensearch',
@@ -84,6 +87,9 @@ export class SavedObjectConfig {
   public permission: {
     enabled: boolean;
   };
+  public annotations: {
+    enabled: boolean;
+  };
   public storage: {
     backend: 'opensearch' | 'sqlite';
     sqlite: { path: string };
@@ -98,6 +104,9 @@ export class SavedObjectConfig {
     this.migration = rawMigrationConfig;
     this.permission = {
       enabled: rawConfig.permission.enabled,
+    };
+    this.annotations = {
+      enabled: rawConfig.annotations.enabled,
     };
     this.storage = {
       backend: rawConfig.storage.backend,

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -50,6 +50,9 @@ type SavedObjectsServiceContract = PublicMethodsOf<SavedObjectsService>;
 
 const createStartContractMock = (typeRegistry?: jest.Mocked<ISavedObjectTypeRegistry>) => {
   const startContrat: jest.Mocked<SavedObjectsServiceStart> = {
+    annotations: {
+      getClient: jest.fn(),
+    },
     getScopedClient: jest.fn(),
     createInternalRepository: jest.fn(),
     createScopedRepository: jest.fn(),
@@ -58,6 +61,15 @@ const createStartContractMock = (typeRegistry?: jest.Mocked<ISavedObjectTypeRegi
   };
 
   startContrat.getScopedClient.mockReturnValue(savedObjectsClientMock.create());
+  startContrat.annotations.getClient.mockReturnValue({
+    createAnnotation: jest.fn(),
+    updateAnnotation: jest.fn(),
+    deleteAnnotation: jest.fn(),
+    findAnnotations: jest.fn(),
+    addAnnotationToObject: jest.fn(),
+    removeAnnotationFromObject: jest.fn(),
+    getAnnotationsForObject: jest.fn(),
+  });
   startContrat.createInternalRepository.mockReturnValue(savedObjectsRepositoryMock.create());
   startContrat.createScopedRepository.mockReturnValue(savedObjectsRepositoryMock.create());
   startContrat.getTypeRegistry.mockReturnValue(typeRegistry ?? typeRegistryMock.create());
@@ -74,6 +86,9 @@ const createInternalStartContractMock = (typeRegistry?: jest.Mocked<ISavedObject
 
 const createSetupContractMock = () => {
   const setupContract: jest.Mocked<SavedObjectsServiceSetup> = {
+    annotations: {
+      registerAnnotationType: jest.fn(),
+    },
     setClientFactoryProvider: jest.fn(),
     addClientWrapper: jest.fn(),
     registerType: jest.fn(),

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -69,6 +69,7 @@ const createStartContractMock = (typeRegistry?: jest.Mocked<ISavedObjectTypeRegi
     findAnnotations: jest.fn(),
     addAnnotationToObject: jest.fn(),
     removeAnnotationFromObject: jest.fn(),
+    setAnnotationsForObject: jest.fn(),
     getAnnotationsForObject: jest.fn(),
   });
   startContrat.createInternalRepository.mockReturnValue(savedObjectsRepositoryMock.create());

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -49,9 +49,10 @@ import { ISavedObjectTypeRegistry } from './saved_objects_type_registry';
 type SavedObjectsServiceContract = PublicMethodsOf<SavedObjectsService>;
 
 const createStartContractMock = (typeRegistry?: jest.Mocked<ISavedObjectTypeRegistry>) => {
+  const getAnnotationClient = jest.fn();
   const startContrat: jest.Mocked<SavedObjectsServiceStart> = {
     annotations: {
-      getClient: jest.fn(),
+      getClient: getAnnotationClient,
     },
     getScopedClient: jest.fn(),
     createInternalRepository: jest.fn(),
@@ -61,7 +62,7 @@ const createStartContractMock = (typeRegistry?: jest.Mocked<ISavedObjectTypeRegi
   };
 
   startContrat.getScopedClient.mockReturnValue(savedObjectsClientMock.create());
-  startContrat.annotations.getClient.mockReturnValue({
+  getAnnotationClient.mockReturnValue({
     createAnnotation: jest.fn(),
     updateAnnotation: jest.fn(),
     deleteAnnotation: jest.fn(),

--- a/src/core/server/saved_objects/saved_objects_service.mock.ts
+++ b/src/core/server/saved_objects/saved_objects_service.mock.ts
@@ -88,6 +88,7 @@ const createInternalStartContractMock = (typeRegistry?: jest.Mocked<ISavedObject
 const createSetupContractMock = () => {
   const setupContract: jest.Mocked<SavedObjectsServiceSetup> = {
     annotations: {
+      enabled: true,
       registerAnnotationType: jest.fn(),
     },
     setClientFactoryProvider: jest.fn(),

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -65,7 +65,8 @@ describe('SavedObjectsService', () => {
   const createCoreContext = ({
     skipMigration = true,
     env,
-  }: { skipMigration?: boolean; env?: Env } = {}) => {
+    annotationsEnabled = false,
+  }: { skipMigration?: boolean; env?: Env; annotationsEnabled?: boolean } = {}) => {
     const configService = configServiceMock.create({ atPath: { skip: true } });
     configService.atPath.mockImplementation((path) => {
       if (path === 'migrations') {
@@ -75,6 +76,7 @@ describe('SavedObjectsService', () => {
         maxImportPayloadBytes: new ByteSizeValue(0),
         maxImportExportSize: new ByteSizeValue(0),
         permission: { enabled: false },
+        annotations: { enabled: annotationsEnabled },
         storage: {
           backend: 'opensearch',
           sqlite: { path: ':memory:' },
@@ -146,7 +148,7 @@ describe('SavedObjectsService', () => {
 
     describe('#addClientWrapper', () => {
       it('registers the wrapper to the clientProvider', async () => {
-        const coreContext = createCoreContext();
+        const coreContext = createCoreContext({ annotationsEnabled: true });
         const soService = new SavedObjectsService(coreContext);
         const setup = await soService.setup(createSetupDeps());
 
@@ -175,6 +177,20 @@ describe('SavedObjectsService', () => {
           wrapperB
         );
       });
+
+      it('does not register the annotation wrapper when annotations are disabled', async () => {
+        const coreContext = createCoreContext();
+        const soService = new SavedObjectsService(coreContext);
+
+        await soService.setup(createSetupDeps());
+        await soService.start(createStartDeps());
+
+        expect(clientProviderInstanceMock.addClientWrapperFactory).not.toHaveBeenCalledWith(
+          ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+          ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+          annotationReferencePreservationWrapper
+        );
+      });
     });
 
     describe('#registerType', () => {
@@ -191,11 +207,46 @@ describe('SavedObjectsService', () => {
         };
         setup.registerType(type);
 
-        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledTimes(2);
+        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledTimes(1);
+        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledWith(type);
+      });
+
+      it('registers the annotation saved object type when annotations are enabled', async () => {
+        const coreContext = createCoreContext({ annotationsEnabled: true });
+        const soService = new SavedObjectsService(coreContext);
+        const setupDeps = createSetupDeps();
+        const setup = await soService.setup(setupDeps);
+
+        expect(setup.annotations.enabled).toBe(true);
         expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledWith(
           savedObjectAnnotationType
         );
-        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledWith(type);
+        expect(setupDeps.http.createRouter).toHaveBeenCalledWith(
+          '/internal/saved_object_annotations'
+        );
+      });
+
+      it('does not register annotation persistence when annotations are disabled', async () => {
+        const coreContext = createCoreContext();
+        const soService = new SavedObjectsService(coreContext);
+        const setupDeps = createSetupDeps();
+        const setup = await soService.setup(setupDeps);
+
+        expect(setup.annotations.enabled).toBe(false);
+        expect(typeRegistryInstanceMock.registerType).not.toHaveBeenCalledWith(
+          savedObjectAnnotationType
+        );
+        expect(setupDeps.http.createRouter).not.toHaveBeenCalledWith(
+          '/internal/saved_object_annotations'
+        );
+        expect(() =>
+          setup.annotations.registerAnnotationType({
+            type: 'tag',
+            supportedObjectTypes: ['dashboard'],
+          })
+        ).toThrow(
+          'Saved object annotations are disabled. Set `savedObjects.annotations.enabled` to `true` to register annotation types.'
+        );
       });
     });
 

--- a/src/core/server/saved_objects/saved_objects_service.test.ts
+++ b/src/core/server/saved_objects/saved_objects_service.test.ts
@@ -52,6 +52,12 @@ import { NodesVersionCompatibility } from '../opensearch/version_check/ensure_op
 import { SavedObjectsRepository } from './service/lib/repository';
 import { SavedObjectRepositoryFactoryProvider } from './service/lib/scoped_client_provider';
 import { ServiceStatusLevels } from '../status';
+import {
+  ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+  ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+  annotationReferencePreservationWrapper,
+  savedObjectAnnotationType,
+} from './annotations';
 
 jest.mock('./service/lib/repository');
 
@@ -152,7 +158,12 @@ describe('SavedObjectsService', () => {
 
         await soService.start(createStartDeps());
 
-        expect(clientProviderInstanceMock.addClientWrapperFactory).toHaveBeenCalledTimes(2);
+        expect(clientProviderInstanceMock.addClientWrapperFactory).toHaveBeenCalledTimes(3);
+        expect(clientProviderInstanceMock.addClientWrapperFactory).toHaveBeenCalledWith(
+          ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+          ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+          annotationReferencePreservationWrapper
+        );
         expect(clientProviderInstanceMock.addClientWrapperFactory).toHaveBeenCalledWith(
           1,
           'A',
@@ -180,7 +191,10 @@ describe('SavedObjectsService', () => {
         };
         setup.registerType(type);
 
-        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledTimes(1);
+        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledTimes(2);
+        expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledWith(
+          savedObjectAnnotationType
+        );
         expect(typeRegistryInstanceMock.registerType).toHaveBeenCalledWith(type);
       });
     });
@@ -343,6 +357,15 @@ describe('SavedObjectsService', () => {
         });
       }).toThrowErrorMatchingInlineSnapshot(
         `"cannot call \`registerType\` after service startup."`
+      );
+
+      expect(() => {
+        setup.annotations.registerAnnotationType({
+          type: 'tag',
+          supportedObjectTypes: ['dashboard'],
+        });
+      }).toThrowErrorMatchingInlineSnapshot(
+        `"cannot call \`registerAnnotationType\` after service startup."`
       );
 
       const customRpository: SavedObjectRepositoryFactoryProvider = () =>

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -377,7 +377,10 @@ export class SavedObjectsService implements CoreService<
       .pipe(first())
       .toPromise();
     this.config = new SavedObjectConfig(savedObjectsConfig, savedObjectsMigrationConfig);
-    this.typeRegistry.registerType(savedObjectAnnotationType);
+    if (this.config.annotations.enabled) {
+      this.typeRegistry.registerType(savedObjectAnnotationType);
+      registerSavedObjectAnnotationRoutes(setupDeps.http);
+    }
 
     // Recorded before any plugin runs, for callers that build mappings without the raw
     // configuration. Permission control comes from the validated config -- the same source
@@ -418,14 +421,19 @@ export class SavedObjectsService implements CoreService<
       migratorPromise: this.migrator$.pipe(first()).toPromise(),
       getCapabilities: () => this.capabilitiesResolver,
     });
-    registerSavedObjectAnnotationRoutes(setupDeps.http);
 
     return {
       status$: this.savedObjectServiceStatus$.asObservable(),
       annotations: {
+        enabled: this.config.annotations.enabled,
         registerAnnotationType: (registration) => {
           if (this.started) {
             throw new Error('cannot call `registerAnnotationType` after service startup.');
+          }
+          if (!this.config?.annotations.enabled) {
+            throw new Error(
+              'Saved object annotations are disabled. Set `savedObjects.annotations.enabled` to `true` to register annotation types.'
+            );
           }
           this.annotationTypeRegistry.register(registration);
         },
@@ -620,11 +628,13 @@ export class SavedObjectsService implements CoreService<
       const clientFactory = this.clientFactoryProvider(repositoryFactory);
       clientProvider.setClientFactory(clientFactory);
     }
-    clientProvider.addClientWrapperFactory(
-      ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
-      ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
-      annotationReferencePreservationWrapper
-    );
+    if (this.config.annotations.enabled) {
+      clientProvider.addClientWrapperFactory(
+        ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+        ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+        annotationReferencePreservationWrapper
+      );
+    }
     this.clientFactoryWrappers.forEach(({ id, factory, priority }) => {
       clientProvider.addClientWrapperFactory(priority, id, factory);
     });

--- a/src/core/server/saved_objects/saved_objects_service.ts
+++ b/src/core/server/saved_objects/saved_objects_service.ts
@@ -72,6 +72,17 @@ import { createMigrationOpenSearchClient } from './migrations/core/';
 import { setConditionalFieldFlags } from './migrations/core/build_active_mappings';
 import { Config } from '../config';
 import { SqliteSavedObjectsRepository } from './storage/sqlite_repository';
+import {
+  ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+  ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+  annotationReferencePreservationWrapper,
+  registerSavedObjectAnnotationRoutes,
+  savedObjectAnnotationType,
+  SavedObjectAnnotationsSetup,
+  SavedObjectAnnotationServiceImpl,
+  SavedObjectAnnotationTypeRegistry,
+} from './annotations';
+import { SavedObjectAnnotationService } from '../../types';
 /**
  * Saved Objects is OpenSearchDashboards's data persistence mechanism allowing plugins to
  * use OpenSearch for storing and querying state. The SavedObjectsServiceSetup API exposes methods
@@ -110,6 +121,8 @@ import { SqliteSavedObjectsRepository } from './storage/sqlite_repository';
  * @public
  */
 export interface SavedObjectsServiceSetup {
+  annotations: SavedObjectAnnotationsSetup;
+
   /**
    * Set the default {@link SavedObjectsClientFactoryProvider | factory provider} for creating Saved Objects clients.
    * Only one provider can be set, subsequent calls to this method will fail.
@@ -211,6 +224,10 @@ export interface InternalSavedObjectsServiceSetup extends SavedObjectsServiceSet
  * @public
  */
 export interface SavedObjectsServiceStart {
+  annotations: {
+    getClient: (req: OpenSearchDashboardsRequest) => SavedObjectAnnotationService;
+  };
+
   /**
    * Creates a {@link SavedObjectsClientContract | Saved Objects client} that
    * uses the credentials from the passed in request to authenticate with
@@ -318,6 +335,7 @@ export class SavedObjectsService implements CoreService<
 
   private migrator$ = new Subject<IOpenSearchDashboardsMigrator>();
   private typeRegistry = new SavedObjectTypeRegistry();
+  private annotationTypeRegistry = new SavedObjectAnnotationTypeRegistry();
   private capabilitiesResolver?: (request: OpenSearchDashboardsRequest) => Promise<Capabilities>;
   private started = false;
 
@@ -359,6 +377,7 @@ export class SavedObjectsService implements CoreService<
       .pipe(first())
       .toPromise();
     this.config = new SavedObjectConfig(savedObjectsConfig, savedObjectsMigrationConfig);
+    this.typeRegistry.registerType(savedObjectAnnotationType);
 
     // Recorded before any plugin runs, for callers that build mappings without the raw
     // configuration. Permission control comes from the validated config -- the same source
@@ -399,9 +418,18 @@ export class SavedObjectsService implements CoreService<
       migratorPromise: this.migrator$.pipe(first()).toPromise(),
       getCapabilities: () => this.capabilitiesResolver,
     });
+    registerSavedObjectAnnotationRoutes(setupDeps.http);
 
     return {
       status$: this.savedObjectServiceStatus$.asObservable(),
+      annotations: {
+        registerAnnotationType: (registration) => {
+          if (this.started) {
+            throw new Error('cannot call `registerAnnotationType` after service startup.');
+          }
+          this.annotationTypeRegistry.register(registration);
+        },
+      },
       setClientFactoryProvider: (provider) => {
         if (this.started) {
           throw new Error('cannot call `setClientFactoryProvider` after service startup.');
@@ -592,6 +620,11 @@ export class SavedObjectsService implements CoreService<
       const clientFactory = this.clientFactoryProvider(repositoryFactory);
       clientProvider.setClientFactory(clientFactory);
     }
+    clientProvider.addClientWrapperFactory(
+      ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_PRIORITY,
+      ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID,
+      annotationReferencePreservationWrapper
+    );
     this.clientFactoryWrappers.forEach(({ id, factory, priority }) => {
       clientProvider.addClientWrapperFactory(priority, id, factory);
     });
@@ -599,6 +632,16 @@ export class SavedObjectsService implements CoreService<
     this.started = true;
 
     return {
+      annotations: {
+        getClient: (request) =>
+          new SavedObjectAnnotationServiceImpl(
+            clientProvider.getClient(request),
+            clientProvider.getClient(request, {
+              excludedWrappers: [ANNOTATION_REFERENCE_PRESERVATION_WRAPPER_ID],
+            }),
+            this.annotationTypeRegistry
+          ),
+      },
       getScopedClient: clientProvider.getClient.bind(clientProvider),
       createScopedRepository: repositoryFactory.createScopedRepository,
       createInternalRepository: repositoryFactory.createInternalRepository,

--- a/src/core/types/index.ts
+++ b/src/core/types/index.ts
@@ -37,6 +37,7 @@ export * from './capabilities';
 export * from './app_category';
 export * from './ui_settings';
 export * from './saved_objects';
+export * from './saved_object_annotations';
 export * from './serializable';
 export * from './custom_branding';
 export * from './workspace';

--- a/src/core/types/saved_object_annotations.ts
+++ b/src/core/types/saved_object_annotations.ts
@@ -60,6 +60,12 @@ export interface RemoveSavedObjectAnnotationFromObjectInput {
   target: SavedObjectAnnotationTarget;
 }
 
+export interface SetSavedObjectAnnotationsForObjectInput {
+  annotationIds: string[];
+  type: string;
+  target: SavedObjectAnnotationTarget;
+}
+
 export interface GetSavedObjectAnnotationsForObjectInput {
   type: string;
   target: SavedObjectAnnotationTarget;
@@ -72,6 +78,7 @@ export interface SavedObjectAnnotationService {
   findAnnotations(options: FindSavedObjectAnnotationsOptions): Promise<SavedObjectAnnotation[]>;
   addAnnotationToObject(input: AddSavedObjectAnnotationToObjectInput): Promise<void>;
   removeAnnotationFromObject(input: RemoveSavedObjectAnnotationFromObjectInput): Promise<void>;
+  setAnnotationsForObject(input: SetSavedObjectAnnotationsForObjectInput): Promise<void>;
   getAnnotationsForObject(
     input: GetSavedObjectAnnotationsForObjectInput
   ): Promise<SavedObjectAnnotation[]>;

--- a/src/core/types/saved_object_annotations.ts
+++ b/src/core/types/saved_object_annotations.ts
@@ -1,0 +1,78 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+export const SAVED_OBJECT_ANNOTATION_TYPE = 'saved-object-annotation';
+
+export interface SavedObjectAnnotationTarget {
+  objectType: string;
+  objectId: string;
+}
+
+export interface CreateSavedObjectAnnotationInput {
+  type: string;
+  name: string;
+  description?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface UpdateSavedObjectAnnotationInput {
+  annotationId: string;
+  type: string;
+  name?: string;
+  description?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface DeleteSavedObjectAnnotationInput {
+  annotationId: string;
+  type: string;
+}
+
+export interface FindSavedObjectAnnotationsOptions {
+  type: string;
+}
+
+export interface SavedObjectAnnotation {
+  id: string;
+  type: string;
+  name: string;
+  description?: string;
+  payload?: Record<string, unknown>;
+}
+
+export interface AddSavedObjectAnnotationToObjectInput {
+  annotationId: string;
+  type: string;
+  target: SavedObjectAnnotationTarget;
+}
+
+export interface RemoveSavedObjectAnnotationFromObjectInput {
+  annotationId: string;
+  type: string;
+  target: SavedObjectAnnotationTarget;
+}
+
+export interface GetSavedObjectAnnotationsForObjectInput {
+  type: string;
+  target: SavedObjectAnnotationTarget;
+}
+
+export interface SavedObjectAnnotationService {
+  createAnnotation(input: CreateSavedObjectAnnotationInput): Promise<SavedObjectAnnotation>;
+  updateAnnotation(input: UpdateSavedObjectAnnotationInput): Promise<SavedObjectAnnotation>;
+  deleteAnnotation(input: DeleteSavedObjectAnnotationInput): Promise<void>;
+  findAnnotations(options: FindSavedObjectAnnotationsOptions): Promise<SavedObjectAnnotation[]>;
+  addAnnotationToObject(input: AddSavedObjectAnnotationToObjectInput): Promise<void>;
+  removeAnnotationFromObject(input: RemoveSavedObjectAnnotationFromObjectInput): Promise<void>;
+  getAnnotationsForObject(
+    input: GetSavedObjectAnnotationsForObjectInput
+  ): Promise<SavedObjectAnnotation[]>;
+}

--- a/src/plugins/dashboard/opensearch_dashboards.json
+++ b/src/plugins/dashboard/opensearch_dashboards.json
@@ -9,11 +9,15 @@
     "urlForwarding",
     "navigation",
     "uiActions",
-    "savedObjects",
-    "savedObjectTags"
+    "savedObjects"
   ],
-  "optionalPlugins": ["home", "share", "usageCollection"],
+  "optionalPlugins": ["home", "share", "usageCollection", "savedObjectTags"],
   "server": true,
   "ui": true,
-  "requiredBundles": ["opensearchDashboardsUtils", "opensearchDashboardsReact", "home", "contextProvider"]
+  "requiredBundles": [
+    "opensearchDashboardsUtils",
+    "opensearchDashboardsReact",
+    "home",
+    "contextProvider"
+  ]
 }

--- a/src/plugins/dashboard/opensearch_dashboards.json
+++ b/src/plugins/dashboard/opensearch_dashboards.json
@@ -9,7 +9,8 @@
     "urlForwarding",
     "navigation",
     "uiActions",
-    "savedObjects"
+    "savedObjects",
+    "savedObjectTags"
   ],
   "optionalPlugins": ["home", "share", "usageCollection"],
   "server": true,

--- a/src/plugins/dashboard/public/application/app.scss
+++ b/src/plugins/dashboard/public/application/app.scss
@@ -18,6 +18,11 @@
   min-width: 0;
 }
 
+.dshTagSelector {
+  width: 240px;
+  max-width: 100%;
+}
+
 // --- Variable Editor/Manage Panel Container ---
 #variablePanelContent {
   &:empty {

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx
@@ -38,6 +38,7 @@ jest.mock('react-router-dom', () => ({
 }));
 
 import { mount } from 'enzyme';
+import { act } from 'react';
 
 import { DashboardListing } from './dashboard_listing';
 import { createDashboardServicesMock } from '../../utils/mocks';
@@ -74,6 +75,60 @@ function wrapDashboardListingInContext(mockServices: any) {
     </I18nProvider>
   );
 }
+
+describe('dashboard tag filtering', () => {
+  it('adds the selected tag as a saved object reference filter', async () => {
+    const mockServices = createDashboardServicesMock();
+    mockServices.savedObjectsClient.find.mockResolvedValue({
+      savedObjects: [
+        {
+          type: 'dashboard',
+          id: 'dashboard-1',
+          attributes: {
+            title: 'Dashboard',
+            description: '',
+            version: 1,
+            timeRestore: false,
+          },
+          references: [],
+        },
+      ],
+      total: 1,
+    });
+    mockServices.dashboardConfig.getHideWriteControls = () => false;
+    mockServices.savedObjectsPublic.settings.getListingLimit = () => 100;
+    mockServices.navigation = {
+      ui: {
+        HeaderControl: () => null,
+      },
+    };
+    mockServices.savedObjectTags.ui.TagSelector = ({ onChange }: any) => (
+      <button data-test-subj="selectProductionTag" onClick={() => onChange('tag-production')} />
+    );
+
+    let component: ReturnType<typeof mount>;
+    await act(async () => {
+      component = mount(wrapDashboardListingInContext(mockServices));
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    component.update();
+
+    await act(async () => {
+      component.find('[data-test-subj="selectProductionTag"]').simulate('click');
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    component.update();
+
+    expect(mockServices.savedObjectsClient.find).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        hasReference: {
+          type: 'saved-object-annotation',
+          id: 'tag-production',
+        },
+      })
+    );
+  });
+});
 
 // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7488
 // skipping because not sure why it even needs to keep state seems like it isn't being used

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx
@@ -184,6 +184,35 @@ describe('dashboard tags', () => {
       'dashboard:dashboard-1'
     );
   });
+
+  it('hides tag controls when the tags plugin is disabled', async () => {
+    const mockServices = createDashboardServicesMock();
+    mockServices.savedObjectsClient.find.mockResolvedValue({
+      savedObjects: [],
+      total: 0,
+    });
+    mockServices.dashboardConfig.getHideWriteControls = () => false;
+    mockServices.savedObjectsPublic.settings.getListingLimit = () => 100;
+    mockServices.navigation = {
+      ui: {
+        HeaderControl: () => null,
+      },
+    };
+    mockServices.savedObjectTags = undefined;
+
+    let component: ReturnType<typeof mount>;
+    await act(async () => {
+      component = mount(wrapDashboardListingInContext(mockServices));
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    component.update();
+
+    const tableListView = component.find(TableListView);
+    expect(tableListView.prop('tableFilters')).toBeUndefined();
+    expect((tableListView.prop('tableColumns') as any[]).map(({ name }) => name)).not.toContain(
+      'Tags'
+    );
+  });
 });
 
 // TODO: https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7488

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.test.tsx
@@ -42,7 +42,10 @@ import { act } from 'react';
 
 import { DashboardListing } from './dashboard_listing';
 import { createDashboardServicesMock } from '../../utils/mocks';
-import { OpenSearchDashboardsContextProvider } from 'src/plugins/opensearch_dashboards_react/public';
+import {
+  OpenSearchDashboardsContextProvider,
+  TableListView,
+} from 'src/plugins/opensearch_dashboards_react/public';
 import { I18nProvider } from '@osd/i18n/react';
 import { IOsdUrlStateStorage } from 'src/plugins/opensearch_dashboards_utils/public';
 
@@ -76,7 +79,7 @@ function wrapDashboardListingInContext(mockServices: any) {
   );
 }
 
-describe('dashboard tag filtering', () => {
+describe('dashboard tags', () => {
   it('adds the selected tag as a saved object reference filter', async () => {
     const mockServices = createDashboardServicesMock();
     mockServices.savedObjectsClient.find.mockResolvedValue({
@@ -126,6 +129,59 @@ describe('dashboard tag filtering', () => {
           id: 'tag-production',
         },
       })
+    );
+  });
+
+  it('adds a Tags column after Last updated', async () => {
+    const mockServices = createDashboardServicesMock();
+    mockServices.savedObjectsClient.find.mockResolvedValue({
+      savedObjects: [
+        {
+          type: 'dashboard',
+          id: 'dashboard-1',
+          attributes: {
+            title: 'Dashboard',
+            description: '',
+          },
+          references: [],
+        },
+      ],
+      total: 1,
+    });
+    mockServices.dashboardConfig.getHideWriteControls = () => false;
+    mockServices.savedObjectsPublic.settings.getListingLimit = () => 100;
+    mockServices.navigation = {
+      ui: {
+        HeaderControl: () => null,
+      },
+    };
+    mockServices.savedObjectTags.ui.TagList = ({ target }: any) => (
+      <span data-test-subj="dashboardListingTags">
+        {target.objectType}:{target.objectId}
+      </span>
+    );
+
+    let component: ReturnType<typeof mount>;
+    await act(async () => {
+      component = mount(wrapDashboardListingInContext(mockServices));
+      await new Promise((resolve) => setImmediate(resolve));
+    });
+    component.update();
+
+    const columns = component.find(TableListView).prop('tableColumns') as any[];
+    const updatedAtColumnIndex = columns.findIndex(
+      (column) => column['data-test-subj'] === 'updated-at'
+    );
+    const tagsColumn = columns[updatedAtColumnIndex + 1];
+    const tableListView = component.find(TableListView).instance() as any;
+    const dashboard = tableListView.state.items[0];
+
+    expect(tagsColumn.name).toBe('Tags');
+    expect(dashboard.savedObjectType).toBe('dashboard');
+
+    const renderedCell = mount(<>{tagsColumn.render(dashboard.id, dashboard)}</>);
+    expect(renderedCell.find('[data-test-subj="dashboardListingTags"]').text()).toBe(
+      'dashboard:dashboard-1'
     );
   });
 });

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
@@ -47,7 +47,7 @@ export const DashboardListing = () => {
   const [selectedTagId, setSelectedTagId] = useState<string>();
   const showUpdatedUx = uiSettings?.get('home:useNewHomePage');
   const { HeaderControl } = navigation.ui;
-  const { TagList, TagSelector } = savedObjectTags.ui;
+  const TagSelector = savedObjectTags?.ui.TagSelector;
   const { setAppRightControls } = application;
 
   useEffect(() => {
@@ -100,9 +100,15 @@ export const DashboardListing = () => {
 
   const hideWriteControls = dashboardConfig.getHideWriteControls();
 
-  const tableColumns = useMemo(
-    () => [
-      ...getTableColumns(application, history, uiSettings),
+  const tableColumns = useMemo(() => {
+    const columns = getTableColumns(application, history, uiSettings);
+    if (!savedObjectTags) {
+      return columns;
+    }
+
+    const { TagList } = savedObjectTags.ui;
+    return [
+      ...columns,
       {
         field: 'id',
         name: i18n.translate('dashboard.listing.table.tagsColumnName', {
@@ -126,9 +132,8 @@ export const DashboardListing = () => {
           />
         ),
       },
-    ],
-    [application, history, uiSettings, TagList]
-  );
+    ];
+  }, [application, history, uiSettings, savedObjectTags]);
 
   const createItem = useCallback(() => {
     history.push(DashboardConstants.CREATE_NEW_DASHBOARD_URL);
@@ -273,17 +278,19 @@ export const DashboardListing = () => {
         })}
         toastNotifications={notifications.toasts}
         showUpdatedUx={showUpdatedUx}
-        refreshKey={selectedTagId}
-        hasActiveFilters={Boolean(selectedTagId)}
+        refreshKey={savedObjectTags ? selectedTagId : undefined}
+        hasActiveFilters={Boolean(savedObjectTags && selectedTagId)}
         tableFilters={
-          <>
-            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
-              <EuiFlexItem grow={false} className="dshTagSelector">
-                <TagSelector selectedTagId={selectedTagId} onChange={setSelectedTagId} />
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer size="s" />
-          </>
+          TagSelector ? (
+            <>
+              <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+                <EuiFlexItem grow={false} className="dshTagSelector">
+                  <TagSelector selectedTagId={selectedTagId} onChange={setSelectedTagId} />
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer size="s" />
+            </>
+          ) : undefined
         }
       />
     </>

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { useMount } from 'react-use';
 import { useLocation } from 'react-router-dom';
+import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
 import {
   useOpenSearchDashboards,
   TableListView,
@@ -35,6 +36,7 @@ export const DashboardListing = () => {
       data: { query },
       osdUrlStateStorage,
       navigation,
+      savedObjectTags,
     },
   } = useOpenSearchDashboards<DashboardServices>();
 
@@ -42,8 +44,10 @@ export const DashboardListing = () => {
   const queryParameters = useMemo(() => new URLSearchParams(location.search), [location]);
   const initialFiltersFromURL = queryParameters.get('filter');
   const [initialFilter, setInitialFilter] = useState<string | null>(initialFiltersFromURL);
+  const [selectedTagId, setSelectedTagId] = useState<string>();
   const showUpdatedUx = uiSettings?.get('home:useNewHomePage');
   const { HeaderControl } = navigation.ui;
+  const { TagSelector } = savedObjectTags.ui;
   const { setAppRightControls } = application;
 
   useEffect(() => {
@@ -138,6 +142,12 @@ export const DashboardListing = () => {
       page: 1,
       searchFields: ['title^3', 'type', 'description'],
       defaultSearchOperator: 'AND',
+      ...(selectedTagId && {
+        hasReference: {
+          type: 'saved-object-annotation',
+          id: selectedTagId,
+        },
+      }),
     });
     const list = res.savedObjects?.map(mapListAttributesToDashboardProvider) || [];
 
@@ -237,6 +247,18 @@ export const DashboardListing = () => {
         })}
         toastNotifications={notifications.toasts}
         showUpdatedUx={showUpdatedUx}
+        refreshKey={selectedTagId}
+        hasActiveFilters={Boolean(selectedTagId)}
+        tableFilters={
+          <>
+            <EuiFlexGroup justifyContent="flexEnd" responsive={false}>
+              <EuiFlexItem grow={false} className="dshTagSelector">
+                <TagSelector selectedTagId={selectedTagId} onChange={setSelectedTagId} />
+              </EuiFlexItem>
+            </EuiFlexGroup>
+            <EuiSpacer size="s" />
+          </>
+        }
       />
     </>
   );

--- a/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_listing/dashboard_listing.tsx
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { i18n } from '@osd/i18n';
 import { useMount } from 'react-use';
 import { useLocation } from 'react-router-dom';
-import { EuiFlexGroup, EuiFlexItem, EuiSpacer } from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiLoadingSpinner, EuiSpacer } from '@elastic/eui';
 import {
   useOpenSearchDashboards,
   TableListView,
@@ -47,7 +47,7 @@ export const DashboardListing = () => {
   const [selectedTagId, setSelectedTagId] = useState<string>();
   const showUpdatedUx = uiSettings?.get('home:useNewHomePage');
   const { HeaderControl } = navigation.ui;
-  const { TagSelector } = savedObjectTags.ui;
+  const { TagList, TagSelector } = savedObjectTags.ui;
   const { setAppRightControls } = application;
 
   useEffect(() => {
@@ -101,8 +101,33 @@ export const DashboardListing = () => {
   const hideWriteControls = dashboardConfig.getHideWriteControls();
 
   const tableColumns = useMemo(
-    () => getTableColumns(application, history, uiSettings),
-    [application, history, uiSettings]
+    () => [
+      ...getTableColumns(application, history, uiSettings),
+      {
+        field: 'id',
+        name: i18n.translate('dashboard.listing.table.tagsColumnName', {
+          defaultMessage: 'Tags',
+        }),
+        sortable: false,
+        ['data-test-subj']: 'dashboard-tags',
+        render: (
+          id: string,
+          record: {
+            savedObjectType: string;
+          }
+        ) => (
+          <TagList
+            target={{
+              objectType: record.savedObjectType,
+              objectId: id,
+            }}
+            loadingContent={<EuiLoadingSpinner size="s" />}
+            emptyContent="-"
+          />
+        ),
+      },
+    ],
+    [application, history, uiSettings, TagList]
   );
 
   const createItem = useCallback(() => {
@@ -126,6 +151,7 @@ export const DashboardListing = () => {
       id: obj.id,
       appId: provider.appId,
       type: provider.savedObjectsName,
+      savedObjectType: obj.type,
       ...obj.attributes,
       updated_at: obj.updated_at,
       viewUrl: provider.viewUrlPathFn(obj),

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/__snapshots__/dashboard_top_nav.test.tsx.snap
@@ -962,7 +962,23 @@ exports[`Dashboard top nav render in embed mode 1`] = `
                 "show": [MockFunction],
               },
             },
+            "savedObjectTags": Object {
+              "ui": Object {
+                "TagAssignmentModal": [Function],
+                "TagList": [Function],
+                "TagSelector": [Function],
+              },
+            },
             "savedObjects": Object {
+              "annotations": Object {
+                "addAnnotationToObject": [MockFunction],
+                "createAnnotation": [MockFunction],
+                "deleteAnnotation": [MockFunction],
+                "findAnnotations": [MockFunction],
+                "getAnnotationsForObject": [MockFunction],
+                "removeAnnotationFromObject": [MockFunction],
+                "updateAnnotation": [MockFunction],
+              },
               "client": Object {
                 "bulkCreate": [MockFunction],
                 "bulkGet": [MockFunction],
@@ -2170,7 +2186,23 @@ exports[`Dashboard top nav render in embed mode, and force hide filter bar 1`] =
                 "show": [MockFunction],
               },
             },
+            "savedObjectTags": Object {
+              "ui": Object {
+                "TagAssignmentModal": [Function],
+                "TagList": [Function],
+                "TagSelector": [Function],
+              },
+            },
             "savedObjects": Object {
+              "annotations": Object {
+                "addAnnotationToObject": [MockFunction],
+                "createAnnotation": [MockFunction],
+                "deleteAnnotation": [MockFunction],
+                "findAnnotations": [MockFunction],
+                "getAnnotationsForObject": [MockFunction],
+                "removeAnnotationFromObject": [MockFunction],
+                "updateAnnotation": [MockFunction],
+              },
               "client": Object {
                 "bulkCreate": [MockFunction],
                 "bulkGet": [MockFunction],
@@ -3378,7 +3410,23 @@ exports[`Dashboard top nav render in embed mode, components can be forced show b
                 "show": [MockFunction],
               },
             },
+            "savedObjectTags": Object {
+              "ui": Object {
+                "TagAssignmentModal": [Function],
+                "TagList": [Function],
+                "TagSelector": [Function],
+              },
+            },
             "savedObjects": Object {
+              "annotations": Object {
+                "addAnnotationToObject": [MockFunction],
+                "createAnnotation": [MockFunction],
+                "deleteAnnotation": [MockFunction],
+                "findAnnotations": [MockFunction],
+                "getAnnotationsForObject": [MockFunction],
+                "removeAnnotationFromObject": [MockFunction],
+                "updateAnnotation": [MockFunction],
+              },
               "client": Object {
                 "bulkCreate": [MockFunction],
                 "bulkGet": [MockFunction],
@@ -4586,7 +4634,23 @@ exports[`Dashboard top nav render in full screen mode with appended URL param bu
                 "show": [MockFunction],
               },
             },
+            "savedObjectTags": Object {
+              "ui": Object {
+                "TagAssignmentModal": [Function],
+                "TagList": [Function],
+                "TagSelector": [Function],
+              },
+            },
             "savedObjects": Object {
+              "annotations": Object {
+                "addAnnotationToObject": [MockFunction],
+                "createAnnotation": [MockFunction],
+                "deleteAnnotation": [MockFunction],
+                "findAnnotations": [MockFunction],
+                "getAnnotationsForObject": [MockFunction],
+                "removeAnnotationFromObject": [MockFunction],
+                "updateAnnotation": [MockFunction],
+              },
               "client": Object {
                 "bulkCreate": [MockFunction],
                 "bulkGet": [MockFunction],
@@ -5794,7 +5858,23 @@ exports[`Dashboard top nav render in full screen mode, no componenets should be 
                 "show": [MockFunction],
               },
             },
+            "savedObjectTags": Object {
+              "ui": Object {
+                "TagAssignmentModal": [Function],
+                "TagList": [Function],
+                "TagSelector": [Function],
+              },
+            },
             "savedObjects": Object {
+              "annotations": Object {
+                "addAnnotationToObject": [MockFunction],
+                "createAnnotation": [MockFunction],
+                "deleteAnnotation": [MockFunction],
+                "findAnnotations": [MockFunction],
+                "getAnnotationsForObject": [MockFunction],
+                "removeAnnotationFromObject": [MockFunction],
+                "updateAnnotation": [MockFunction],
+              },
               "client": Object {
                 "bulkCreate": [MockFunction],
                 "bulkGet": [MockFunction],
@@ -7002,7 +7082,23 @@ exports[`Dashboard top nav render with all components 1`] = `
                 "show": [MockFunction],
               },
             },
+            "savedObjectTags": Object {
+              "ui": Object {
+                "TagAssignmentModal": [Function],
+                "TagList": [Function],
+                "TagSelector": [Function],
+              },
+            },
             "savedObjects": Object {
+              "annotations": Object {
+                "addAnnotationToObject": [MockFunction],
+                "createAnnotation": [MockFunction],
+                "deleteAnnotation": [MockFunction],
+                "findAnnotations": [MockFunction],
+                "getAnnotationsForObject": [MockFunction],
+                "removeAnnotationFromObject": [MockFunction],
+                "updateAnnotation": [MockFunction],
+              },
               "client": Object {
                 "bulkCreate": [MockFunction],
                 "bulkGet": [MockFunction],

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_tag_list_tooltip.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_tag_list_tooltip.test.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiLoadingSpinner } from '@elastic/eui';
+import { mount } from 'enzyme';
+import { TagListProps } from '../../../../../saved_object_tags/public';
+import { DashboardTagListTooltip } from './dashboard_tag_list_tooltip';
+
+const target = {
+  objectType: 'dashboard',
+  objectId: 'dashboard-1',
+};
+
+describe('DashboardTagListTooltip', () => {
+  it('owns the popup dimensions and loading presentation', () => {
+    const TagList = ({ loadingContent }: TagListProps) => <>{loadingContent}</>;
+    const component = mount(
+      <DashboardTagListTooltip TagList={TagList} target={target} refreshKey={0} />
+    );
+
+    expect(component.find(EuiLoadingSpinner).prop('size')).toBe('m');
+    expect(
+      component.find('[data-test-subj="dashboardTagListTooltip"]').first().prop('style')
+    ).toEqual(
+      expect.objectContaining({
+        minWidth: 240,
+        minHeight: 48,
+        paddingTop: 8,
+      })
+    );
+  });
+
+  it('owns the empty presentation', () => {
+    const TagList = ({ emptyContent }: TagListProps) => <>{emptyContent}</>;
+    const component = mount(
+      <DashboardTagListTooltip TagList={TagList} target={target} refreshKey={0} />
+    );
+
+    expect(component.find('[data-test-subj="dashboardTagListTooltipEmpty"]').first().text()).toBe(
+      'No tags'
+    );
+  });
+});

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_tag_list_tooltip.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_tag_list_tooltip.tsx
@@ -44,7 +44,7 @@ export const DashboardTagListTooltip = ({
       }
       emptyContent={
         <div data-test-subj="dashboardTagListTooltipEmpty" style={centeredContentStyle}>
-          <EuiText color="subdued" size="xs">
+          <EuiText size="xs">
             {i18n.translate('dashboard.topNav.tagsTooltip.emptyMessage', {
               defaultMessage: 'No tags',
             })}

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_tag_list_tooltip.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_tag_list_tooltip.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiLoadingSpinner, EuiText } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { TagListProps } from '../../../../../saved_object_tags/public';
+
+interface DashboardTagListTooltipProps {
+  TagList: React.ComponentType<TagListProps>;
+  target: TagListProps['target'];
+  refreshKey: number;
+}
+
+const tooltipContentStyle: React.CSSProperties = {
+  minWidth: 36,
+  minHeight: 24,
+  paddingTop: 4,
+  display: 'flex',
+  alignItems: 'center',
+};
+
+const centeredContentStyle: React.CSSProperties = {
+  width: '100%',
+  display: 'flex',
+  justifyContent: 'center',
+};
+
+export const DashboardTagListTooltip = ({
+  TagList,
+  target,
+  refreshKey,
+}: DashboardTagListTooltipProps) => (
+  <div data-test-subj="dashboardTagListTooltip" style={tooltipContentStyle}>
+    <TagList
+      target={target}
+      refreshKey={refreshKey}
+      loadingContent={
+        <div data-test-subj="dashboardTagListTooltipLoading" style={centeredContentStyle}>
+          <EuiLoadingSpinner size="m" />
+        </div>
+      }
+      emptyContent={
+        <div data-test-subj="dashboardTagListTooltipEmpty" style={centeredContentStyle}>
+          <EuiText color="subdued" size="xs">
+            {i18n.translate('dashboard.topNav.tagsTooltip.emptyMessage', {
+              defaultMessage: 'No tags',
+            })}
+          </EuiText>
+        </div>
+      }
+    />
+  </div>
+);

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx
@@ -219,6 +219,28 @@ describe('Dashboard top nav', () => {
     expect(mockServices.overlays.openModal).toHaveBeenCalledTimes(1);
   });
 
+  test('hides tags when the tags plugin is disabled', async () => {
+    mockServices.savedObjectTags = undefined;
+    mockServices.uiSettings.get.mockImplementation((key: string) => key === 'home:useNewHomePage');
+    const component = mount(
+      wrapDashboardTopNavInContext(
+        mockServices,
+        { ...currentState, fullScreenMode: false, viewMode: ViewMode.VIEW },
+        false,
+        'dashboard-1',
+        true
+      )
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => process.nextTick(resolve));
+    });
+    component.update();
+
+    const config = component.find(TopNavMenu).prop('config') as any[];
+    expect(config.map(({ testId }) => testId)).not.toContain('dashboardTagsMenuItem');
+  });
+
   describe('Keyboard Shortcuts Integration', () => {
     let mockUseKeyboardShortcut: jest.Mock;
     let mockRegister: jest.Mock;

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx
@@ -62,6 +62,7 @@ function wrapDashboardTopNavInContext(
   const services = {
     ...servicesWithoutKeyboardShortcut,
     dashboardCapabilities: {
+      ...servicesWithoutKeyboardShortcut.dashboardCapabilities,
       saveQuery: true,
     },
     navigation: {
@@ -183,6 +184,9 @@ describe('Dashboard top nav', () => {
   });
 
   test('shows tags in the saved dashboard view header and opens the assignment modal', async () => {
+    mockServices.dashboardCapabilities = {
+      showWriteControls: true,
+    };
     mockServices.uiSettings.get.mockImplementation((key: string) => key === 'home:useNewHomePage');
     const component = mount(
       wrapDashboardTopNavInContext(
@@ -219,8 +223,35 @@ describe('Dashboard top nav', () => {
     expect(mockServices.overlays.openModal).toHaveBeenCalledTimes(1);
   });
 
+  test('hides the tag mutation control when write controls are disabled', async () => {
+    mockServices.dashboardCapabilities = {
+      showWriteControls: false,
+    };
+    mockServices.uiSettings.get.mockImplementation((key: string) => key === 'home:useNewHomePage');
+    const component = mount(
+      wrapDashboardTopNavInContext(
+        mockServices,
+        { ...currentState, fullScreenMode: false, viewMode: ViewMode.VIEW },
+        false,
+        'dashboard-1',
+        true
+      )
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => process.nextTick(resolve));
+    });
+    component.update();
+
+    const config = component.find(TopNavMenu).prop('config') as any[];
+    expect(config.map(({ testId }) => testId)).not.toContain('dashboardTagsMenuItem');
+  });
+
   test('hides tags when the tags plugin is disabled', async () => {
     mockServices.savedObjectTags = undefined;
+    mockServices.dashboardCapabilities = {
+      showWriteControls: true,
+    };
     mockServices.uiSettings.get.mockImplementation((key: string) => key === 'home:useNewHomePage');
     const component = mount(
       wrapDashboardTopNavInContext(

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.test.tsx
@@ -33,6 +33,7 @@ import { Dashboard } from '../../../dashboard';
 import { DashboardContainer } from '../../embeddable';
 import { createDashboardServicesMock } from '../../utils/mocks';
 import { mount } from 'enzyme';
+import { act } from 'react';
 import { TopNavMenu, TopNavControls as HeaderControl } from 'src/plugins/navigation/public';
 import { dashboardAppStateStub } from '../../utils/stubs';
 import { ViewMode } from 'src/plugins/embeddable/public';
@@ -52,7 +53,9 @@ jest.mock('react-router-dom', () => ({
 function wrapDashboardTopNavInContext(
   mockServices: any,
   currentState: DashboardAppState,
-  includeKeyboardShortcut = false
+  includeKeyboardShortcut = false,
+  dashboardIdFromUrl = '',
+  isChromeVisible = false
 ) {
   const { keyboardShortcut, ...servicesWithoutKeyboardShortcut } = mockServices;
 
@@ -72,7 +75,7 @@ function wrapDashboardTopNavInContext(
   };
 
   const topNavProps = {
-    isChromeVisible: false,
+    isChromeVisible,
     savedDashboardInstance: {},
     appState: {
       getState: () => currentState,
@@ -82,7 +85,7 @@ function wrapDashboardTopNavInContext(
     isEmbeddableRendered: true,
     currentContainer: {} as DashboardContainer,
     indexPatterns: [],
-    dashboardIdFromUrl: '',
+    dashboardIdFromUrl,
   };
 
   return (
@@ -177,6 +180,43 @@ describe('Dashboard top nav', () => {
     component.update();
 
     expect(component).toMatchSnapshot();
+  });
+
+  test('shows tags in the saved dashboard view header and opens the assignment modal', async () => {
+    mockServices.uiSettings.get.mockImplementation((key: string) => key === 'home:useNewHomePage');
+    const component = mount(
+      wrapDashboardTopNavInContext(
+        mockServices,
+        { ...currentState, fullScreenMode: false, viewMode: ViewMode.VIEW },
+        false,
+        'dashboard-1',
+        true
+      )
+    );
+
+    await act(async () => {
+      await new Promise((resolve) => process.nextTick(resolve));
+    });
+    component.update();
+
+    const config = component.find(TopNavMenu).prop('config') as any[];
+    const tagAction = config.find(({ testId }) => testId === 'dashboardTagsMenuItem');
+    expect(tagAction).toBeDefined();
+    expect(tagAction.tooltip.props).toEqual(
+      expect.objectContaining({
+        refreshKey: 0,
+        target: {
+          objectType: 'dashboard',
+          objectId: 'dashboard-1',
+        },
+      })
+    );
+
+    act(() => {
+      tagAction.run();
+    });
+
+    expect(mockServices.overlays.openModal).toHaveBeenCalledTimes(1);
   });
 
   describe('Keyboard Shortcuts Integration', () => {

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
@@ -247,11 +247,15 @@ const TopNav = ({
         currentContainer
       );
       const TagList = services.savedObjectTags?.ui.TagList;
-      if (dashboardIdFromUrl && services.savedObjectTags) {
+      if (
+        dashboardIdFromUrl &&
+        services.savedObjectTags &&
+        services.dashboardCapabilities.showWriteControls
+      ) {
         navActions[TopNavIds.TAGS] = openTagAssignmentModal;
       }
       const tagsTooltip =
-        dashboardIdFromUrl && TagList ? (
+        dashboardIdFromUrl && TagList && services.dashboardCapabilities.showWriteControls ? (
           <DashboardTagListTooltip
             TagList={TagList}
             target={{

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
@@ -7,7 +7,10 @@ import { memo, useState, useEffect, useCallback } from 'react';
 import { IndexPattern } from 'src/plugins/data/public';
 import { useLocation } from 'react-router-dom';
 import { i18n } from '@osd/i18n';
-import { useOpenSearchDashboards } from '../../../../../opensearch_dashboards_react/public';
+import {
+  toMountPoint,
+  useOpenSearchDashboards,
+} from '../../../../../opensearch_dashboards_react/public';
 import { getTopNavConfig, getTopNavRightConfig, getTopNavLegacyConfig } from './top_nav';
 import { DashboardAppStateContainer, DashboardAppState, DashboardServices } from '../../../types';
 import { getNavActions } from '../../utils/get_nav_actions';
@@ -17,6 +20,7 @@ import { TopNavMenuItemRenderType, TopNavControlData } from '../../../../../navi
 import { TopNavIds } from './top_nav';
 import { ViewMode, isErrorEmbeddable, openAddPanelFlyout } from '../../../../../embeddable/public';
 import { getSavedObjectFinder } from '../../../../../saved_objects/public';
+import { DashboardTagListTooltip } from './dashboard_tag_list_tooltip';
 
 interface DashboardTopNavProps {
   isChromeVisible: boolean;
@@ -54,9 +58,11 @@ const TopNav = ({
   const [topNavMenu, setTopNavMenu] = useState<any>();
   const [topRightControls, setTopRightControls] = useState<TopNavControlData[]>([]);
   const [isFullScreenMode, setIsFullScreenMode] = useState<any>();
+  const [tagRefreshKey, setTagRefreshKey] = useState(0);
 
   const { services } = useOpenSearchDashboards<DashboardServices>();
   const { TopNavMenu, HeaderControl } = services.navigation.ui;
+  const { TagAssignmentModal, TagList } = services.savedObjectTags.ui;
   const { dashboardConfig, setHeaderActionMenu, keyboardShortcut } = services;
   const { setAppRightControls } = services.application;
 
@@ -83,6 +89,29 @@ const TopNav = ({
       keyboardNavActions[TopNavIds.SAVE]();
     }
   }, [keyboardNavActions]);
+
+  const handleTagsChange = useCallback(() => {
+    setTagRefreshKey((refreshKey) => refreshKey + 1);
+  }, []);
+
+  const openTagAssignmentModal = useCallback(() => {
+    if (!dashboardIdFromUrl) {
+      return;
+    }
+
+    const modal = services.overlays.openModal(
+      toMountPoint(
+        <TagAssignmentModal
+          target={{
+            objectType: 'dashboard',
+            objectId: dashboardIdFromUrl,
+          }}
+          onChange={handleTagsChange}
+          onClose={() => modal.close()}
+        />
+      )
+    );
+  }, [TagAssignmentModal, dashboardIdFromUrl, handleTagsChange, services.overlays]);
 
   const handleAddPanel = useCallback(() => {
     // directly open the add panel flyout
@@ -217,17 +246,32 @@ const TopNav = ({
         dashboardIdFromUrl,
         currentContainer
       );
+      if (dashboardIdFromUrl) {
+        navActions[TopNavIds.TAGS] = openTagAssignmentModal;
+      }
+      const tagsTooltip = dashboardIdFromUrl ? (
+        <DashboardTagListTooltip
+          TagList={TagList}
+          target={{
+            objectType: 'dashboard',
+            objectId: dashboardIdFromUrl,
+          }}
+          refreshKey={tagRefreshKey}
+        />
+      ) : undefined;
       setTopNavMenu(
         showActionsInGroup
           ? getTopNavConfig(
               currentAppState?.viewMode,
               navActions,
-              dashboardConfig.getHideWriteControls()
+              dashboardConfig.getHideWriteControls(),
+              tagsTooltip
             )
           : getTopNavLegacyConfig(
               currentAppState?.viewMode,
               navActions,
-              dashboardConfig.getHideWriteControls()
+              dashboardConfig.getHideWriteControls(),
+              tagsTooltip
             )
       );
       setTopRightControls(
@@ -245,6 +289,9 @@ const TopNav = ({
     dashboard,
     dashboardIdFromUrl,
     showActionsInGroup,
+    openTagAssignmentModal,
+    TagList,
+    tagRefreshKey,
   ]);
 
   useEffect(() => {

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/dashboard_top_nav.tsx
@@ -62,7 +62,6 @@ const TopNav = ({
 
   const { services } = useOpenSearchDashboards<DashboardServices>();
   const { TopNavMenu, HeaderControl } = services.navigation.ui;
-  const { TagAssignmentModal, TagList } = services.savedObjectTags.ui;
   const { dashboardConfig, setHeaderActionMenu, keyboardShortcut } = services;
   const { setAppRightControls } = services.application;
 
@@ -95,7 +94,8 @@ const TopNav = ({
   }, []);
 
   const openTagAssignmentModal = useCallback(() => {
-    if (!dashboardIdFromUrl) {
+    const TagAssignmentModal = services.savedObjectTags?.ui.TagAssignmentModal;
+    if (!dashboardIdFromUrl || !TagAssignmentModal) {
       return;
     }
 
@@ -111,7 +111,7 @@ const TopNav = ({
         />
       )
     );
-  }, [TagAssignmentModal, dashboardIdFromUrl, handleTagsChange, services.overlays]);
+  }, [dashboardIdFromUrl, handleTagsChange, services.overlays, services.savedObjectTags]);
 
   const handleAddPanel = useCallback(() => {
     // directly open the add panel flyout
@@ -246,19 +246,21 @@ const TopNav = ({
         dashboardIdFromUrl,
         currentContainer
       );
-      if (dashboardIdFromUrl) {
+      const TagList = services.savedObjectTags?.ui.TagList;
+      if (dashboardIdFromUrl && services.savedObjectTags) {
         navActions[TopNavIds.TAGS] = openTagAssignmentModal;
       }
-      const tagsTooltip = dashboardIdFromUrl ? (
-        <DashboardTagListTooltip
-          TagList={TagList}
-          target={{
-            objectType: 'dashboard',
-            objectId: dashboardIdFromUrl,
-          }}
-          refreshKey={tagRefreshKey}
-        />
-      ) : undefined;
+      const tagsTooltip =
+        dashboardIdFromUrl && TagList ? (
+          <DashboardTagListTooltip
+            TagList={TagList}
+            target={{
+              objectType: 'dashboard',
+              objectId: dashboardIdFromUrl,
+            }}
+            refreshKey={tagRefreshKey}
+          />
+        ) : undefined;
       setTopNavMenu(
         showActionsInGroup
           ? getTopNavConfig(
@@ -290,7 +292,6 @@ const TopNav = ({
     dashboardIdFromUrl,
     showActionsInGroup,
     openTagAssignmentModal,
-    TagList,
     tagRefreshKey,
   ]);
 

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.test.ts
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ViewMode } from '../../../../../../embeddable/public';
+import { NavAction } from '../../../../types';
+import { getTopNavConfig } from './get_top_nav_config';
+import { TopNavIds } from './top_nav_ids';
+
+describe('getTopNavConfig', () => {
+  const actions = Object.values(TopNavIds).reduce<Record<string, NavAction>>((result, id) => {
+    result[id] = jest.fn();
+    return result;
+  }, {});
+
+  it('places tags immediately after save in edit mode', () => {
+    const config = getTopNavConfig(ViewMode.EDIT, actions, false);
+
+    expect(config.map(({ testId }) => testId)).toEqual([
+      'dashboardEditSwitch',
+      'dashboardSaveMenuItem',
+      'dashboardTagsMenuItem',
+      'dashboardAddPanelButton',
+      'dashboardOptionsButton',
+      'shareTopNavButton',
+    ]);
+  });
+
+  it('includes tags in view mode', () => {
+    const config = getTopNavConfig(ViewMode.VIEW, actions, false);
+
+    expect(config.map(({ testId }) => testId)).toEqual([
+      'dashboardEditSwitch',
+      'dashboardTagsMenuItem',
+      'dashboardClone',
+      'shareTopNavButton',
+    ]);
+  });
+
+  it('includes tags in view mode when write controls are hidden', () => {
+    const config = getTopNavConfig(ViewMode.VIEW, actions, true);
+
+    expect(config.map(({ testId }) => testId)).toEqual([
+      'dashboardTagsMenuItem',
+      'shareTopNavButton',
+    ]);
+  });
+
+  it('omits tags when no action is available', () => {
+    const config = getTopNavConfig(
+      ViewMode.EDIT,
+      {
+        ...actions,
+        [TopNavIds.TAGS]: undefined,
+      } as unknown as Record<string, NavAction>,
+      false
+    );
+
+    expect(config.map(({ testId }) => testId)).not.toContain('dashboardTagsMenuItem');
+  });
+});

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.ts
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.ts
@@ -29,6 +29,7 @@
  */
 
 import { i18n } from '@osd/i18n';
+import { ReactNode } from 'react';
 import { ViewMode } from '../../../../../../embeddable/public';
 import { TopNavIds } from './top_nav_ids';
 import { NavAction } from '../../../../types';
@@ -47,17 +48,24 @@ import {
 export function getTopNavLegacyConfig(
   dashboardMode: ViewMode,
   actions: { [key: string]: NavAction },
-  hideWriteControls: boolean
+  hideWriteControls: boolean,
+  tagsTooltip?: ReactNode
 ) {
   switch (dashboardMode) {
     case ViewMode.VIEW:
       return hideWriteControls
         ? [
             getLegacyFullScreenConfig(actions[TopNavIds.FULL_SCREEN]),
+            ...(actions[TopNavIds.TAGS]
+              ? [getLegacyTagsConfig(actions[TopNavIds.TAGS], tagsTooltip)]
+              : []),
             getLegacyShareConfig(actions[TopNavIds.SHARE]),
           ]
         : [
             getLegacyFullScreenConfig(actions[TopNavIds.FULL_SCREEN]),
+            ...(actions[TopNavIds.TAGS]
+              ? [getLegacyTagsConfig(actions[TopNavIds.TAGS], tagsTooltip)]
+              : []),
             getLegacyShareConfig(actions[TopNavIds.SHARE]),
             getLegacyCloneConfig(actions[TopNavIds.CLONE]),
             getLegacyEditConfig(actions[TopNavIds.ENTER_EDIT_MODE]),
@@ -69,6 +77,9 @@ export function getTopNavLegacyConfig(
         getLegacyAddConfig(actions[TopNavIds.ADD_EXISTING]),
         getLegacyViewConfig(actions[TopNavIds.EXIT_EDIT_MODE]),
         getLegacySaveConfig(actions[TopNavIds.SAVE]),
+        ...(actions[TopNavIds.TAGS]
+          ? [getLegacyTagsConfig(actions[TopNavIds.TAGS], tagsTooltip)]
+          : []),
         getLegacyCreateNewConfig(actions[TopNavIds.VISUALIZE]),
       ];
     default:
@@ -125,6 +136,22 @@ function getLegacySaveConfig(action: NavAction) {
       defaultMessage: 'Save your dashboard',
     }),
     testId: 'dashboardSaveMenuItem',
+    run: action,
+  };
+}
+
+function getLegacyTagsConfig(action: NavAction, tooltip?: ReactNode) {
+  return {
+    id: 'tags',
+    iconType: 'tag',
+    label: i18n.translate('dashboard.topNav.tagsButtonAriaLabel', {
+      defaultMessage: 'tags',
+    }),
+    description: i18n.translate('dashboard.topNav.tagsConfigDescription', {
+      defaultMessage: 'Manage dashboard tags',
+    }),
+    tooltip,
+    testId: 'dashboardTagsMenuItem',
     run: action,
   };
 }
@@ -238,14 +265,23 @@ function getLegacyOptionsConfig(action: NavAction) {
 export function getTopNavConfig(
   dashboardMode: ViewMode,
   actions: { [key: string]: NavAction },
-  hideWriteControls: boolean
+  hideWriteControls: boolean,
+  tagsTooltip?: ReactNode
 ) {
   switch (dashboardMode) {
     case ViewMode.VIEW:
       return hideWriteControls
-        ? [getShareConfig(actions[TopNavIds.SHARE])]
+        ? [
+            ...(actions[TopNavIds.TAGS]
+              ? [getTagsConfig(actions[TopNavIds.TAGS], tagsTooltip)]
+              : []),
+            getShareConfig(actions[TopNavIds.SHARE]),
+          ]
         : [
             getEditConfig(actions[TopNavIds.ENTER_EDIT_MODE], false),
+            ...(actions[TopNavIds.TAGS]
+              ? [getTagsConfig(actions[TopNavIds.TAGS], tagsTooltip)]
+              : []),
             getCloneConfig(actions[TopNavIds.CLONE]),
             getShareConfig(actions[TopNavIds.SHARE]),
           ];
@@ -253,6 +289,7 @@ export function getTopNavConfig(
       return [
         getEditConfig(actions[TopNavIds.EXIT_EDIT_MODE], true),
         getSaveConfig(actions[TopNavIds.SAVE]),
+        ...(actions[TopNavIds.TAGS] ? [getTagsConfig(actions[TopNavIds.TAGS], tagsTooltip)] : []),
         getAddConfig(actions[TopNavIds.ADD_EXISTING]),
         getOptionsConfig(actions[TopNavIds.OPTIONS]),
         getShareConfig(actions[TopNavIds.SHARE]),
@@ -312,6 +349,23 @@ function getSaveConfig(action: NavAction): TopNavMenuIconData {
     testId: 'dashboardSaveMenuItem',
     run: action,
     iconType: 'save',
+    controlType: 'icon',
+  };
+}
+
+function getTagsConfig(action: NavAction, tooltip?: ReactNode): TopNavMenuIconData {
+  return {
+    tooltip:
+      tooltip ??
+      i18n.translate('dashboard.topNav.tagsButtonTooltip', {
+        defaultMessage: 'Tags',
+      }),
+    ariaLabel: i18n.translate('dashboard.topNav.tagsButtonAriaLabel', {
+      defaultMessage: 'Manage dashboard tags',
+    }),
+    testId: 'dashboardTagsMenuItem',
+    run: action,
+    iconType: 'tag',
     controlType: 'icon',
   };
 }

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.ts
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/get_top_nav_config.ts
@@ -143,7 +143,6 @@ function getLegacySaveConfig(action: NavAction) {
 function getLegacyTagsConfig(action: NavAction, tooltip?: ReactNode) {
   return {
     id: 'tags',
-    iconType: 'tag',
     label: i18n.translate('dashboard.topNav.tagsButtonAriaLabel', {
       defaultMessage: 'tags',
     }),

--- a/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/top_nav_ids.ts
+++ b/src/plugins/dashboard/public/application/components/dashboard_top_nav/top_nav/top_nav_ids.ts
@@ -32,6 +32,7 @@ export const TopNavIds = {
   SHARE: 'share',
   OPTIONS: 'options',
   SAVE: 'save',
+  TAGS: 'tags',
   EXIT_EDIT_MODE: 'exitEditMode',
   ENTER_EDIT_MODE: 'enterEditMode',
   CLONE: 'clone',

--- a/src/plugins/dashboard/public/application/utils/mocks.ts
+++ b/src/plugins/dashboard/public/application/utils/mocks.ts
@@ -47,5 +47,12 @@ export const createDashboardServicesMock = () => {
         getListingLimit: jest.fn(),
       },
     },
+    savedObjectTags: {
+      ui: {
+        TagSelector: () => null,
+        TagList: () => null,
+        TagAssignmentModal: () => null,
+      },
+    },
   } as unknown as jest.Mocked<DashboardServices>;
 };

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -130,7 +130,7 @@ import { DashboardProvider, DashboardServices } from './types';
 import { bootstrap } from './ui_triggers';
 import { VariablesBar } from './application/components/dashboard_variables';
 import { dashboardNavPopover } from './dashboard_nav_popover';
-import { SavedObjectTagsStart } from '../../saved_object_tags/public';
+import type { SavedObjectTagsStart } from '../../saved_object_tags/public';
 
 declare module '../../share/public' {
   export interface UrlGeneratorStateMapping {
@@ -167,7 +167,7 @@ interface StartDependencies {
   share?: SharePluginStart;
   uiActions: UiActionsStart;
   savedObjects: SavedObjectsStart;
-  savedObjectTags: SavedObjectTagsStart;
+  savedObjectTags?: SavedObjectTagsStart;
 }
 
 export type RegisterDashboardProviderFn = (provider: DashboardProvider) => void;

--- a/src/plugins/dashboard/public/plugin.tsx
+++ b/src/plugins/dashboard/public/plugin.tsx
@@ -130,6 +130,7 @@ import { DashboardProvider, DashboardServices } from './types';
 import { bootstrap } from './ui_triggers';
 import { VariablesBar } from './application/components/dashboard_variables';
 import { dashboardNavPopover } from './dashboard_nav_popover';
+import { SavedObjectTagsStart } from '../../saved_object_tags/public';
 
 declare module '../../share/public' {
   export interface UrlGeneratorStateMapping {
@@ -166,6 +167,7 @@ interface StartDependencies {
   share?: SharePluginStart;
   uiActions: UiActionsStart;
   savedObjects: SavedObjectsStart;
+  savedObjectTags: SavedObjectTagsStart;
 }
 
 export type RegisterDashboardProviderFn = (provider: DashboardProvider) => void;
@@ -452,6 +454,7 @@ export class DashboardPlugin implements Plugin<
           scopedHistory: params.history,
           setHeaderActionMenu: params.setHeaderActionMenu,
           savedObjectsPublic: savedObjects,
+          savedObjectTags: pluginsStart.savedObjectTags,
           restorePreviousUrl,
           toastNotifications: coreStart.notifications.toasts,
         };

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -56,6 +56,7 @@ import { EmbeddableStart, ViewMode } from '../../embeddable/public';
 import { NavigationPublicPluginStart as NavigationStart } from '../../navigation/public';
 import { SavedDashboardPanel730ToLatest } from '../common';
 import { UiActionsStart } from '../../ui_actions/public';
+import { SavedObjectTagsStart } from '../../saved_object_tags/public';
 import { Variable } from './variables/types';
 
 export interface DashboardCapabilities {
@@ -285,6 +286,7 @@ export interface DashboardServices extends CoreStart {
   scopedHistory: ScopedHistory;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   savedObjectsPublic: SavedObjectsStart;
+  savedObjectTags: SavedObjectTagsStart;
   restorePreviousUrl: () => void;
   addBasePath?: (url: string) => string;
   toastNotifications: ToastsStart;

--- a/src/plugins/dashboard/public/types.ts
+++ b/src/plugins/dashboard/public/types.ts
@@ -56,7 +56,7 @@ import { EmbeddableStart, ViewMode } from '../../embeddable/public';
 import { NavigationPublicPluginStart as NavigationStart } from '../../navigation/public';
 import { SavedDashboardPanel730ToLatest } from '../common';
 import { UiActionsStart } from '../../ui_actions/public';
-import { SavedObjectTagsStart } from '../../saved_object_tags/public';
+import type { SavedObjectTagsStart } from '../../saved_object_tags/public';
 import { Variable } from './variables/types';
 
 export interface DashboardCapabilities {
@@ -286,7 +286,7 @@ export interface DashboardServices extends CoreStart {
   scopedHistory: ScopedHistory;
   setHeaderActionMenu: AppMountParameters['setHeaderActionMenu'];
   savedObjectsPublic: SavedObjectsStart;
-  savedObjectTags: SavedObjectTagsStart;
+  savedObjectTags?: SavedObjectTagsStart;
   restorePreviousUrl: () => void;
   addBasePath?: (url: string) => string;
   toastNotifications: ToastsStart;

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_data.tsx
@@ -30,6 +30,7 @@
 
 import { EuiButtonProps, EuiButtonIconProps } from '@elastic/eui';
 import { EuiIconType } from '@elastic/eui/src/components/icon/icon';
+import { ReactNode } from 'react';
 
 export type TopNavMenuAction = (anchorElement: HTMLElement) => void;
 export type TopNavMenuClickAction = (targetElement: HTMLElement) => void;
@@ -44,7 +45,7 @@ export interface TopNavMenuLegacyData {
   testId?: string;
   className?: string;
   disableButton?: boolean | (() => boolean);
-  tooltip?: string | (() => string | undefined);
+  tooltip?: ReactNode | (() => ReactNode);
   ariaLabel?: string;
   emphasize?: boolean;
   iconType?: EuiIconType;
@@ -62,7 +63,7 @@ interface TopNavMenuCommonData {
   testId?: string;
   className?: string;
   disabled?: boolean | (() => boolean);
-  tooltip?: string | (() => string | undefined);
+  tooltip?: ReactNode | (() => ReactNode);
 }
 
 export type TopNavMenuButtonData = TopNavMenuCommonData &
@@ -87,7 +88,7 @@ export type TopNavMenuIconData = TopNavMenuCommonData &
       ariaLabel: string;
       run?: TopNavMenuClickAction;
       href?: string;
-      tooltip: string | (() => string | undefined);
+      tooltip: ReactNode | (() => ReactNode);
       controlType: 'icon';
     },
     'href' | 'run'

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.test.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.test.tsx
@@ -174,6 +174,20 @@ describe('TopNavMenu', () => {
     expect(wrapper.find(EuiButtonIcon).length).toBe(1);
   });
 
+  it('Should render React tooltip content', () => {
+    const tooltip = <span data-test-subj="tooltipContent">Tooltip content</span>;
+    const props = {
+      ...defaultProps,
+      controlType: 'icon',
+      iconType: 'tag',
+      tooltip,
+      ariaLabel: 'Tags',
+    } as TopNavMenuIconData;
+    const wrapper = shallowWithIntl(<TopNavMenuItem {...props} />);
+
+    expect(wrapper.find(EuiToolTip).prop('content')).toBe(tooltip);
+  });
+
   it('Should render a switch', () => {
     const props = { ...defaultProps, controlType: 'switch', checked: true } as TopNavMenuSwitchData;
     const wrapper = shallowWithIntl(<TopNavMenuItem {...props} />);

--- a/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
+++ b/src/plugins/navigation/public/top_nav_menu/top_nav_menu_item.tsx
@@ -29,7 +29,7 @@
  */
 
 import { upperFirst, isFunction } from 'lodash';
-import { MouseEvent } from 'react';
+import { MouseEvent, ReactNode } from 'react';
 import classNames from 'classnames';
 import {
   EuiToolTip,
@@ -54,9 +54,9 @@ function TopNavMenuLegacyItem(props: TopNavMenuLegacyData) {
     return val ?? false;
   }
 
-  function getTooltip(): string {
+  function getTooltip(): ReactNode {
     const val = isFunction(props.tooltip) ? props.tooltip() : props.tooltip;
-    return val ?? '';
+    return val;
   }
 
   function handleClick(e: MouseEvent<HTMLButtonElement>) {

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.test.tsx
@@ -1,0 +1,89 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ *
+ * Any modifications Copyright OpenSearch Contributors. See
+ * GitHub history for details.
+ */
+
+jest.mock(
+  'lodash',
+  () => ({
+    ...jest.requireActual('lodash'),
+    debounce: (func: (...args: any[]) => any) => {
+      const debounced = (...args: any[]) => func(...args);
+      debounced.cancel = jest.fn();
+      return debounced;
+    },
+  }),
+  { virtual: true }
+);
+
+import React from 'react';
+import { act } from 'react';
+import { shallow } from 'enzyme';
+import { TableListView, TableListViewProps } from './table_list_view';
+
+const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+const createDeferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
+const createProps = (
+  findItems: TableListViewProps['findItems'],
+  refreshKey: string
+): TableListViewProps => ({
+  entityName: 'dashboard',
+  entityNamePlural: 'dashboards',
+  findItems,
+  initialFilter: '',
+  initialPageSize: 10,
+  listingLimit: 100,
+  noItemsFragment: <div />,
+  tableColumns: [],
+  tableListTitle: 'Dashboards',
+  toastNotifications: {} as TableListViewProps['toastNotifications'],
+  refreshKey,
+});
+
+describe('TableListView', () => {
+  it('ignores results fetched for an older refresh key', async () => {
+    const first = createDeferred<{ total: number; hits: any[] }>();
+    const second = createDeferred<{ total: number; hits: any[] }>();
+    const findItems = jest
+      .fn()
+      .mockResolvedValueOnce({ total: 0, hits: [] })
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const component = shallow(<TableListView {...createProps(findItems, 'initial')} />);
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    component.setProps({ refreshKey: 'tag-a' });
+    component.setProps({ refreshKey: 'tag-b' });
+
+    await act(async () => {
+      second.resolve({ total: 1, hits: [{ id: 'b', title: 'B' }] });
+      await flushPromises();
+    });
+    component.update();
+    expect(component.state('items')).toEqual([{ id: 'b', title: 'B' }]);
+
+    await act(async () => {
+      first.resolve({ total: 1, hits: [{ id: 'a', title: 'A' }] });
+      await flushPromises();
+    });
+    component.update();
+    expect(component.state('items')).toEqual([{ id: 'b', title: 'B' }]);
+  });
+});

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.test.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.test.tsx
@@ -22,7 +22,6 @@ jest.mock(
   { virtual: true }
 );
 
-import React from 'react';
 import { act } from 'react';
 import { shallow } from 'enzyme';
 import { TableListView, TableListViewProps } from './table_list_view';

--- a/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
+++ b/src/plugins/opensearch_dashboards_react/public/table_list_view/table_list_view.tsx
@@ -75,6 +75,9 @@ export interface TableListViewProps {
   tableColumns: Column[];
   tableListTitle: string;
   toastNotifications: ToastsStart;
+  tableFilters?: React.ReactNode;
+  refreshKey?: string;
+  hasActiveFilters?: boolean;
   /**
    * Id of the heading element describing the table. This id will be used as `aria-labelledby` of the wrapper element.
    * If the table is not empty, this component renders its own h1 element using the same id.
@@ -143,7 +146,13 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
     this.fetchItems();
   }
 
-  debouncedFetch = debounce(async (filter: string) => {
+  componentDidUpdate(previousProps: TableListViewProps) {
+    if (previousProps.refreshKey !== this.props.refreshKey) {
+      this.fetchItems();
+    }
+  }
+
+  debouncedFetch = debounce(async (filter: string, refreshKey?: string) => {
     try {
       const response = await this.props.findItems(filter);
 
@@ -154,7 +163,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
       // We need this check to handle the case where search results come back in a different
       // order than they were sent out. Only load results for the most recent search.
       // Also, in case filter is empty, items are being pre-sorted alphabetically.
-      if (filter === this.state.filter) {
+      if (filter === this.state.filter && refreshKey === this.props.refreshKey) {
         this.setState({
           hasInitialFetchReturned: true,
           isFetchingItems: false,
@@ -181,7 +190,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
         isFetchingItems: true,
         fetchError: undefined,
       },
-      this.debouncedFetch.bind(null, this.state.filter)
+      this.debouncedFetch.bind(null, this.state.filter, this.props.refreshKey)
     );
   };
 
@@ -235,7 +244,12 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
   }
 
   hasNoItems() {
-    return !this.state.isFetchingItems && this.state.items.length === 0 && !this.state.filter;
+    return (
+      !this.state.isFetchingItems &&
+      this.state.items.length === 0 &&
+      !this.state.filter &&
+      !this.props.hasActiveFilters
+    );
   }
 
   renderConfirmDeleteModal() {
@@ -546,6 +560,7 @@ class TableListView extends React.Component<TableListViewProps, TableListViewSta
 
         {this.renderListingLimitWarning()}
         {this.renderFetchError()}
+        {this.props.tableFilters}
 
         {this.renderTable()}
       </div>

--- a/src/plugins/saved_object_tags/common/index.ts
+++ b/src/plugins/saved_object_tags/common/index.ts
@@ -1,0 +1,6 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const TAG_ANNOTATION_TYPE = 'tag';

--- a/src/plugins/saved_object_tags/opensearch_dashboards.json
+++ b/src/plugins/saved_object_tags/opensearch_dashboards.json
@@ -1,0 +1,7 @@
+{
+  "id": "savedObjectTags",
+  "version": "opensearchDashboards",
+  "requiredPlugins": [],
+  "server": true,
+  "ui": true
+}

--- a/src/plugins/saved_object_tags/opensearch_dashboards.json
+++ b/src/plugins/saved_object_tags/opensearch_dashboards.json
@@ -1,6 +1,7 @@
 {
   "id": "savedObjectTags",
   "version": "opensearchDashboards",
+  "configPath": ["savedObjectTags"],
   "requiredPlugins": [],
   "server": true,
   "ui": true

--- a/src/plugins/saved_object_tags/public/components/index.ts
+++ b/src/plugins/saved_object_tags/public/components/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { TagAssignmentModal } from './tag_assignment_modal';
+export { TagList } from './tag_list';
+export { TagSelector } from './tag_selector';

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
@@ -26,6 +26,7 @@ const createAnnotationService = () =>
     createAnnotation: jest.fn(),
     addAnnotationToObject: jest.fn().mockResolvedValue(undefined),
     removeAnnotationFromObject: jest.fn().mockResolvedValue(undefined),
+    setAnnotationsForObject: jest.fn().mockResolvedValue(undefined),
   }) as unknown as jest.Mocked<SavedObjectAnnotationService>;
 
 const target = {
@@ -34,7 +35,7 @@ const target = {
 };
 
 describe('TagAssignmentModal', () => {
-  it('loads current assignments and saves added and removed tags', async () => {
+  it('loads current assignments and replaces them with the selected tags', async () => {
     const annotationService = createAnnotationService();
     annotationService.findAnnotations.mockResolvedValue([
       { id: 'tag-1', type: 'tag', name: 'Production', payload: { color: '#54B399' } },
@@ -83,16 +84,13 @@ describe('TagAssignmentModal', () => {
       await flushPromises();
     });
 
-    expect(annotationService.addAnnotationToObject).toHaveBeenCalledWith({
-      annotationId: 'tag-2',
+    expect(annotationService.setAnnotationsForObject).toHaveBeenCalledWith({
+      annotationIds: ['tag-2'],
       type: 'tag',
       target,
     });
-    expect(annotationService.removeAnnotationFromObject).toHaveBeenCalledWith({
-      annotationId: 'tag-1',
-      type: 'tag',
-      target,
-    });
+    expect(annotationService.addAnnotationToObject).not.toHaveBeenCalled();
+    expect(annotationService.removeAnnotationFromObject).not.toHaveBeenCalled();
     expect(onChange).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -168,8 +166,8 @@ describe('TagAssignmentModal', () => {
       name: 'Production',
       payload: { color: '#54B399' },
     });
-    expect(annotationService.addAnnotationToObject).toHaveBeenCalledWith({
-      annotationId: 'tag-new',
+    expect(annotationService.setAnnotationsForObject).toHaveBeenCalledWith({
+      annotationIds: ['tag-new'],
       type: 'tag',
       target,
     });

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
@@ -7,11 +7,11 @@ import React from 'react';
 import { act } from 'react';
 import {
   EuiBadge,
-  EuiButton,
   EuiButtonEmpty,
   EuiColorPicker,
   EuiComboBox,
   EuiFieldText,
+  EuiSmallButton,
 } from '@elastic/eui';
 import { mount } from 'enzyme';
 import { SavedObjectAnnotationService } from '../../../../core/public';
@@ -77,7 +77,7 @@ describe('TagAssignmentModal', () => {
 
     await act(async () => {
       component
-        .find(EuiButton)
+        .find(EuiSmallButton)
         .filterWhere((button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentSave')
         .prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
       await flushPromises();
@@ -147,7 +147,7 @@ describe('TagAssignmentModal', () => {
 
     await act(async () => {
       component
-        .find(EuiButton)
+        .find(EuiSmallButton)
         .filterWhere((button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentSave')
         .prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
       await flushPromises();
@@ -163,5 +163,62 @@ describe('TagAssignmentModal', () => {
       type: 'tag',
       target,
     });
+  });
+
+  it('rejects a duplicate tag name ignoring case and surrounding whitespace', async () => {
+    const annotationService = createAnnotationService();
+    annotationService.findAnnotations.mockResolvedValue([
+      { id: 'tag-1', type: 'tag', name: 'Production' },
+    ]);
+    annotationService.getAnnotationsForObject.mockResolvedValue([]);
+    const component = mount(
+      <TagAssignmentModal
+        annotationService={annotationService}
+        target={target}
+        onClose={() => {}}
+      />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    act(() => {
+      component
+        .find(EuiButtonEmpty)
+        .filterWhere(
+          (button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentShowCreate'
+        )
+        .prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
+    });
+    component.update();
+
+    act(() => {
+      component
+        .find(EuiFieldText)
+        .filterWhere((field) => field.prop('data-test-subj') === 'savedObjectTagAssignmentName')
+        .prop('onChange')!({
+        target: { value: ' production ' },
+      } as React.ChangeEvent<HTMLInputElement>);
+    });
+    component.update();
+
+    expect(
+      component
+        .find(EuiFieldText)
+        .filterWhere((field) => field.prop('data-test-subj') === 'savedObjectTagAssignmentName')
+        .prop('isInvalid')
+    ).toBe(true);
+    expect(component.text()).toContain(
+      'A tag named "Production" already exists. Select the existing tag instead.'
+    );
+    expect(
+      component
+        .find(EuiSmallButton)
+        .filterWhere((button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentSave')
+        .prop('isDisabled')
+    ).toBe(true);
+    expect(annotationService.createAnnotation).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
@@ -5,7 +5,14 @@
 
 import React from 'react';
 import { act } from 'react';
-import { EuiButton, EuiButtonEmpty, EuiColorPicker, EuiComboBox, EuiFieldText } from '@elastic/eui';
+import {
+  EuiBadge,
+  EuiButton,
+  EuiButtonEmpty,
+  EuiColorPicker,
+  EuiComboBox,
+  EuiFieldText,
+} from '@elastic/eui';
 import { mount } from 'enzyme';
 import { SavedObjectAnnotationService } from '../../../../core/public';
 import { TagAssignmentModal } from './tag_assignment_modal';
@@ -30,7 +37,7 @@ describe('TagAssignmentModal', () => {
   it('loads current assignments and saves added and removed tags', async () => {
     const annotationService = createAnnotationService();
     annotationService.findAnnotations.mockResolvedValue([
-      { id: 'tag-1', type: 'tag', name: 'Production' },
+      { id: 'tag-1', type: 'tag', name: 'Production', payload: { color: '#54B399' } },
       { id: 'tag-2', type: 'tag', name: 'Executive' },
     ]);
     annotationService.getAnnotationsForObject.mockResolvedValue([
@@ -56,6 +63,12 @@ describe('TagAssignmentModal', () => {
     expect(comboBox.prop('selectedOptions')).toEqual([
       expect.objectContaining({ label: 'Production', value: 'tag-1' }),
     ]);
+
+    const renderedOption = mount(
+      <>{comboBox.prop('renderOption')!(comboBox.prop('options')![0], '', '')}</>
+    );
+    expect(renderedOption.find(EuiBadge).prop('color')).toBe('#54B399');
+    expect(renderedOption.text()).toBe('Production');
 
     act(() => {
       comboBox.prop('onChange')!([{ label: 'Executive', value: 'tag-2' }]);

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
@@ -1,0 +1,154 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act } from 'react';
+import { EuiButton, EuiButtonEmpty, EuiColorPicker, EuiComboBox, EuiFieldText } from '@elastic/eui';
+import { mount } from 'enzyme';
+import { SavedObjectAnnotationService } from '../../../../core/public';
+import { TagAssignmentModal } from './tag_assignment_modal';
+
+const flushPromises = () => new Promise((resolve) => process.nextTick(resolve));
+
+const createAnnotationService = () =>
+  ({
+    findAnnotations: jest.fn(),
+    getAnnotationsForObject: jest.fn(),
+    createAnnotation: jest.fn(),
+    addAnnotationToObject: jest.fn().mockResolvedValue(undefined),
+    removeAnnotationFromObject: jest.fn().mockResolvedValue(undefined),
+  }) as unknown as jest.Mocked<SavedObjectAnnotationService>;
+
+const target = {
+  objectType: 'dashboard',
+  objectId: 'dashboard-1',
+};
+
+describe('TagAssignmentModal', () => {
+  it('loads current assignments and saves added and removed tags', async () => {
+    const annotationService = createAnnotationService();
+    annotationService.findAnnotations.mockResolvedValue([
+      { id: 'tag-1', type: 'tag', name: 'Production' },
+      { id: 'tag-2', type: 'tag', name: 'Executive' },
+    ]);
+    annotationService.getAnnotationsForObject.mockResolvedValue([
+      { id: 'tag-1', type: 'tag', name: 'Production' },
+    ]);
+    const onClose = jest.fn();
+    const onChange = jest.fn();
+    const component = mount(
+      <TagAssignmentModal
+        annotationService={annotationService}
+        target={target}
+        onClose={onClose}
+        onChange={onChange}
+      />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    const comboBox = component.find(EuiComboBox);
+    expect(comboBox.prop('selectedOptions')).toEqual([
+      expect.objectContaining({ label: 'Production', value: 'tag-1' }),
+    ]);
+
+    act(() => {
+      comboBox.prop('onChange')!([{ label: 'Executive', value: 'tag-2' }]);
+    });
+    component.update();
+
+    await act(async () => {
+      component
+        .find(EuiButton)
+        .filterWhere((button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentSave')
+        .prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
+      await flushPromises();
+    });
+
+    expect(annotationService.addAnnotationToObject).toHaveBeenCalledWith({
+      annotationId: 'tag-2',
+      type: 'tag',
+      target,
+    });
+    expect(annotationService.removeAnnotationFromObject).toHaveBeenCalledWith({
+      annotationId: 'tag-1',
+      type: 'tag',
+      target,
+    });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates and assigns a new tag when requested', async () => {
+    const annotationService = createAnnotationService();
+    annotationService.findAnnotations.mockResolvedValue([]);
+    annotationService.getAnnotationsForObject.mockResolvedValue([]);
+    annotationService.createAnnotation.mockResolvedValue({
+      id: 'tag-new',
+      type: 'tag',
+      name: 'Production',
+      payload: { color: '#54B399' },
+    });
+    const component = mount(
+      <TagAssignmentModal
+        annotationService={annotationService}
+        target={target}
+        onClose={() => {}}
+      />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    act(() => {
+      component
+        .find(EuiButtonEmpty)
+        .filterWhere(
+          (button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentShowCreate'
+        )
+        .prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
+    });
+    component.update();
+
+    act(() => {
+      component
+        .find(EuiFieldText)
+        .filterWhere((field) => field.prop('data-test-subj') === 'savedObjectTagAssignmentName')
+        .prop('onChange')!({
+        target: { value: 'Production' },
+      } as React.ChangeEvent<HTMLInputElement>);
+      component.find(EuiColorPicker).prop('onChange')!('#54B399', {
+        hex: '#54B399',
+        isValid: true,
+        rgba: [84, 179, 153, 1],
+      });
+    });
+    component.update();
+
+    await act(async () => {
+      component
+        .find(EuiButton)
+        .filterWhere((button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentSave')
+        .prop('onClick')!({} as React.MouseEvent<HTMLButtonElement>);
+      await flushPromises();
+    });
+
+    expect(annotationService.createAnnotation).toHaveBeenCalledWith({
+      type: 'tag',
+      name: 'Production',
+      payload: { color: '#54B399' },
+    });
+    expect(annotationService.addAnnotationToObject).toHaveBeenCalledWith({
+      annotationId: 'tag-new',
+      type: 'tag',
+      target,
+    });
+  });
+});

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.test.tsx
@@ -130,6 +130,16 @@ describe('TagAssignmentModal', () => {
     });
     component.update();
 
+    expect(
+      component
+        .find(EuiButtonEmpty)
+        .filterWhere(
+          (button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentCancelCreate'
+        )
+        .text()
+    ).toBe('Discard');
+    expect(component.find(EuiColorPicker).prop('placeholder')).toBe('No color');
+
     act(() => {
       component
         .find(EuiFieldText)
@@ -163,6 +173,12 @@ describe('TagAssignmentModal', () => {
       type: 'tag',
       target,
     });
+    expect(
+      component
+        .find(EuiSmallButton)
+        .filterWhere((button) => button.prop('data-test-subj') === 'savedObjectTagAssignmentSave')
+        .text()
+    ).toBe('Save tags');
   });
 
   it('rejects a duplicate tag name ignoring case and surrounding whitespace', async () => {

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
@@ -41,7 +41,6 @@ const normalizeTagName = (name: string) => name.trim().toLowerCase();
 
 export const TagAssignmentModal = ({ annotationService, target, onClose, onChange }: Props) => {
   const [tags, setTags] = useState<SavedObjectAnnotation[]>([]);
-  const [initialTagIds, setInitialTagIds] = useState<string[]>([]);
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
@@ -70,7 +69,6 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
 
         const assignedTagIds = assignedTags.map(({ id }) => id);
         setTags(availableTags);
-        setInitialTagIds(assignedTagIds);
         setSelectedTagIds(assignedTagIds);
       })
       .catch((error) => {
@@ -124,40 +122,21 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
     setIsSaving(true);
     setErrorMessage(undefined);
 
-    const initialTagIdSet = new Set(initialTagIds);
-    const selectedTagIdSet = new Set(selectedTagIds);
-    const tagIdsToAdd = selectedTagIds.filter((tagId) => !initialTagIdSet.has(tagId));
-    const tagIdsToRemove = initialTagIds.filter((tagId) => !selectedTagIdSet.has(tagId));
-
     try {
-      for (const annotationId of tagIdsToAdd) {
-        await annotationService.addAnnotationToObject({
-          annotationId,
-          type: TAG_ANNOTATION_TYPE,
-          target: { objectId, objectType },
-        });
-      }
-
-      for (const annotationId of tagIdsToRemove) {
-        await annotationService.removeAnnotationFromObject({
-          annotationId,
-          type: TAG_ANNOTATION_TYPE,
-          target: { objectId, objectType },
-        });
-      }
-
+      let annotationIds = selectedTagIds;
       if (showCreateTag) {
         const newTag = await annotationService.createAnnotation({
           type: TAG_ANNOTATION_TYPE,
           name: newTagName,
           payload: newTagColor ? { color: newTagColor } : undefined,
         });
-        await annotationService.addAnnotationToObject({
-          annotationId: newTag.id,
-          type: TAG_ANNOTATION_TYPE,
-          target: { objectId, objectType },
-        });
+        annotationIds = [...annotationIds, newTag.id];
       }
+      await annotationService.setAnnotationsForObject({
+        annotationIds,
+        type: TAG_ANNOTATION_TYPE,
+        target: { objectId, objectType },
+      });
 
       onChange?.();
       onClose();

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
@@ -269,12 +269,23 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
                   }}
                 >
                   {i18n.translate('savedObjectTags.tagAssignmentModal.cancelCreateTagButton', {
-                    defaultMessage: 'Cancel',
+                    defaultMessage: 'Discard',
                   })}
                 </EuiButtonEmpty>
               }
             >
-              <EuiColorPicker color={newTagColor} compressed fullWidth onChange={setNewTagColor} />
+              <EuiColorPicker
+                color={newTagColor}
+                compressed
+                fullWidth
+                placeholder={i18n.translate(
+                  'savedObjectTags.tagAssignmentModal.noColorPlaceholder',
+                  {
+                    defaultMessage: 'No color',
+                  }
+                )}
+                onChange={setNewTagColor}
+              />
             </EuiFormRow>
           </>
         )}
@@ -294,7 +305,7 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
           onClick={saveAssignments}
         >
           {i18n.translate('savedObjectTags.tagAssignmentModal.saveButton', {
-            defaultMessage: 'Save',
+            defaultMessage: 'Save tags',
           })}
         </EuiSmallButton>
       </EuiModalFooter>

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
@@ -24,6 +24,7 @@ import { i18n } from '@osd/i18n';
 import { SavedObjectAnnotation, SavedObjectAnnotationService } from '../../../../core/public';
 import { TAG_ANNOTATION_TYPE } from '../../common';
 import { TagAssignmentModalProps } from '../types';
+import { renderTagOption } from './tag_option';
 
 interface Props extends TagAssignmentModalProps {
   annotationService: SavedObjectAnnotationService;
@@ -186,6 +187,7 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
             isLoading={isLoading}
             options={options}
             selectedOptions={selectedOptions}
+            renderOption={renderTagOption}
             placeholder={i18n.translate('savedObjectTags.tagAssignmentModal.tagsPlaceholder', {
               defaultMessage: 'Select tags',
             })}

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
@@ -1,0 +1,278 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiColorPicker,
+  EuiComboBox,
+  EuiComboBoxOptionOption,
+  EuiFieldText,
+  EuiFormRow,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiModalHeaderTitle,
+  EuiSpacer,
+} from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { SavedObjectAnnotation, SavedObjectAnnotationService } from '../../../../core/public';
+import { TAG_ANNOTATION_TYPE } from '../../common';
+import { TagAssignmentModalProps } from '../types';
+
+interface Props extends TagAssignmentModalProps {
+  annotationService: SavedObjectAnnotationService;
+}
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error
+    ? error.message
+    : i18n.translate('savedObjectTags.tagAssignmentModal.unknownError', {
+        defaultMessage: 'An unexpected error occurred.',
+      });
+
+export const TagAssignmentModal = ({ annotationService, target, onClose, onChange }: Props) => {
+  const [tags, setTags] = useState<SavedObjectAnnotation[]>([]);
+  const [initialTagIds, setInitialTagIds] = useState<string[]>([]);
+  const [selectedTagIds, setSelectedTagIds] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string>();
+  const [showCreateTag, setShowCreateTag] = useState(false);
+  const [newTagName, setNewTagName] = useState('');
+  const [newTagColor, setNewTagColor] = useState('');
+  const { objectId, objectType } = target;
+
+  useEffect(() => {
+    let mounted = true;
+    setIsLoading(true);
+    setErrorMessage(undefined);
+
+    Promise.all([
+      annotationService.findAnnotations({ type: TAG_ANNOTATION_TYPE }),
+      annotationService.getAnnotationsForObject({
+        type: TAG_ANNOTATION_TYPE,
+        target: { objectId, objectType },
+      }),
+    ])
+      .then(([availableTags, assignedTags]) => {
+        if (!mounted) {
+          return;
+        }
+
+        const assignedTagIds = assignedTags.map(({ id }) => id);
+        setTags(availableTags);
+        setInitialTagIds(assignedTagIds);
+        setSelectedTagIds(assignedTagIds);
+      })
+      .catch((error) => {
+        if (mounted) {
+          setErrorMessage(getErrorMessage(error));
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [annotationService, objectId, objectType]);
+
+  const options = useMemo<Array<EuiComboBoxOptionOption<string>>>(
+    () =>
+      tags.map((tag) => ({
+        label: tag.name,
+        key: tag.id,
+        value: tag.id,
+        color: typeof tag.payload?.color === 'string' ? tag.payload.color : undefined,
+      })),
+    [tags]
+  );
+
+  const selectedOptions = options.filter(
+    ({ value }): value is string => typeof value === 'string' && selectedTagIds.includes(value)
+  );
+
+  const saveAssignments = async () => {
+    setIsSaving(true);
+    setErrorMessage(undefined);
+
+    const initialTagIdSet = new Set(initialTagIds);
+    const selectedTagIdSet = new Set(selectedTagIds);
+    const tagIdsToAdd = selectedTagIds.filter((tagId) => !initialTagIdSet.has(tagId));
+    const tagIdsToRemove = initialTagIds.filter((tagId) => !selectedTagIdSet.has(tagId));
+
+    try {
+      for (const annotationId of tagIdsToAdd) {
+        await annotationService.addAnnotationToObject({
+          annotationId,
+          type: TAG_ANNOTATION_TYPE,
+          target: { objectId, objectType },
+        });
+      }
+
+      for (const annotationId of tagIdsToRemove) {
+        await annotationService.removeAnnotationFromObject({
+          annotationId,
+          type: TAG_ANNOTATION_TYPE,
+          target: { objectId, objectType },
+        });
+      }
+
+      if (showCreateTag) {
+        const newTag = await annotationService.createAnnotation({
+          type: TAG_ANNOTATION_TYPE,
+          name: newTagName,
+          payload: newTagColor ? { color: newTagColor } : undefined,
+        });
+        await annotationService.addAnnotationToObject({
+          annotationId: newTag.id,
+          type: TAG_ANNOTATION_TYPE,
+          target: { objectId, objectType },
+        });
+      }
+
+      onChange?.();
+      onClose();
+    } catch (error) {
+      setErrorMessage(getErrorMessage(error));
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <EuiModal data-test-subj="savedObjectTagAssignmentModal" maxWidth={560} onClose={onClose}>
+      <EuiModalHeader>
+        <EuiModalHeaderTitle>
+          {i18n.translate('savedObjectTags.tagAssignmentModal.title', {
+            defaultMessage: 'Manage tags',
+          })}
+        </EuiModalHeaderTitle>
+      </EuiModalHeader>
+
+      <EuiModalBody>
+        {errorMessage && (
+          <>
+            <EuiCallOut
+              color="danger"
+              iconType="alert"
+              title={i18n.translate('savedObjectTags.tagAssignmentModal.errorTitle', {
+                defaultMessage: 'Unable to update tags',
+              })}
+            >
+              <p>{errorMessage}</p>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
+
+        <EuiFormRow
+          fullWidth
+          label={i18n.translate('savedObjectTags.tagAssignmentModal.tagsLabel', {
+            defaultMessage: 'Tags',
+          })}
+        >
+          <EuiComboBox
+            data-test-subj="savedObjectTagAssignmentSelect"
+            fullWidth
+            isLoading={isLoading}
+            options={options}
+            selectedOptions={selectedOptions}
+            placeholder={i18n.translate('savedObjectTags.tagAssignmentModal.tagsPlaceholder', {
+              defaultMessage: 'Select tags',
+            })}
+            onChange={(selection) =>
+              setSelectedTagIds(
+                selection.flatMap(({ value }) => (typeof value === 'string' ? [value] : []))
+              )
+            }
+          />
+        </EuiFormRow>
+
+        <EuiSpacer size="s" />
+
+        {!showCreateTag ? (
+          <EuiButtonEmpty
+            data-test-subj="savedObjectTagAssignmentShowCreate"
+            flush="left"
+            iconType="plusInCircle"
+            size="s"
+            onClick={() => setShowCreateTag(true)}
+          >
+            {i18n.translate('savedObjectTags.tagAssignmentModal.createTagButton', {
+              defaultMessage: 'Create tag',
+            })}
+          </EuiButtonEmpty>
+        ) : (
+          <>
+            <EuiFormRow
+              fullWidth
+              label={i18n.translate('savedObjectTags.tagAssignmentModal.newTagNameLabel', {
+                defaultMessage: 'New tag name',
+              })}
+            >
+              <EuiFieldText
+                autoFocus
+                data-test-subj="savedObjectTagAssignmentName"
+                fullWidth
+                value={newTagName}
+                onChange={(event) => setNewTagName(event.target.value)}
+              />
+            </EuiFormRow>
+            <EuiFormRow
+              fullWidth
+              label={i18n.translate('savedObjectTags.tagAssignmentModal.newTagColorLabel', {
+                defaultMessage: 'Color',
+              })}
+              labelAppend={
+                <EuiButtonEmpty
+                  data-test-subj="savedObjectTagAssignmentCancelCreate"
+                  flush="right"
+                  size="xs"
+                  onClick={() => {
+                    setShowCreateTag(false);
+                    setNewTagName('');
+                    setNewTagColor('');
+                  }}
+                >
+                  {i18n.translate('savedObjectTags.tagAssignmentModal.cancelCreateTagButton', {
+                    defaultMessage: 'Cancel',
+                  })}
+                </EuiButtonEmpty>
+              }
+            >
+              <EuiColorPicker color={newTagColor} compressed fullWidth onChange={setNewTagColor} />
+            </EuiFormRow>
+          </>
+        )}
+      </EuiModalBody>
+
+      <EuiModalFooter>
+        <EuiButtonEmpty data-test-subj="savedObjectTagAssignmentCancel" onClick={onClose}>
+          {i18n.translate('savedObjectTags.tagAssignmentModal.cancelButton', {
+            defaultMessage: 'Cancel',
+          })}
+        </EuiButtonEmpty>
+        <EuiButton
+          data-test-subj="savedObjectTagAssignmentSave"
+          fill
+          isDisabled={isLoading}
+          isLoading={isSaving}
+          onClick={saveAssignments}
+        >
+          {i18n.translate('savedObjectTags.tagAssignmentModal.saveButton', {
+            defaultMessage: 'Save',
+          })}
+        </EuiButton>
+      </EuiModalFooter>
+    </EuiModal>
+  );
+};

--- a/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_assignment_modal.tsx
@@ -3,9 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
-  EuiButton,
   EuiButtonEmpty,
   EuiCallOut,
   EuiColorPicker,
@@ -18,6 +17,7 @@ import {
   EuiModalFooter,
   EuiModalHeader,
   EuiModalHeaderTitle,
+  EuiSmallButton,
   EuiSpacer,
 } from '@elastic/eui';
 import { i18n } from '@osd/i18n';
@@ -36,6 +36,8 @@ const getErrorMessage = (error: unknown) =>
     : i18n.translate('savedObjectTags.tagAssignmentModal.unknownError', {
         defaultMessage: 'An unexpected error occurred.',
       });
+
+const normalizeTagName = (name: string) => name.trim().toLowerCase();
 
 export const TagAssignmentModal = ({ annotationService, target, onClose, onChange }: Props) => {
   const [tags, setTags] = useState<SavedObjectAnnotation[]>([]);
@@ -99,8 +101,24 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
   );
 
   const selectedOptions = options.filter(
-    ({ value }): value is string => typeof value === 'string' && selectedTagIds.includes(value)
+    ({ value }) => typeof value === 'string' && selectedTagIds.includes(value)
   );
+  const duplicateTag = useMemo(() => {
+    if (!showCreateTag) {
+      return undefined;
+    }
+
+    const normalizedName = normalizeTagName(newTagName);
+    return tags.find((tag) => normalizeTagName(tag.name) === normalizedName);
+  }, [newTagName, showCreateTag, tags]);
+  const duplicateTagError = duplicateTag
+    ? i18n.translate('savedObjectTags.tagAssignmentModal.duplicateTagError', {
+        defaultMessage: 'A tag named "{tagName}" already exists. Select the existing tag instead.',
+        values: {
+          tagName: duplicateTag.name,
+        },
+      })
+    : undefined;
 
   const saveAssignments = async () => {
     setIsSaving(true);
@@ -182,6 +200,7 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
           })}
         >
           <EuiComboBox
+            compressed
             data-test-subj="savedObjectTagAssignmentSelect"
             fullWidth
             isLoading={isLoading}
@@ -206,7 +225,7 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
             data-test-subj="savedObjectTagAssignmentShowCreate"
             flush="left"
             iconType="plusInCircle"
-            size="s"
+            size="xs"
             onClick={() => setShowCreateTag(true)}
           >
             {i18n.translate('savedObjectTags.tagAssignmentModal.createTagButton', {
@@ -216,15 +235,19 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
         ) : (
           <>
             <EuiFormRow
+              error={duplicateTagError}
               fullWidth
+              isInvalid={Boolean(duplicateTag)}
               label={i18n.translate('savedObjectTags.tagAssignmentModal.newTagNameLabel', {
                 defaultMessage: 'New tag name',
               })}
             >
               <EuiFieldText
                 autoFocus
+                compressed
                 data-test-subj="savedObjectTagAssignmentName"
                 fullWidth
+                isInvalid={Boolean(duplicateTag)}
                 value={newTagName}
                 onChange={(event) => setNewTagName(event.target.value)}
               />
@@ -258,22 +281,22 @@ export const TagAssignmentModal = ({ annotationService, target, onClose, onChang
       </EuiModalBody>
 
       <EuiModalFooter>
-        <EuiButtonEmpty data-test-subj="savedObjectTagAssignmentCancel" onClick={onClose}>
+        <EuiButtonEmpty size="s" data-test-subj="savedObjectTagAssignmentCancel" onClick={onClose}>
           {i18n.translate('savedObjectTags.tagAssignmentModal.cancelButton', {
             defaultMessage: 'Cancel',
           })}
         </EuiButtonEmpty>
-        <EuiButton
+        <EuiSmallButton
           data-test-subj="savedObjectTagAssignmentSave"
           fill
-          isDisabled={isLoading}
+          isDisabled={isLoading || Boolean(duplicateTag)}
           isLoading={isSaving}
           onClick={saveAssignments}
         >
           {i18n.translate('savedObjectTags.tagAssignmentModal.saveButton', {
             defaultMessage: 'Save',
           })}
-        </EuiButton>
+        </EuiSmallButton>
       </EuiModalFooter>
     </EuiModal>
   );

--- a/src/plugins/saved_object_tags/public/components/tag_list.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_list.test.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act } from 'react';
+import { mount } from 'enzyme';
+import { EuiBadge } from '@elastic/eui';
+import { SavedObjectAnnotationService } from '../../../../core/public';
+import { TagList } from './tag_list';
+
+const flushPromises = () => new Promise((resolve) => process.nextTick(resolve));
+
+describe('TagList', () => {
+  it('renders caller-provided loading content', () => {
+    const annotationService = {
+      getAnnotationsForObject: jest.fn().mockReturnValue(new Promise(() => {})),
+    } as unknown as SavedObjectAnnotationService;
+    const component = mount(
+      <TagList
+        annotationService={annotationService}
+        target={{ objectType: 'dashboard', objectId: 'dashboard-1' }}
+        loadingContent={<span data-test-subj="tagListLoading">Loading</span>}
+      />
+    );
+
+    expect(component.find('[data-test-subj="tagListLoading"]').first().text()).toBe('Loading');
+  });
+
+  it('loads and renders tags for the target object', async () => {
+    const annotationService = {
+      getAnnotationsForObject: jest.fn().mockResolvedValue([
+        {
+          id: 'tag-1',
+          type: 'tag',
+          name: 'Production',
+          payload: { color: '#54B399' },
+        },
+      ]),
+    } as unknown as SavedObjectAnnotationService;
+    const component = mount(
+      <TagList
+        annotationService={annotationService}
+        target={{ objectType: 'dashboard', objectId: 'dashboard-1' }}
+      />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    expect(annotationService.getAnnotationsForObject).toHaveBeenCalledWith({
+      type: 'tag',
+      target: { objectType: 'dashboard', objectId: 'dashboard-1' },
+    });
+    expect(component.find(EuiBadge).text()).toBe('Production');
+  });
+
+  it('reloads tags when the refresh key changes', async () => {
+    const annotationService = {
+      getAnnotationsForObject: jest
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([{ id: 'tag-1', type: 'tag', name: 'Production' }]),
+    } as unknown as SavedObjectAnnotationService;
+    const component = mount(
+      <TagList
+        annotationService={annotationService}
+        target={{ objectType: 'dashboard', objectId: 'dashboard-1' }}
+        refreshKey={0}
+      />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.setProps({ refreshKey: 1 });
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    expect(annotationService.getAnnotationsForObject).toHaveBeenCalledTimes(2);
+    expect(component.find(EuiBadge).text()).toBe('Production');
+  });
+
+  it('renders caller-provided empty content', async () => {
+    const annotationService = {
+      getAnnotationsForObject: jest.fn().mockResolvedValue([]),
+    } as unknown as SavedObjectAnnotationService;
+    const component = mount(
+      <TagList
+        annotationService={annotationService}
+        target={{ objectType: 'dashboard', objectId: 'dashboard-1' }}
+        emptyContent={<span data-test-subj="tagListEmpty">No tags</span>}
+      />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    expect(component.find('[data-test-subj="tagListEmpty"]').first().text()).toBe('No tags');
+  });
+});

--- a/src/plugins/saved_object_tags/public/components/tag_list.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_list.tsx
@@ -1,0 +1,79 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { EuiBadge, EuiBadgeGroup } from '@elastic/eui';
+import { SavedObjectAnnotation, SavedObjectAnnotationService } from '../../../../core/public';
+import { TAG_ANNOTATION_TYPE } from '../../common';
+import { TagListProps } from '../types';
+
+interface Props extends TagListProps {
+  annotationService: SavedObjectAnnotationService;
+}
+
+export const TagList = ({
+  annotationService,
+  target,
+  refreshKey,
+  loadingContent,
+  emptyContent,
+}: Props) => {
+  const [tags, setTags] = useState<SavedObjectAnnotation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const { objectId, objectType } = target;
+
+  useEffect(() => {
+    let mounted = true;
+    setIsLoading(true);
+    annotationService
+      .getAnnotationsForObject({
+        type: TAG_ANNOTATION_TYPE,
+        target: {
+          objectId,
+          objectType,
+        },
+      })
+      .then((annotations) => {
+        if (mounted) {
+          setTags(annotations);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setTags([]);
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [annotationService, objectId, objectType, refreshKey]);
+
+  if (isLoading) {
+    return loadingContent ? <>{loadingContent}</> : null;
+  }
+
+  if (!tags.length) {
+    return emptyContent ? <>{emptyContent}</> : null;
+  }
+
+  return (
+    <EuiBadgeGroup data-test-subj="savedObjectTagList">
+      {tags.map((tag) => (
+        <EuiBadge
+          key={tag.id}
+          color={typeof tag.payload?.color === 'string' ? tag.payload.color : 'hollow'}
+        >
+          {tag.name}
+        </EuiBadge>
+      ))}
+    </EuiBadgeGroup>
+  );
+};

--- a/src/plugins/saved_object_tags/public/components/tag_option.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_option.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiBadge, EuiComboBoxOptionOption, EuiHighlight } from '@elastic/eui';
+
+export const renderTagOption = (option: EuiComboBoxOptionOption<string>, searchValue: string) => (
+  <EuiBadge color={option.color || 'hollow'}>
+    <EuiHighlight search={searchValue}>{option.label}</EuiHighlight>
+  </EuiBadge>
+);

--- a/src/plugins/saved_object_tags/public/components/tag_selector.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_selector.test.tsx
@@ -26,7 +26,11 @@ describe('TagSelector', () => {
     } as unknown as SavedObjectAnnotationService;
     const onChange = jest.fn();
     const component = mount(
-      <TagSelector annotationService={annotationService} onChange={onChange} />
+      <TagSelector
+        annotationService={annotationService}
+        selectedTagId="tag-1"
+        onChange={onChange}
+      />
     );
 
     await act(async () => {
@@ -38,6 +42,10 @@ describe('TagSelector', () => {
     expect(comboBox.prop('options')).toEqual([
       { label: 'Production', key: 'tag-1', value: 'tag-1', color: '#54B399' },
     ]);
+    expect(comboBox.prop('selectedOptions')).toEqual([
+      { label: 'Production', key: 'tag-1', value: 'tag-1', color: '#54B399' },
+    ]);
+    expect(comboBox.prop('singleSelection')).toBe(true);
 
     const renderedOption = mount(
       <>{comboBox.prop('renderOption')!(comboBox.prop('options')![0], 'prod', '')}</>

--- a/src/plugins/saved_object_tags/public/components/tag_selector.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_selector.test.tsx
@@ -6,7 +6,7 @@
 import React from 'react';
 import { act } from 'react';
 import { mount } from 'enzyme';
-import { EuiComboBox } from '@elastic/eui';
+import { EuiBadge, EuiComboBox } from '@elastic/eui';
 import { SavedObjectAnnotationService } from '../../../../core/public';
 import { TagSelector } from './tag_selector';
 
@@ -38,6 +38,12 @@ describe('TagSelector', () => {
     expect(comboBox.prop('options')).toEqual([
       { label: 'Production', key: 'tag-1', value: 'tag-1', color: '#54B399' },
     ]);
+
+    const renderedOption = mount(
+      <>{comboBox.prop('renderOption')!(comboBox.prop('options')![0], 'prod', '')}</>
+    );
+    expect(renderedOption.find(EuiBadge).prop('color')).toBe('#54B399');
+    expect(renderedOption.text()).toBe('Production');
 
     comboBox.prop('onChange')!([{ label: 'Production', value: 'tag-1' }]);
     expect(onChange).toHaveBeenCalledWith('tag-1');

--- a/src/plugins/saved_object_tags/public/components/tag_selector.test.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_selector.test.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { act } from 'react';
+import { mount } from 'enzyme';
+import { EuiComboBox } from '@elastic/eui';
+import { SavedObjectAnnotationService } from '../../../../core/public';
+import { TagSelector } from './tag_selector';
+
+const flushPromises = () => new Promise((resolve) => process.nextTick(resolve));
+
+describe('TagSelector', () => {
+  it('loads tags and reports the selected annotation ID', async () => {
+    const annotationService = {
+      findAnnotations: jest.fn().mockResolvedValue([
+        {
+          id: 'tag-1',
+          type: 'tag',
+          name: 'Production',
+          payload: { color: '#54B399' },
+        },
+      ]),
+    } as unknown as SavedObjectAnnotationService;
+    const onChange = jest.fn();
+    const component = mount(
+      <TagSelector annotationService={annotationService} onChange={onChange} />
+    );
+
+    await act(async () => {
+      await flushPromises();
+    });
+    component.update();
+
+    const comboBox = component.find(EuiComboBox);
+    expect(comboBox.prop('options')).toEqual([
+      { label: 'Production', key: 'tag-1', value: 'tag-1', color: '#54B399' },
+    ]);
+
+    comboBox.prop('onChange')!([{ label: 'Production', value: 'tag-1' }]);
+    expect(onChange).toHaveBeenCalledWith('tag-1');
+  });
+});

--- a/src/plugins/saved_object_tags/public/components/tag_selector.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_selector.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { EuiComboBox, EuiComboBoxOptionOption } from '@elastic/eui';
+import { i18n } from '@osd/i18n';
+import { SavedObjectAnnotation, SavedObjectAnnotationService } from '../../../../core/public';
+import { TAG_ANNOTATION_TYPE } from '../../common';
+import { TagSelectorProps } from '../types';
+
+interface Props extends TagSelectorProps {
+  annotationService: SavedObjectAnnotationService;
+}
+
+export const TagSelector = ({ annotationService, selectedTagId, onChange }: Props) => {
+  const [tags, setTags] = useState<SavedObjectAnnotation[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    setIsLoading(true);
+    setHasError(false);
+    annotationService
+      .findAnnotations({ type: TAG_ANNOTATION_TYPE })
+      .then((annotations) => {
+        if (mounted) {
+          setTags(annotations);
+        }
+      })
+      .catch(() => {
+        if (mounted) {
+          setHasError(true);
+        }
+      })
+      .finally(() => {
+        if (mounted) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, [annotationService]);
+
+  const options = useMemo<Array<EuiComboBoxOptionOption<string>>>(
+    () =>
+      tags.map((tag) => ({
+        label: tag.name,
+        key: tag.id,
+        value: tag.id,
+        color: typeof tag.payload?.color === 'string' ? tag.payload.color : undefined,
+      })),
+    [tags]
+  );
+  const selectedOptions = selectedTagId
+    ? options.filter(({ value }) => value === selectedTagId)
+    : [];
+
+  if (hasError) {
+    return null;
+  }
+
+  return (
+    <EuiComboBox
+      aria-label={i18n.translate('savedObjectTags.tagSelector.ariaLabel', {
+        defaultMessage: 'Filter by tag',
+      })}
+      data-test-subj="savedObjectTagSelector"
+      placeholder={i18n.translate('savedObjectTags.tagSelector.placeholder', {
+        defaultMessage: 'Filter by tag',
+      })}
+      options={options}
+      selectedOptions={selectedOptions}
+      singleSelection={{ asPlainText: true }}
+      isClearable
+      isLoading={isLoading}
+      fullWidth
+      onChange={(selection) => onChange(selection[0]?.value)}
+    />
+  );
+};

--- a/src/plugins/saved_object_tags/public/components/tag_selector.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_selector.tsx
@@ -9,6 +9,7 @@ import { i18n } from '@osd/i18n';
 import { SavedObjectAnnotation, SavedObjectAnnotationService } from '../../../../core/public';
 import { TAG_ANNOTATION_TYPE } from '../../common';
 import { TagSelectorProps } from '../types';
+import { renderTagOption } from './tag_option';
 
 interface Props extends TagSelectorProps {
   annotationService: SavedObjectAnnotationService;
@@ -76,6 +77,7 @@ export const TagSelector = ({ annotationService, selectedTagId, onChange }: Prop
       options={options}
       selectedOptions={selectedOptions}
       singleSelection={{ asPlainText: true }}
+      renderOption={renderTagOption}
       isClearable
       isLoading={isLoading}
       fullWidth

--- a/src/plugins/saved_object_tags/public/components/tag_selector.tsx
+++ b/src/plugins/saved_object_tags/public/components/tag_selector.tsx
@@ -67,6 +67,7 @@ export const TagSelector = ({ annotationService, selectedTagId, onChange }: Prop
 
   return (
     <EuiComboBox
+      compressed
       aria-label={i18n.translate('savedObjectTags.tagSelector.ariaLabel', {
         defaultMessage: 'Filter by tag',
       })}
@@ -76,7 +77,7 @@ export const TagSelector = ({ annotationService, selectedTagId, onChange }: Prop
       })}
       options={options}
       selectedOptions={selectedOptions}
-      singleSelection={{ asPlainText: true }}
+      singleSelection
       renderOption={renderTagOption}
       isClearable
       isLoading={isLoading}

--- a/src/plugins/saved_object_tags/public/index.ts
+++ b/src/plugins/saved_object_tags/public/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PluginInitializerContext } from '../../../core/public';
+import { SavedObjectTagsPlugin } from './plugin';
+
+export {
+  SavedObjectTagsStart,
+  TagAssignmentModalProps,
+  TagListProps,
+  TagSelectorProps,
+} from './types';
+
+export const plugin = (_initializerContext: PluginInitializerContext) =>
+  new SavedObjectTagsPlugin();

--- a/src/plugins/saved_object_tags/public/plugin.tsx
+++ b/src/plugins/saved_object_tags/public/plugin.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreStart, Plugin } from '../../../core/public';
+import { TagAssignmentModal, TagList, TagSelector } from './components';
+import { SavedObjectTagsStart } from './types';
+
+export class SavedObjectTagsPlugin implements Plugin<void, SavedObjectTagsStart> {
+  public setup() {}
+
+  public start(core: CoreStart): SavedObjectTagsStart {
+    return {
+      ui: {
+        TagSelector: (props) => (
+          <TagSelector annotationService={core.savedObjects.annotations} {...props} />
+        ),
+        TagList: (props) => (
+          <TagList annotationService={core.savedObjects.annotations} {...props} />
+        ),
+        TagAssignmentModal: (props) => (
+          <TagAssignmentModal annotationService={core.savedObjects.annotations} {...props} />
+        ),
+      },
+    };
+  }
+
+  public stop() {}
+}

--- a/src/plugins/saved_object_tags/public/types.ts
+++ b/src/plugins/saved_object_tags/public/types.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ComponentType, ReactNode } from 'react';
+import { SavedObjectAnnotationTarget } from '../../../core/public';
+
+export interface TagSelectorProps {
+  selectedTagId?: string;
+  onChange: (tagId?: string) => void;
+}
+
+export interface TagListProps {
+  target: SavedObjectAnnotationTarget;
+  refreshKey?: number;
+  loadingContent?: ReactNode;
+  emptyContent?: ReactNode;
+}
+
+export interface TagAssignmentModalProps {
+  target: SavedObjectAnnotationTarget;
+  onClose: () => void;
+  onChange?: () => void;
+}
+
+export interface SavedObjectTagsStart {
+  ui: {
+    TagSelector: ComponentType<TagSelectorProps>;
+    TagList: ComponentType<TagListProps>;
+    TagAssignmentModal: ComponentType<TagAssignmentModalProps>;
+  };
+}

--- a/src/plugins/saved_object_tags/server/config.ts
+++ b/src/plugins/saved_object_tags/server/config.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+export const configSchema = schema.object({
+  enabled: schema.boolean({ defaultValue: false }),
+});
+
+export type SavedObjectTagsConfig = TypeOf<typeof configSchema>;

--- a/src/plugins/saved_object_tags/server/index.ts
+++ b/src/plugins/saved_object_tags/server/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { PluginInitializerContext } from '../../../core/server';
+import { SavedObjectTagsPlugin } from './plugin';
+
+export const plugin = (_initializerContext: PluginInitializerContext) =>
+  new SavedObjectTagsPlugin();

--- a/src/plugins/saved_object_tags/server/index.ts
+++ b/src/plugins/saved_object_tags/server/index.ts
@@ -3,8 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../core/server';
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../core/server';
+import { configSchema, SavedObjectTagsConfig } from './config';
 import { SavedObjectTagsPlugin } from './plugin';
 
-export const plugin = (_initializerContext: PluginInitializerContext) =>
+export const config: PluginConfigDescriptor<SavedObjectTagsConfig> = {
+  schema: configSchema,
+};
+
+export const plugin = (_initializerContext: PluginInitializerContext<SavedObjectTagsConfig>) =>
   new SavedObjectTagsPlugin();

--- a/src/plugins/saved_object_tags/server/plugin.test.ts
+++ b/src/plugins/saved_object_tags/server/plugin.test.ts
@@ -5,9 +5,14 @@
 
 import { coreMock } from '../../../core/server/mocks';
 import { TAG_ANNOTATION_TYPE } from '../common';
+import { configSchema } from './config';
 import { SavedObjectTagsPlugin } from './plugin';
 
 describe('SavedObjectTagsPlugin', () => {
+  it('is disabled by default', () => {
+    expect(configSchema.validate({})).toEqual({ enabled: false });
+  });
+
   it('registers tags for dashboards and visualizations', () => {
     const core = coreMock.createSetup();
     const plugin = new SavedObjectTagsPlugin();
@@ -19,5 +24,16 @@ describe('SavedObjectTagsPlugin', () => {
       supportedObjectTypes: ['dashboard', 'visualization'],
       uniqueName: true,
     });
+  });
+
+  it('rejects enabling tags when core annotations are disabled', () => {
+    const core = coreMock.createSetup();
+    core.savedObjects.annotations.enabled = false;
+    const plugin = new SavedObjectTagsPlugin();
+
+    expect(() => plugin.setup(core)).toThrow(
+      '`savedObjectTags.enabled` requires `savedObjects.annotations.enabled` to be true.'
+    );
+    expect(core.savedObjects.annotations.registerAnnotationType).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/saved_object_tags/server/plugin.test.ts
+++ b/src/plugins/saved_object_tags/server/plugin.test.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { coreMock } from '../../../core/server/mocks';
+import { TAG_ANNOTATION_TYPE } from '../common';
+import { SavedObjectTagsPlugin } from './plugin';
+
+describe('SavedObjectTagsPlugin', () => {
+  it('registers tags for dashboards and visualizations', () => {
+    const core = coreMock.createSetup();
+    const plugin = new SavedObjectTagsPlugin();
+
+    plugin.setup(core);
+
+    expect(core.savedObjects.annotations.registerAnnotationType).toHaveBeenCalledWith({
+      type: TAG_ANNOTATION_TYPE,
+      supportedObjectTypes: ['dashboard', 'visualization'],
+    });
+  });
+});

--- a/src/plugins/saved_object_tags/server/plugin.test.ts
+++ b/src/plugins/saved_object_tags/server/plugin.test.ts
@@ -17,6 +17,7 @@ describe('SavedObjectTagsPlugin', () => {
     expect(core.savedObjects.annotations.registerAnnotationType).toHaveBeenCalledWith({
       type: TAG_ANNOTATION_TYPE,
       supportedObjectTypes: ['dashboard', 'visualization'],
+      uniqueName: true,
     });
   });
 });

--- a/src/plugins/saved_object_tags/server/plugin.ts
+++ b/src/plugins/saved_object_tags/server/plugin.ts
@@ -11,6 +11,7 @@ export class SavedObjectTagsPlugin implements Plugin<void, void> {
     core.savedObjects.annotations.registerAnnotationType({
       type: TAG_ANNOTATION_TYPE,
       supportedObjectTypes: ['dashboard', 'visualization'],
+      uniqueName: true,
     });
   }
 

--- a/src/plugins/saved_object_tags/server/plugin.ts
+++ b/src/plugins/saved_object_tags/server/plugin.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreSetup, Plugin } from '../../../core/server';
+import { TAG_ANNOTATION_TYPE } from '../common';
+
+export class SavedObjectTagsPlugin implements Plugin<void, void> {
+  public setup(core: CoreSetup) {
+    core.savedObjects.annotations.registerAnnotationType({
+      type: TAG_ANNOTATION_TYPE,
+      supportedObjectTypes: ['dashboard', 'visualization'],
+    });
+  }
+
+  public start() {}
+  public stop() {}
+}

--- a/src/plugins/saved_object_tags/server/plugin.ts
+++ b/src/plugins/saved_object_tags/server/plugin.ts
@@ -8,6 +8,12 @@ import { TAG_ANNOTATION_TYPE } from '../common';
 
 export class SavedObjectTagsPlugin implements Plugin<void, void> {
   public setup(core: CoreSetup) {
+    if (!core.savedObjects.annotations.enabled) {
+      throw new Error(
+        '`savedObjectTags.enabled` requires `savedObjects.annotations.enabled` to be true.'
+      );
+    }
+
     core.savedObjects.annotations.registerAnnotationType({
       type: TAG_ANNOTATION_TYPE,
       supportedObjectTypes: ['dashboard', 'visualization'],


### PR DESCRIPTION
### Description

As the number of dashboards and visualizations grows, finding and organizing saved objects by title alone becomes difficult. This PR introduces saved object tags so users can classify dashboards with reusable, colored labels and filter the dashboard list by tag.

Rather than adding a tag-specific field and lifecycle logic to every saved object type, this PR introduces a generic annotation framework in the Saved Objects service. Tags are the first annotation type built on this framework.

### How the annotation framework works

An annotation definition is stored as a regular `saved-object-annotation` saved object. It contains a type, name, optional description, and optional payload for annotation-specific metadata. Tags use the payload to store their color.

Plugins register annotation types during setup and declare which saved object types they support. The tags plugin registers the `tag` annotation type for dashboards and visualizations and requires tag names to be unique.

Annotations are attached to target objects through saved object references. For example, assigning a tag to a dashboard adds a reference from the dashboard to the tag definition. This allows the existing Saved Objects infrastructure to handle relationships, export and import, and filtering through `hasReference`.

The core annotation service provides operations to:

- Create, update, find, and delete annotation definitions.
- Attach and remove annotations from supported saved objects.
- Retrieve annotations assigned to a saved object.
- Validate annotation types and supported target object types.
- Remove references from target objects before deleting an annotation.

Saved object writers do not normally know about references owned by other features. To prevent tags from disappearing when a dashboard is saved or overwritten, core preserves persisted annotation references across regular create, update, bulk-create, and bulk-update operations. Annotation mutations use an internal client path so explicitly removing a reference still works.

The framework is exposed through request-scoped server services, internal HTTP routes, and a browser client. Additional annotation types can reuse the same lifecycle and attachment behavior without introducing custom fields on every target saved object type.

### Dashboard integration

The initial UI integration focuses on dashboards. Users can create, assign, and remove colored tags from the dashboard header in either view or edit mode. Hovering over the tag action displays the currently assigned tags.

The dashboard listing includes a Tags column and supports filtering dashboards by a selected tag. Tag options and selected values are consistently rendered as colored labels.


### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

https://github.com/user-attachments/assets/05505813-592d-4138-ae6a-fb35d41aa6e0



<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
