### PR TITLE
Supports configuring OpenSearch Dashboards to `zh-CN`, `zh-TW`, `tr-TR`, `pt-PT`, `pt-BR`, `ko-KR`, `ja-JP`, `it-IT`, `id-ID`, `fr-FR`, `fr-CA`, `es-ES`, `es-419`, `de-DE`

### DIFF
--- a/config/opensearch_dashboards.yml
+++ b/config/opensearch_dashboards.yml
@@ -186,7 +186,11 @@
 # ops.interval: 5000
 
 # Specifies locale to be used for all localizable strings, dates and number formats.
-# Supported languages are the following: English - en , by default , Chinese - zh-CN .
+# Supported languages are the following: English - en (default), German - de-DE, Spanish - es-ES,
+# Spanish (Latin America) - es-419, French - fr-FR, French (Canada) - fr-CA, Indonesian - id-ID,
+# Italian - it-IT, Japanese - ja-JP, Korean - ko-KR, Portuguese - pt-PT, Portuguese (Brazil) - pt-BR,
+# Turkish - tr-TR, Chinese (Simplified) - zh-CN, Chinese (Traditional) - zh-TW.
+# In Docker, this can be set with the I18N_LOCALE environment variable.
 # i18n.locale: "en"
 
 # Set the allowlist to check input graphite Url. Allowlist is the default check list.

--- a/src/dev/build/tasks/copy_source_task.ts
+++ b/src/dev/build/tasks/copy_source_task.ts
@@ -45,6 +45,7 @@ export const CopySource: Task = {
       dot: false,
       select: [
         'src/**',
+        'src/.i18nrc.json',
         '!src/**/*.{test,test.mocks,mock}.{js,ts,tsx}',
         '!src/**/mocks.ts', // special file who imports .mock files
         '!src/**/{target,__tests__,__snapshots__,__mocks__}/**',


### PR DESCRIPTION
### Description

<!-- Describe what this change achieves-->

- Supports configuring OpenSearch Dashboards to `zh-CN`, `zh-TW`, `tr-TR`, `pt-PT`, `pt-BR`, `ko-KR`, `ja-JP`, `it-IT`, `id-ID`, `fr-FR`, `fr-CA`, `es-ES`, `es-419`, `de-DE`.
- `dot: false` excludes dotfiles from `src/**`, so the i18n registration manifest must be listed explicitly. Without it the distributable ships `src/translations/*.json` but the server's `*/.i18nrc.json` lookup finds zero translation paths, so `i18n.locale` (e.g. `I18N_LOCALE=zh-CN` in the Docker image) silently stays in English. See https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8075#issuecomment-5550508447 .

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

- closes #8075 .
- closes #9868 .
- closes #8244 .
- closes #772 .

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

- <img width="2876" height="1466" alt="image" src="https://github.com/user-attachments/assets/9ee9a95a-a3be-4f3e-86d8-6a26dbf495e3" />

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

- Based on https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8075#issuecomment-5550530122 .

### Check List

- [x] All tests pass
  - [x] `yarn test:jest`
  - [x] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
