### PR TITLE
[Explore] Add data-test-subj to log action menu items

### DIFF
--- a/src/plugins/explore/public/components/log_action_menu/log_action_menu.test.tsx
+++ b/src/plugins/explore/public/components/log_action_menu/log_action_menu.test.tsx
@@ -140,6 +140,20 @@ describe('LogActionMenu', () => {
       });
     });
 
+    it('sets a data-test-subj on each menu item using the action id', async () => {
+      mockGetCompatibleActions.mockReturnValue([mockAction1, mockAction2]);
+
+      render(<LogActionMenu {...defaultProps} />);
+
+      const button = screen.getByTestId('logActionMenuButton');
+      fireEvent.click(button);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('logActionMenuItem-action-1')).toBeInTheDocument();
+        expect(screen.getByTestId('logActionMenuItem-action-2')).toBeInTheDocument();
+      });
+    });
+
     it('displays action icons in the menu', async () => {
       mockGetCompatibleActions.mockReturnValue([mockAction1]);
 

--- a/src/plugins/explore/public/components/log_action_menu/log_action_menu.tsx
+++ b/src/plugins/explore/public/components/log_action_menu/log_action_menu.tsx
@@ -98,6 +98,7 @@ export const LogActionMenu: React.FC<LogActionMenuProps> = ({
         name: action.displayName,
         icon: action.iconType,
         onClick: () => handleActionSelect(action),
+        'data-test-subj': `logActionMenuItem-${action.id}`,
       })),
     },
   ];


### PR DESCRIPTION
### Description

Adds a `data-test-subj` to each item in the log action menu context panel (`log_action_menu.tsx` in the `explore` plugin). Each item now gets `logActionMenuItem-${action.id}`, so individual log actions can be selected reliably from functional and integration tests. Previously only the trigger button (`logActionMenuButton`) was addressable, and menu items could only be located by their display text.

### Issues Resolved

N/A

## Screenshot

No visible UI change (test-only attribute).

## Testing the changes

- `yarn jest src/plugins/explore/public/components/log_action_menu/log_action_menu.test.tsx` (18 passed, including a new case asserting `logActionMenuItem-<id>` is present on each item)
- eslint clean on the changed files

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
