### PR TITLE
fix(chat): gate /api/chat/proxy on workspace access

### DIFF
--- a/src/core/server/utils/index.ts
+++ b/src/core/server/utils/index.ts
@@ -35,6 +35,7 @@ export * from './streams';
 export { getPrincipalsFromRequest } from './auth_info';
 export { getWorkspaceIdFromUrl, cleanWorkspaceId } from '../../utils';
 export { updateWorkspaceState, getWorkspaceState } from './workspace';
+export { isRequestWorkspaceAuthorized, WorkspaceAccessContract } from './workspace_access';
 export {
   ACLAuditorStateKey,
   initializeACLAuditor,

--- a/src/core/server/utils/workspace_access.ts
+++ b/src/core/server/utils/workspace_access.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from '@osd/logging';
+import { OpenSearchDashboardsRequest } from '../http/router';
+import { PermissionModeId } from '../../types';
+import { getWorkspaceState } from './workspace';
+
+export interface WorkspaceAccessContract {
+  authorizeWorkspace: (
+    request: OpenSearchDashboardsRequest,
+    workspaceIds: string[],
+    permissionModes?: PermissionModeId[]
+  ) => Promise<{ authorized: boolean }>;
+}
+
+export async function isRequestWorkspaceAuthorized(
+  workspace: WorkspaceAccessContract | undefined,
+  request: OpenSearchDashboardsRequest,
+  logger: Logger
+): Promise<boolean> {
+  const workspaceId = getWorkspaceState(request).requestWorkspaceId;
+  if (!workspaceId) return false;
+  if (!workspace) return true; // no authZ when workspace disabled
+  try {
+    const { authorized } = await workspace.authorizeWorkspace(request, [workspaceId]);
+    return authorized;
+  } catch (error) {
+    logger.warn(
+      `Workspace authorization check failed, denying request: ${
+        error instanceof Error ? error.message : error
+      }`
+    );
+    return false;
+  }
+}

--- a/src/plugins/chat/opensearch_dashboards.json
+++ b/src/plugins/chat/opensearch_dashboards.json
@@ -10,6 +10,6 @@
     "contextProvider",
     "charts"
   ],
-  "optionalPlugins": ["dataSource"],
+  "optionalPlugins": ["dataSource", "workspace"],
   "requiredBundles": ["dataSourceManagement"]
 }

--- a/src/plugins/chat/server/plugin.ts
+++ b/src/plugins/chat/server/plugin.ts
@@ -19,6 +19,11 @@ import {
 import { ChatPluginSetup, ChatPluginStart } from './types';
 import { defineRoutes } from './routes';
 import { ChatConfigType } from './config';
+import { WorkspacePluginStart } from '../../workspace/server';
+
+interface ChatServerStartDeps {
+  workspace?: WorkspacePluginStart;
+}
 
 /**
  * @experimental
@@ -29,6 +34,7 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
   private readonly config$: Observable<ChatConfigType>;
   private capabilitiesResolver?: (request: OpenSearchDashboardsRequest) => Promise<Capabilities>;
   private httpAuth?: HttpAuth;
+  private workspace?: WorkspacePluginStart;
 
   constructor(initializerContext: PluginInitializerContext) {
     this.logger = initializerContext.logger.get();
@@ -41,6 +47,7 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
     const router = core.http.createRouter();
     const getCapabilitiesResolver = () => this.capabilitiesResolver;
     const getHttpAuth = () => this.httpAuth;
+    const getWorkspace = () => this.workspace;
 
     // Register capability to indicate observability agent availability
     core.capabilities.registerProvider(() => ({
@@ -57,7 +64,8 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
       config.mlCommonsAgentId,
       config.observabilityAgentId,
       config.forwardCredentials,
-      getHttpAuth
+      getHttpAuth,
+      getWorkspace
     );
 
     return {
@@ -66,12 +74,13 @@ export class ChatPlugin implements Plugin<ChatPluginSetup, ChatPluginStart> {
     };
   }
 
-  public start(core: CoreStart) {
+  public start(core: CoreStart, deps: ChatServerStartDeps) {
     this.logger.debug('chat: Started');
 
     this.capabilitiesResolver = (request: OpenSearchDashboardsRequest) =>
       core.capabilities.resolveCapabilities(request);
     this.httpAuth = core.http.auth;
+    this.workspace = deps.workspace;
 
     return {};
   }

--- a/src/plugins/chat/server/routes/index.test.ts
+++ b/src/plugins/chat/server/routes/index.test.ts
@@ -10,6 +10,13 @@ import { defineRoutes, generateOboToken, getValidOboToken } from './index';
 import { MLAgentRouterFactory } from './ml_routes/ml_agent_router';
 import { MLAgentRouterRegistry } from './ml_routes/router_registry';
 import { RequestHandlerContext, Logger } from '../../../../core/server';
+import { getWorkspaceState } from '../../../../core/server/utils/workspace';
+import { WorkspacePluginStart } from '../../../workspace/server';
+
+jest.mock('../../../../core/server/utils/workspace', () => ({
+  ...jest.requireActual('../../../../core/server/utils/workspace'),
+  getWorkspaceState: jest.fn(() => ({})),
+}));
 
 // Mock native fetch
 global.fetch = jest.fn();
@@ -25,7 +32,8 @@ describe('Chat Proxy Routes', () => {
     agUiUrl?: string,
     getCapabilitiesResolver?: () => ((request: any) => Promise<any>) | undefined,
     mlCommonsAgentId?: string,
-    forwardCredentials?: boolean
+    forwardCredentials?: boolean,
+    getWorkspace?: () => { authorizeWorkspace: jest.Mock } | undefined
   ) => {
     const { server: testServer, httpSetup, handlerContext } = await setupServer();
     lastHandlerContext = handlerContext;
@@ -39,7 +47,9 @@ describe('Chat Proxy Routes', () => {
       getCapabilitiesResolver,
       mlCommonsAgentId,
       undefined,
-      forwardCredentials
+      forwardCredentials,
+      undefined,
+      getWorkspace as unknown as (() => WorkspacePluginStart | undefined) | undefined
     );
 
     // Mock dynamicConfigService required by server.start()
@@ -64,6 +74,7 @@ describe('Chat Proxy Routes', () => {
     });
 
     jest.clearAllMocks();
+    (getWorkspaceState as jest.Mock).mockReturnValue({});
   });
 
   afterEach(async () => {
@@ -598,6 +609,77 @@ describe('Chat Proxy Routes', () => {
 
         expect(requestBody.messages).toHaveLength(1);
         expect(requestBody.messages[0]).toEqual(validRequest.messages[0]);
+      });
+    });
+
+    describe('Workspace access', () => {
+      const mockAgUiStream = () =>
+        mockFetch.mockResolvedValue({
+          ok: true,
+          status: 200,
+          body: { getReader: () => ({ read: jest.fn().mockResolvedValue({ done: true }) }) },
+        } as any);
+
+      const forwardedBody = () =>
+        JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+
+      it('strips a client-supplied workspaceId on an unscoped request', async () => {
+        mockAgUiStream();
+        (getWorkspaceState as jest.Mock).mockReturnValue({});
+
+        const httpSetup = await testSetup('http://test-agui:3000');
+        await supertest(httpSetup.server.listener)
+          .post('/api/chat/proxy')
+          .send({ ...validRequest, forwardedProps: { workspaceId: 'spoofed-ws' } })
+          .expect(200);
+
+        expect(forwardedBody().forwardedProps).not.toHaveProperty('workspaceId');
+      });
+
+      it('pins workspaceId to the request workspace, overwriting a spoofed value', async () => {
+        mockAgUiStream();
+        (getWorkspaceState as jest.Mock).mockReturnValue({ requestWorkspaceId: 'ws-real' });
+        const authorizeWorkspace = jest.fn().mockResolvedValue({ authorized: true });
+
+        const httpSetup = await testSetup(
+          'http://test-agui:3000',
+          undefined,
+          undefined,
+          undefined,
+          () => ({
+            authorizeWorkspace,
+          })
+        );
+        await supertest(httpSetup.server.listener)
+          .post('/api/chat/proxy')
+          .send({ ...validRequest, forwardedProps: { workspaceId: 'spoofed-ws' } })
+          .expect(200);
+
+        expect(authorizeWorkspace).toHaveBeenCalledWith(expect.any(Object), ['ws-real']);
+        expect(forwardedBody().forwardedProps.workspaceId).toBe('ws-real');
+      });
+
+      it('returns 403 when the caller is not authorized for the request workspace', async () => {
+        mockAgUiStream();
+        (getWorkspaceState as jest.Mock).mockReturnValue({ requestWorkspaceId: 'ws-real' });
+        const authorizeWorkspace = jest.fn().mockResolvedValue({ authorized: false });
+
+        const httpSetup = await testSetup(
+          'http://test-agui:3000',
+          undefined,
+          undefined,
+          undefined,
+          () => ({
+            authorizeWorkspace,
+          })
+        );
+        const response = await supertest(httpSetup.server.listener)
+          .post('/api/chat/proxy')
+          .send({ ...validRequest, forwardedProps: { workspaceId: 'spoofed-ws' } })
+          .expect(403);
+
+        expect(response.body.message).toBe('Access to this workspace is denied');
+        expect(mockFetch).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/plugins/chat/server/routes/index.ts
+++ b/src/plugins/chat/server/routes/index.ts
@@ -14,7 +14,12 @@ import {
   Capabilities,
   OpenSearchClient,
 } from '../../../../core/server';
-import { getPrincipalsFromRequest } from '../../../../core/server/utils';
+import {
+  getPrincipalsFromRequest,
+  getWorkspaceState,
+  isRequestWorkspaceAuthorized,
+} from '../../../../core/server/utils';
+import { WorkspacePluginStart } from '../../../workspace/server';
 import { MLAgentRouterFactory } from './ml_routes/ml_agent_router';
 import { MLAgentRouterRegistry } from './ml_routes/router_registry';
 import { injectSystemPrompt } from '../prompts';
@@ -243,7 +248,8 @@ export function defineRoutes(
   mlCommonsAgentId?: string,
   observabilityAgentId?: string,
   forwardCredentials?: boolean,
-  getHttpAuth?: () => HttpAuth | undefined
+  getHttpAuth?: () => HttpAuth | undefined,
+  getWorkspace?: () => WorkspacePluginStart | undefined
 ) {
   // Route for searching agent memory sessions (conversation history)
   router.post(
@@ -361,6 +367,23 @@ export function defineRoutes(
     },
     async (context, request, response) => {
       const dataSourceId = request.query?.dataSourceId;
+
+      // If given workspaceId, then ensure user can access the workspace, and
+      // forwardedProps.workspaceId is consistent. Otherwise no ACL check and
+      // no forwardedProps.workspaceId.
+      const requestWorkspaceId = getWorkspaceState(request).requestWorkspaceId;
+      const mutableBody = request.body as { forwardedProps?: Record<string, unknown> };
+      const forwardedProps = (mutableBody.forwardedProps ?? {}) as Record<string, unknown>;
+      if (requestWorkspaceId) {
+        if (!(await isRequestWorkspaceAuthorized(getWorkspace?.(), request, logger))) {
+          logger.warn('Chat proxy rejected: caller lacks access to the requested workspace');
+          return response.forbidden({ body: { message: 'Access to this workspace is denied' } });
+        }
+        forwardedProps.workspaceId = requestWorkspaceId;
+      } else {
+        delete forwardedProps.workspaceId;
+      }
+      mutableBody.forwardedProps = forwardedProps;
 
       try {
         // Inject server-side system prompt if present


### PR DESCRIPTION
### Description

The proxy forwards forwardedProps verbatim to the ML/AG-UI agent. We may add an agent that consumes `forwardedProps.workspaceId`. Without a workspace check a caller could reach that agent with a workspaceId they are not authorized for.

Authorize the request's workspace before forwarding, and pin forwardedProps.workspaceId to the server-derived workspace (or strip it when the request is unscoped) so the claim cannot be spoofed.

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
