### PR TITLE
feat(chat): add open-state data-test-subj to chat header button

### DIFF
--- a/src/plugins/chat/public/components/chat_header_button.test.tsx
+++ b/src/plugins/chat/public/components/chat_header_button.test.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render } from '@testing-library/react';
+import { render, act } from '@testing-library/react';
+import { BehaviorSubject } from 'rxjs';
 
 import { ChatHeaderButton } from './chat_header_button';
 import { coreMock } from '../../../../core/public/mocks';
@@ -87,6 +88,77 @@ describe('ChatHeaderButton', () => {
       button?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
 
       expect(mockCore.chat.closeWindow).toHaveBeenCalled();
+    });
+  });
+
+  describe('open state data-test-subj', () => {
+    it('should expose the open-window test subj when the window is closed', () => {
+      mockCore.chat.getWindowState$.mockReturnValue(
+        new BehaviorSubject({
+          isWindowOpen: false,
+          windowMode: 'sidecar' as const,
+          paddingSize: 400,
+        })
+      );
+
+      const { container } = render(<ChatHeaderButton core={mockCore} />);
+
+      expect(
+        container.querySelector('[data-test-subj="chatHeaderButtonOpenChatWindow"]')
+      ).toBeTruthy();
+      expect(
+        container.querySelector('[data-test-subj="chatHeaderButtonCloseChatWindow"]')
+      ).toBeNull();
+    });
+
+    it('should expose the close-window test subj when the window is open', () => {
+      mockCore.chat.getWindowState$.mockReturnValue(
+        new BehaviorSubject({
+          isWindowOpen: true,
+          windowMode: 'sidecar' as const,
+          paddingSize: 400,
+        })
+      );
+
+      const { container } = render(<ChatHeaderButton core={mockCore} />);
+
+      expect(
+        container.querySelector('[data-test-subj="chatHeaderButtonCloseChatWindow"]')
+      ).toBeTruthy();
+      expect(
+        container.querySelector('[data-test-subj="chatHeaderButtonOpenChatWindow"]')
+      ).toBeNull();
+    });
+
+    it('should replace the button node (not mutate in place) when the window state changes', () => {
+      const windowState$ = new BehaviorSubject({
+        isWindowOpen: false,
+        windowMode: 'sidecar' as const,
+        paddingSize: 400,
+      });
+      mockCore.chat.getWindowState$.mockReturnValue(windowState$);
+
+      const { container } = render(<ChatHeaderButton core={mockCore} />);
+
+      const openButton = container.querySelector(
+        '[data-test-subj="chatHeaderButtonOpenChatWindow"]'
+      );
+      expect(openButton).toBeTruthy();
+
+      act(() => {
+        windowState$.next({ isWindowOpen: true, windowMode: 'sidecar', paddingSize: 400 });
+      });
+
+      const closeButton = container.querySelector(
+        '[data-test-subj="chatHeaderButtonCloseChatWindow"]'
+      );
+      expect(closeButton).toBeTruthy();
+      // The rendered node is a brand-new element (state-derived key forces a
+      // remount), not the same node with a mutated attribute.
+      expect(closeButton).not.toBe(openButton);
+      // The old node is detached but keeps its original (pre-click) test subj,
+      // which is what click telemetry reads from the clicked element.
+      expect(openButton?.getAttribute('data-test-subj')).toBe('chatHeaderButtonOpenChatWindow');
     });
   });
 

--- a/src/plugins/chat/public/components/chat_header_button.tsx
+++ b/src/plugins/chat/public/components/chat_header_button.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { EuiToolTip, EuiButtonEmpty, EuiIcon } from '@elastic/eui';
 import { FormattedMessage } from '@osd/i18n/react';
 import { CoreStart } from '../../../../core/public';
@@ -23,6 +23,17 @@ export const ChatHeaderButton = React.forwardRef<ChatHeaderButtonInstance, ChatH
     // Use core chat service enablement logic
     const isChatAvailable = core.chat.isAvailable();
 
+    // Track the chat window open state reactively so the button's data-test-subj
+    // reflects the action a click will perform.
+    const [isWindowOpen, setIsWindowOpen] = useState(core.chat.isWindowOpen());
+
+    useEffect(() => {
+      const subscription = core.chat
+        .getWindowState$()
+        .subscribe((state) => setIsWindowOpen(state.isWindowOpen));
+      return () => subscription.unsubscribe();
+    }, [core.chat]);
+
     const toggleChatWindow = useCallback(() => {
       if (core.chat.isWindowOpen()) {
         core.chat.closeWindow();
@@ -35,14 +46,27 @@ export const ChatHeaderButton = React.forwardRef<ChatHeaderButtonInstance, ChatH
       return null;
     }
 
+    // The data-test-subj encodes the action the button will perform (open when
+    // closed, close when open). Use the same value as the React `key` so that
+    // when the window state changes, React unmounts this button and mounts a
+    // fresh one rather than mutating the attribute on the live node in place.
+    // The automatic click-telemetry listener reads the clicked node while the
+    // click bubbles up; because the clicked node is replaced (not mutated), the
+    // node it reads keeps its pre-click data-test-subj regardless of timing.
+    const testSubj = isWindowOpen
+      ? 'chatHeaderButtonCloseChatWindow'
+      : 'chatHeaderButtonOpenChatWindow';
+
     return (
       <EuiToolTip content="Open Chat Assistant">
         <EuiButtonEmpty
+          key={testSubj}
           size="s"
           onClick={toggleChatWindow}
           color="primary"
           aria-label="Toggle chat assistant"
           className="chatHeaderButton__button"
+          data-test-subj={testSubj}
         >
           <EuiIcon type={gradientGenerateIcon} size="s" className="chatHeaderButton__icon" />
           <FormattedMessage id="chat.headerButton.askAI" defaultMessage="Ask AI" />


### PR DESCRIPTION
### Description

The chat header (Ask AI) button now exposes a `data-test-subj` that reflects the chat window open state. The button subscribes to `core.chat.getWindowState$()` and renders one of two hooks:

- `chatHeaderButtonOpenChatWindow` when the chat window is closed (clicking will open it)
- `chatHeaderButtonCloseChatWindow` when the chat window is open (clicking will close it)

Before this change the button only read `core.chat.isWindowOpen()` on click and had no state-reflecting test hook, so functional tests could neither assert nor wait on the chat window state from the header button. The attribute now updates live as the window opens and closes.

### Issues Resolved

N/A

## Screenshot

N/A - no visual change. Only a `data-test-subj` attribute is added to the existing button.

## Testing the changes

- Added unit tests in `src/plugins/chat/public/components/chat_header_button.test.tsx` covering the closed state, the open state, and a live open/close transition.
- Ran `yarn test:jest src/plugins/chat/public/components/chat_header_button.test.tsx` - 12/12 pass.
- `tsc --noEmit` clean and `eslint` clean on the changed files.

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
