### PR TITLE
Fix PPL aggregation request mutation

### DIFF
--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.test.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.test.ts
@@ -761,6 +761,9 @@ describe('pplSearchStrategyProvider', () => {
           { name: 'field1', type: 'long', values: [] },
           { name: 'field2', type: 'text', values: [] },
         ],
+        // aggs is initialised to {} before the loop, so it is always present when aggConfig is
+        // set — even when every individual aggregation request fails (all keys are skipped).
+        aggs: {},
         meta: {
           date_histogram: {
             field: 'timestamp',
@@ -775,5 +778,90 @@ describe('pplSearchStrategyProvider', () => {
       took: 10,
     });
     expect(usage.trackSuccess).toHaveBeenCalledWith(10);
+  });
+
+  it('should accumulate all keys when aggConfig.qs has multiple entries', async () => {
+    // Primary search response
+    const mockPrimaryResponse = {
+      success: true,
+      data: {
+        schema: [{ name: 'field1', type: 'long' }],
+        datarows: [[1]],
+      },
+      took: 10,
+    };
+    // Per-key agg responses: key '1' → bucketA, key '2' → bucketB
+    const mockAggResponse1 = {
+      success: true,
+      data: {
+        datarows: [
+          [10, '2024-01-01'],
+          [20, '2024-01-02'],
+        ],
+      },
+    };
+    const mockAggResponse2 = {
+      success: true,
+      data: {
+        datarows: [
+          [30, '2024-01-01'],
+          [40, '2024-01-02'],
+        ],
+      },
+    };
+    const mockDescribeQuery = jest
+      .fn()
+      .mockResolvedValueOnce(mockPrimaryResponse)
+      .mockResolvedValueOnce(mockAggResponse1)
+      .mockResolvedValueOnce(mockAggResponse2);
+    const mockFacet = {
+      describeQuery: mockDescribeQuery,
+    } as unknown as facet.Facet;
+    jest.spyOn(facet, 'Facet').mockImplementation(() => mockFacet);
+    (utils.getFields as jest.Mock).mockReturnValue([{ name: 'field1', type: 'long' }]);
+
+    const originalQuery = 'source = my_table';
+    const strategy = pplSearchStrategyProvider(config$, logger, client, usage);
+    const result = await strategy.search(
+      mockRequestHandlerContext,
+      {
+        body: {
+          query: { query: originalQuery, dataset: { id: 'test-dataset' } },
+          aggConfig: {
+            qs: {
+              '1': 'source = my_table | stats count() by span(ts, 1h)',
+              '2': 'source = my_table | stats avg(val) by span(ts, 1h)',
+            },
+          },
+        },
+      } as unknown as IOpenSearchDashboardsSearchRequest<unknown>,
+      {}
+    );
+
+    // Both keys must be present — neither should overwrite the other
+    // @ts-expect-error TS2339 TODO(ts-error): fixme
+    expect(result.body.aggs).toEqual({
+      '1': [
+        { key: '2024-01-01', value: 10 },
+        { key: '2024-01-02', value: 20 },
+      ],
+      '2': [
+        { key: '2024-01-01', value: 30 },
+        { key: '2024-01-02', value: 40 },
+      ],
+    });
+
+    // The original query string on the request must not have been mutated
+    expect(mockDescribeQuery.mock.calls[1][1].body.query.query).toBe(
+      'source = my_table | stats count() by span(ts, 1h)'
+    );
+    expect(mockDescribeQuery.mock.calls[2][1].body.query.query).toBe(
+      'source = my_table | stats avg(val) by span(ts, 1h)'
+    );
+    // The two agg calls must receive independent request objects (not the same reference)
+    expect(mockDescribeQuery.mock.calls[1][1]).not.toBe(mockDescribeQuery.mock.calls[2][1]);
+    expect(mockDescribeQuery.mock.calls[1][1].body).not.toBe(
+      mockDescribeQuery.mock.calls[2][1].body
+    );
   });
 });

--- a/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
+++ b/src/plugins/query_enhancements/server/search/ppl_search_strategy.ts
@@ -122,12 +122,23 @@ export const pplSearchStrategyProvider = (
           const aggFetchSize = await context.core.uiSettings.client.get<number>(
             AGGREGATION_SAMPLE_SIZE_SETTING
           );
-          const aggRequest = { ...request, body: { ...request.body, fetchSize: aggFetchSize } };
+          // Initialise once before the loop so results from every key accumulate instead of being
+          // reset to {} on each iteration (which previously left only the last key in aggs).
+          (dataFrame as IDataFrameWithAggs).aggs = {};
           for (const [key, aggQueryString] of Object.entries(aggConfig.qs)) {
-            aggRequest.body.query = { ...aggRequest.body.query, query: aggQueryString };
-            const rawAggs: any = await pplFacet.describeQuery(context, aggRequest);
+            // Build a fresh, fully-isolated request per iteration.  A single shallow spread of
+            // `body` is not sufficient because `query` is a nested object — mutating it on the
+            // shared copy corrupted the original query string for all subsequent iterations.
+            const iterRequest = {
+              ...request,
+              body: {
+                ...request.body,
+                fetchSize: aggFetchSize,
+                query: { ...request.body.query, query: aggQueryString },
+              },
+            };
+            const rawAggs: any = await pplFacet.describeQuery(context, iterRequest);
             if (!rawAggs.success) continue;
-            (dataFrame as IDataFrameWithAggs).aggs = {};
             (dataFrame as IDataFrameWithAggs).aggs[key] = rawAggs.data.datarows?.map((hit: any) => {
               return {
                 key: hit[1],


### PR DESCRIPTION
### Description

Fix the PPL search strategy aggregation loop to prevent request mutation and preserve aggregation results across multiple aggregation queries.

Previously, the aggregation request was reused and its nested query object was mutated for each aggregation. This could cause subsequent iterations to operate on a modified request. Additionally, aggs was reset inside the loop, causing results from previously processed aggregation keys to be overwritten.

This change:

Creates a fresh, isolated request for each aggregation query.
Preserves the original request query.
Initializes aggs once before the aggregation loop so results from all keys are retained.
Adds regression coverage for multiple aggregation queries.

### Issues Resolved
Closes #11679

## Screenshot

NA

## Testing the changes

Targeted PPL search strategy tests:

yarn test:jest src/plugins/query_enhancements/server/search/ppl_search_strategy.test.ts

Result: 23 passed, 23 total

Also verified:

git diff --check

No whitespace errors.

The full Query Enhancements test suite was also run. It had one unrelated existing failure in:

src/plugins/query_enhancements/public/search/filters/sql_filter_utils.test.ts

The failing SQL test was reproduced independently and is unrelated to these changes.

### Check List

- [x] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
