### PR TITLE
fix(visualization): improve horizontal bar gauge layout

### DIFF
--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_component.scss
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_component.scss
@@ -9,8 +9,8 @@ $bar-gauge-radius: 2px;
 
   &.horizontal {
     flex-direction: column;
-    padding: 4% 2%;
-    gap: 40px; // fixed to 40px, min height for horizontal bar
+    padding: 20px;
+    gap: 20px; // fixed to 20px, min height for horizontal bar
   }
 
   &.vertical {
@@ -30,7 +30,7 @@ $bar-gauge-radius: 2px;
   }
 
   .horizontal & {
-    min-height: 40px;
+    min-height: 64px;
   }
 }
 
@@ -40,10 +40,12 @@ $bar-gauge-radius: 2px;
   flex: 1;
 
   &.horizontal {
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 4px;
     width: 100%;
-    min-height: 40px; // don't shrink below this — container scrolls
+    min-height: 64px; // don't shrink below this — container scrolls
+    overflow: visible;
   }
 
   &.vertical {
@@ -57,22 +59,33 @@ $bar-gauge-radius: 2px;
 // bar gauge label
 .bar-gauge-label {
   font-size: 12px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 
   .horizontal & {
-    width: 80px;
-    min-width: 80px;
-    padding-right: 8px;
-    text-align: right;
+    font-size: 18px;
+    width: 100%;
+    min-width: 0;
+    text-align: left;
+    white-space: normal;
+    overflow-wrap: anywhere;
   }
 
   .vertical & {
     width: 100%;
     padding-top: 8px;
     text-align: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
+}
+
+.bar-gauge-bar-row {
+  display: flex;
+  align-items: stretch;
+  column-gap: 16px;
+  flex: 1;
+  width: 100%;
+  min-height: 40px;
 }
 
 // unfilled area background
@@ -82,6 +95,7 @@ $bar-gauge-radius: 2px;
   border-radius: $bar-gauge-radius;
 
   .horizontal & {
+    min-width: 0;
     height: 100%;
   }
 
@@ -144,12 +158,19 @@ $bar-gauge-radius: 2px;
 .bar-gauge-value {
   font-weight: 400;
   white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+
+  .horizontal & {
+    flex: 0 0 var(--bar-gauge-value-width);
+    width: var(--bar-gauge-value-width);
+    align-self: center;
+    text-align: right;
+  }
 
   .vertical & {
     font-size: 14px;
     text-align: center;
     margin-bottom: 4px;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 }

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_item.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_item.test.tsx
@@ -131,6 +131,23 @@ describe('BarGaugeItem', () => {
       expect(screen.getByText('89.2')).toBeInTheDocument();
     });
 
+    it('renders the category above a row containing the bar and value', () => {
+      const { container } = render(
+        <BarGaugeItem
+          item={makeItem({ category: 'A long category', displayValue: '89.2' })}
+          styles={makeStyles({ valueDisplay: 'valueColor' })}
+          isHorizontal={true}
+        />
+      );
+
+      const item = container.querySelector('.bar-gauge-item.horizontal');
+      expect(item?.firstElementChild).toHaveClass('bar-gauge-label');
+
+      const barRow = item?.querySelector('.bar-gauge-bar-row');
+      expect(barRow?.children[0]).toHaveClass('bar-gauge-background');
+      expect(barRow?.children[1]).toHaveClass('bar-gauge-value');
+    });
+
     it('does not render value element when valueDisplay is hidden', () => {
       const { container } = render(
         <BarGaugeItem

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_item.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_item.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiToolTip } from '@elastic/eui';
+import { EuiToolTip } from '@elastic/eui';
 import { Threshold } from '../types';
 import { BarGaugeChartStyle } from './bar_gauge_vis_config';
 import { getColors } from '../theme/default_colors';
@@ -155,24 +155,17 @@ export const BarGaugeItem: React.FC<BarGaugeItemProps> = ({
 
   const renderHorizontal = () => {
     return (
-      <EuiFlexGroup direction="column" justifyContent="center" gutterSize="xs">
-        {!valueHidden && (
-          <EuiFlexItem grow={false}>
-            {/* 80px = category label width, 8px = padding */}
-            <div style={{ paddingLeft: 80 + 8 }}>
-              <div className="bar-gauge-value" style={valueStyle} title={displayValue}>
-                {displayValue}
-              </div>
+      <div className={`bar-gauge-item ${orientation}`}>
+        {categoryLabel}
+        <div className="bar-gauge-bar-row">
+          {bar}
+          {!valueHidden && (
+            <div className="bar-gauge-value" style={valueStyle} title={displayValue}>
+              {displayValue}
             </div>
-          </EuiFlexItem>
-        )}
-        <EuiFlexItem>
-          <div className={`bar-gauge-item ${orientation}`}>
-            {categoryLabel}
-            {bar}
-          </div>
-        </EuiFlexItem>
-      </EuiFlexGroup>
+          )}
+        </div>
+      </div>
     );
   };
 

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.test.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.test.tsx
@@ -14,6 +14,16 @@ global.ResizeObserver = class MockResizeObserver {
   unobserve = jest.fn();
 };
 
+const mockMeasureText = jest.fn((text: string) => ({ width: text.length * 8 }));
+
+Object.defineProperty(HTMLCanvasElement.prototype, 'getContext', {
+  configurable: true,
+  value: jest.fn(() => ({
+    font: '',
+    measureText: mockMeasureText,
+  })),
+});
+
 jest.mock('./bar_gauge_component.scss', () => ({}));
 
 // Mock BarGaugeItem to isolate render logic from item rendering details
@@ -43,6 +53,10 @@ jest.mock('../style_panel/unit/collection', () => ({
 const defaultStyles = defaultBarGaugeChartStyles;
 
 describe('BarGaugeRender', () => {
+  beforeEach(() => {
+    mockMeasureText.mockImplementation((text: string) => ({ width: text.length * 8 }));
+  });
+
   describe('rendering items', () => {
     it('renders one BarGaugeItem per data entry', () => {
       const data = [
@@ -146,6 +160,33 @@ describe('BarGaugeRender', () => {
         <BarGaugeRender data={[]} styles={defaultStyles} isHorizontal={false} />
       );
       expect(container.querySelector('.main-bar-gauge-container')).toHaveClass('vertical');
+    });
+
+    it('sizes the horizontal value column to the widest formatted display value', () => {
+      mockMeasureText.mockImplementation((text: string) => ({
+        width: text === '888 °C' ? 72.4 : 54.1,
+      }));
+      const styles = {
+        ...defaultStyles,
+        decimals: 0,
+        unitSuffix: '°C',
+      };
+      const { container } = render(
+        <BarGaugeRender
+          data={[
+            { category: 'A', value: 111 },
+            { category: 'B', value: 888 },
+          ]}
+          styles={styles}
+          isHorizontal={true}
+        />
+      );
+
+      expect(mockMeasureText).toHaveBeenCalledWith('111 °C');
+      expect(mockMeasureText).toHaveBeenCalledWith('888 °C');
+
+      const mainContainer = container.querySelector('.main-bar-gauge-container') as HTMLElement;
+      expect(mainContainer.style.getPropertyValue('--bar-gauge-value-width')).toBe('75px');
     });
   });
 

--- a/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.tsx
+++ b/src/plugins/explore/public/components/visualizations/bar_gauge/bar_gauge_render.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback, useMemo, useState, useRef, useEffect } from 'react';
+import { CSSProperties, useCallback, useMemo, useState, useRef, useEffect } from 'react';
 import { debounce } from 'lodash';
 import { Threshold } from '../types';
 import { BarGaugeChartStyle } from './bar_gauge_vis_config';
@@ -20,6 +20,30 @@ interface BarGaugeRenderProps {
   styles: BarGaugeChartStyle;
   isHorizontal: boolean;
 }
+
+interface BarGaugeContainerStyle extends CSSProperties {
+  '--bar-gauge-value-width': string;
+}
+
+const DEFAULT_VALUE_FONT_SIZE = 14;
+const VALUE_WIDTH_BUFFER = 2;
+const DEFAULT_VALUE_FONT_FAMILY =
+  'Rubik, -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
+
+let measurementContext: CanvasRenderingContext2D | null = null;
+
+const measureTextWidth = (text: string, fontSize: number, fontFamily: string): number => {
+  if (!measurementContext && typeof document !== 'undefined') {
+    measurementContext = document.createElement('canvas').getContext('2d');
+  }
+
+  if (!measurementContext) {
+    return text.length * fontSize * 0.6;
+  }
+
+  measurementContext.font = `400 ${fontSize}px ${fontFamily}`;
+  return measurementContext.measureText(text).width;
+};
 
 // Build thresholds for each bar
 const buildItemThresholds = (
@@ -45,6 +69,7 @@ const buildItemThresholds = (
 export const BarGaugeRender = ({ data, styles, isHorizontal }: BarGaugeRenderProps) => {
   // State for container dimensions
   const [containerDimensions, setContainerDimensions] = useState({ width: 0, height: 0 });
+  const [valueFontFamily, setValueFontFamily] = useState(DEFAULT_VALUE_FONT_FAMILY);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const handlerRef = useRef(
     debounce((entries: ResizeObserverEntry[]) => {
@@ -58,6 +83,8 @@ export const BarGaugeRender = ({ data, styles, isHorizontal }: BarGaugeRenderPro
   useEffect(() => {
     const element = containerRef.current;
     if (!element) return;
+
+    setValueFontFamily(getComputedStyle(element).fontFamily || DEFAULT_VALUE_FONT_FAMILY);
 
     const handler = handlerRef.current;
     const resizeObserver = new ResizeObserver(handler);
@@ -198,10 +225,30 @@ export const BarGaugeRender = ({ data, styles, isHorizontal }: BarGaugeRenderPro
     return Math.min(24, fontSize);
   }, [containerDimensions, data.length, isHorizontal, items]);
 
+  const valueColumnWidth = useMemo(() => {
+    if (!isHorizontal || styles.exclusive.valueDisplay === 'hidden' || items.length === 0) {
+      return 0;
+    }
+
+    const fontSize = valueFontSize ?? DEFAULT_VALUE_FONT_SIZE;
+    const widestValue = items.reduce(
+      (maxWidth, item) =>
+        Math.max(maxWidth, measureTextWidth(item.displayValue, fontSize, valueFontFamily)),
+      0
+    );
+
+    return Math.ceil(widestValue) + VALUE_WIDTH_BUFFER;
+  }, [isHorizontal, items, styles.exclusive.valueDisplay, valueFontFamily, valueFontSize]);
+
+  const containerStyle: BarGaugeContainerStyle | undefined = isHorizontal
+    ? { '--bar-gauge-value-width': `${valueColumnWidth}px` }
+    : undefined;
+
   return (
     <div
       ref={containerRef}
       className={`main-bar-gauge-container ${isHorizontal ? 'horizontal' : 'vertical'}`}
+      style={containerStyle}
     >
       {items.map((item, index) => (
         <BarGaugeItem


### PR DESCRIPTION
### Description
Horizontal bar gauges currently reserve a fixed-width label column, causing long series names to be truncated. This change introduces a layout that makes labels and values easier to read and compare.


- display full series labels above horizontal bars
- align values using a shared measured-width column

<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot
<img width="1154" height="393" alt="Screenshot 2026-09-04 at 17 28 22" src="https://github.com/user-attachments/assets/117b0acf-4811-42da-b2f9-1ba15fea7458" />

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
