### PR TITLE
Fix clipped boundary bars when showing the full time range

### DIFF
--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
@@ -11,7 +11,14 @@ import {
   createDoubleNumericalBarChart,
 } from './to_expression';
 import { BarChartStyle, defaultBarChartStyles } from './bar_vis_config';
-import { VisColumn, VisFieldType, AxisRole, ThresholdMode, AggregationType } from '../types';
+import {
+  VisColumn,
+  VisFieldType,
+  AxisRole,
+  ThresholdMode,
+  AggregationType,
+  TimeUnit,
+} from '../types';
 import { getColors } from '../theme/default_colors';
 
 describe('bar to_expression', () => {
@@ -290,6 +297,34 @@ describe('bar to_expression', () => {
       expect(seriesWithMarkLine.markLine.data[0].yAxis).toBe(15);
     });
 
+    test('aligns the full time range to the visualization bucket boundaries', () => {
+      const from = new Date(2023, 0, 1, 12);
+      const to = new Date(2023, 0, 2, 12);
+      const styles: BarChartStyle = {
+        ...defaultBarChartStyles,
+        bucket: {
+          ...defaultBarChartStyles.bucket,
+          bucketTimeUnit: TimeUnit.DATE,
+        },
+      };
+
+      const { spec } = createTimeBarChart(
+        mockData,
+        styles,
+        {
+          [AxisRole.X]: mockDateColumn,
+          [AxisRole.Y]: [mockNumericalColumn],
+        },
+        {
+          from: from.toISOString(),
+          to: to.toISOString(),
+        }
+      );
+
+      expect(spec.xAxis.min).toEqual(new Date(2023, 0, 1));
+      expect(spec.xAxis.max).toEqual(new Date(2023, 0, 3));
+    });
+
     describe('bucketing vs skip bucketing', () => {
       const axisMappings = {
         [AxisRole.X]: mockDateColumn,
@@ -404,6 +439,24 @@ describe('bar to_expression', () => {
       expect(result.legendItems.map((item) => item.color)).toEqual([palette[0], palette[2]]);
     });
 
+    test('aligns the full time range to the auto-inferred bucket boundaries', () => {
+      const axisMappings = {
+        [AxisRole.X]: mockDateColumn,
+        [AxisRole.Y]: mockNumericalColumn,
+        [AxisRole.COLOR]: mockCategoricalColumn,
+      };
+      const from = new Date(2023, 0, 1, 12);
+      const to = new Date(2023, 0, 2, 12);
+
+      const { spec } = createGroupedTimeBarChart(mockData, defaultBarChartStyles, axisMappings, {
+        from: from.toISOString(),
+        to: to.toISOString(),
+      });
+
+      expect(spec.xAxis.min).toEqual(new Date(2023, 0, 1));
+      expect(spec.xAxis.max).toEqual(new Date(2023, 0, 3));
+    });
+
     describe('bucketing vs skip bucketing', () => {
       const axisMappings = {
         [AxisRole.X]: mockDateColumn,
@@ -435,14 +488,21 @@ describe('bar to_expression', () => {
           bucket: { ...defaultBarChartStyles.bucket, aggregationType: AggregationType.NONE },
         };
 
+        const timeRange = {
+          from: new Date(2023, 0, 1, 8, 0, 0, 50).toISOString(),
+          to: new Date(2023, 0, 1, 8, 0, 0, 350).toISOString(),
+        };
         const { spec: noBucketSpec } = createGroupedTimeBarChart(
           sameBucketData,
           noBucketStyles,
-          axisMappings
+          axisMappings,
+          timeRange
         );
 
         // No bucketing: pivot groups by raw timestamp strings (3 unique = header + 3 data rows)
         expect(noBucketSpec.dataset.source.length).toBe(4);
+        expect(noBucketSpec.xAxis.min).toEqual(new Date(timeRange.from));
+        expect(noBucketSpec.xAxis.max).toEqual(new Date(timeRange.to));
       });
     });
   });

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.test.ts
@@ -364,6 +364,32 @@ describe('bar to_expression', () => {
         // No bucketing: all 3 raw data points preserved (header + 3 data rows)
         expect(noBucketSpec.dataset.source.length).toBe(4);
       });
+
+      test('includes query-produced bucket starts outside the full time range', () => {
+        const noBucketStyles: BarChartStyle = {
+          ...defaultBarChartStyles,
+          bucket: { ...defaultBarChartStyles.bucket, aggregationType: AggregationType.NONE },
+        };
+        const queryBucketData = [
+          { count: 10, date: '2026-09-05T12:00:00.000Z' },
+          { count: 91, date: '2026-09-05T16:00:00.000Z' },
+          { count: 75, date: '2026-09-05T20:00:00.000Z' },
+        ];
+        const timeRange = {
+          from: '2026-09-05T15:19:52.000Z',
+          to: '2026-09-07T15:19:52.000Z',
+        };
+
+        const { spec } = createTimeBarChart(
+          queryBucketData,
+          noBucketStyles,
+          axisMappings,
+          timeRange
+        );
+
+        expect(spec.xAxis.min).toEqual(new Date(queryBucketData[0].date));
+        expect(spec.xAxis.max).toEqual(new Date(timeRange.to));
+      });
     });
   });
 
@@ -489,8 +515,8 @@ describe('bar to_expression', () => {
         };
 
         const timeRange = {
-          from: new Date(2023, 0, 1, 8, 0, 0, 50).toISOString(),
-          to: new Date(2023, 0, 1, 8, 0, 0, 350).toISOString(),
+          from: '2023-01-01T08:00:00.150Z',
+          to: '2023-01-01T08:00:00.250Z',
         };
         const { spec: noBucketSpec } = createGroupedTimeBarChart(
           sameBucketData,
@@ -501,8 +527,8 @@ describe('bar to_expression', () => {
 
         // No bucketing: pivot groups by raw timestamp strings (3 unique = header + 3 data rows)
         expect(noBucketSpec.dataset.source.length).toBe(4);
-        expect(noBucketSpec.xAxis.min).toEqual(new Date(timeRange.from));
-        expect(noBucketSpec.xAxis.max).toEqual(new Date(timeRange.to));
+        expect(noBucketSpec.xAxis.min).toEqual(new Date(sameBucketData[0].date));
+        expect(noBucketSpec.xAxis.max).toEqual(new Date(sameBucketData[2].date));
       });
     });
   });

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -46,6 +46,36 @@ const alignTimeRangeToBuckets = (
   };
 };
 
+const includeDataInTimeRange = (
+  timeRange: { from: string; to: string } | undefined,
+  data: Array<Record<string, any>>,
+  timeField: string
+) => {
+  if (!timeRange) {
+    return timeRange;
+  }
+
+  const from = new Date(timeRange.from);
+  const to = new Date(timeRange.to);
+  let minTimestamp = Infinity;
+  let maxTimestamp = -Infinity;
+  data.forEach((row) => {
+    const timestamp = new Date(row[timeField]).getTime();
+    if (!isNaN(timestamp)) {
+      minTimestamp = Math.min(minTimestamp, timestamp);
+      maxTimestamp = Math.max(maxTimestamp, timestamp);
+    }
+  });
+  if (isNaN(from.getTime()) || isNaN(to.getTime()) || !isFinite(minTimestamp)) {
+    return timeRange;
+  }
+
+  return {
+    from: new Date(Math.min(from.getTime(), minTimestamp)).toISOString(),
+    to: new Date(Math.max(to.getTime(), maxTimestamp)).toISOString(),
+  };
+};
+
 export const createBarSpec = (
   transformedData: Array<Record<string, any>>,
   styles: BarChartStyle,
@@ -123,9 +153,11 @@ export const createTimeBarChart = (
     : timeUnit === TimeUnit.AUTO
       ? inferTimeIntervals(transformedData, timeField)
       : timeUnit;
-  const bucketAwareTimeRange =
+  const visibleTimeRange =
     styles.showFullTimeRange && transformedData.length > 0
-      ? alignTimeRangeToBuckets(timeRange, effectiveTimeUnit)
+      ? effectiveTimeUnit
+        ? alignTimeRangeToBuckets(timeRange, effectiveTimeUnit)
+        : includeDataInTimeRange(timeRange, transformedData, timeField)
       : timeRange;
   const result = pipe(
     skipBucketing
@@ -162,7 +194,7 @@ export const createTimeBarChart = (
     styles,
     axisConfig,
     axisColumnMappings: axisColumnMappings ?? {},
-    timeRange: bucketAwareTimeRange,
+    timeRange: visibleTimeRange,
   });
 
   return { spec: result.spec, legendItems: result.legendItems ?? [] };
@@ -213,9 +245,11 @@ export const createGroupedTimeBarChart = (
     : timeUnit === TimeUnit.AUTO
       ? inferTimeIntervals(transformedData, timeField)
       : timeUnit;
-  const bucketAwareTimeRange =
+  const visibleTimeRange =
     styles.showFullTimeRange && transformedData.length > 0
-      ? alignTimeRangeToBuckets(timeRange, effectiveTimeUnit)
+      ? effectiveTimeUnit
+        ? alignTimeRangeToBuckets(timeRange, effectiveTimeUnit)
+        : includeDataInTimeRange(timeRange, transformedData, timeField)
       : timeRange;
 
   const result = pipe(
@@ -257,7 +291,7 @@ export const createGroupedTimeBarChart = (
     styles,
     axisConfig,
     axisColumnMappings: axisColumnMappings ?? {},
-    timeRange: bucketAwareTimeRange,
+    timeRange: visibleTimeRange,
   });
 
   return { spec: result.spec, legendItems: result.legendItems ?? [] };

--- a/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
+++ b/src/plugins/explore/public/components/visualizations/bar/to_expression.ts
@@ -7,7 +7,7 @@ import { AxisRole, VisFieldType, TimeUnit, AggregationType, VisColumn } from '..
 import { BarChartStyle } from './bar_vis_config';
 import { getAxisConfig, applyPercentageAxis, getNormalizedAxisConfig } from '../utils/utils';
 
-import { createBarSeries } from './bar_chart_utils';
+import { createBarSeries, inferTimeIntervals } from './bar_chart_utils';
 import {
   pipe,
   createBaseConfig,
@@ -24,6 +24,27 @@ import {
   transform,
   pivot,
 } from '../utils/data_transformation';
+import { ceilToTimeUnit, roundToTimeUnit } from '../utils/data_transformation/utils/time';
+
+const alignTimeRangeToBuckets = (
+  timeRange: { from: string; to: string } | undefined,
+  timeUnit: TimeUnit | undefined
+) => {
+  if (!timeRange || !timeUnit) {
+    return timeRange;
+  }
+
+  const from = new Date(timeRange.from);
+  const to = new Date(timeRange.to);
+  if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+    return timeRange;
+  }
+
+  return {
+    from: roundToTimeUnit(from, timeUnit).toISOString(),
+    to: ceilToTimeUnit(to, timeUnit).toISOString(),
+  };
+};
 
 export const createBarSpec = (
   transformedData: Array<Record<string, any>>,
@@ -97,6 +118,15 @@ export const createTimeBarChart = (
   const timeUnit = styles.bucket?.bucketTimeUnit ?? TimeUnit.AUTO;
   const aggregationType = styles.bucket.aggregationType ?? AggregationType.SUM;
   const skipBucketing = styles.bucket.aggregationType === AggregationType.NONE;
+  const effectiveTimeUnit = skipBucketing
+    ? undefined
+    : timeUnit === TimeUnit.AUTO
+      ? inferTimeIntervals(transformedData, timeField)
+      : timeUnit;
+  const bucketAwareTimeRange =
+    styles.showFullTimeRange && transformedData.length > 0
+      ? alignTimeRangeToBuckets(timeRange, effectiveTimeUnit)
+      : timeRange;
   const result = pipe(
     skipBucketing
       ? transform(convertTo2DArray())
@@ -104,7 +134,7 @@ export const createTimeBarChart = (
           aggregate({
             groupBy: timeField,
             field: seriesFields,
-            timeUnit,
+            timeUnit: effectiveTimeUnit,
             aggregationType,
           }),
           transformStackPercentage(styles, { excludeFields: [timeField] }),
@@ -132,7 +162,7 @@ export const createTimeBarChart = (
     styles,
     axisConfig,
     axisColumnMappings: axisColumnMappings ?? {},
-    timeRange,
+    timeRange: bucketAwareTimeRange,
   });
 
   return { spec: result.spec, legendItems: result.legendItems ?? [] };
@@ -178,6 +208,15 @@ export const createGroupedTimeBarChart = (
   const timeUnit = styles?.bucket?.bucketTimeUnit ?? TimeUnit.AUTO;
   const aggregationType = styles?.bucket?.aggregationType ?? AggregationType.SUM;
   const skipBucketing = styles.bucket.aggregationType === AggregationType.NONE;
+  const effectiveTimeUnit = skipBucketing
+    ? undefined
+    : timeUnit === TimeUnit.AUTO
+      ? inferTimeIntervals(transformedData, timeField)
+      : timeUnit;
+  const bucketAwareTimeRange =
+    styles.showFullTimeRange && transformedData.length > 0
+      ? alignTimeRangeToBuckets(timeRange, effectiveTimeUnit)
+      : timeRange;
 
   const result = pipe(
     transform(
@@ -185,7 +224,7 @@ export const createGroupedTimeBarChart = (
         groupBy: timeField,
         pivot: colorField,
         field: valueField,
-        timeUnit: skipBucketing ? undefined : timeUnit,
+        timeUnit: effectiveTimeUnit,
         // Pivot requires grouping — when bucketing is disabled, fall back to SUM to group raw timestamps by pivot column
         aggregationType: skipBucketing ? AggregationType.SUM : aggregationType,
       }),
@@ -218,7 +257,7 @@ export const createGroupedTimeBarChart = (
     styles,
     axisConfig,
     axisColumnMappings: axisColumnMappings ?? {},
-    timeRange,
+    timeRange: bucketAwareTimeRange,
   });
 
   return { spec: result.spec, legendItems: result.legendItems ?? [] };

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/time.test.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/time.test.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { TimeUnit } from '../../../types';
+import { ceilToTimeUnit } from './time';
+
+describe('ceilToTimeUnit', () => {
+  test.each([
+    [TimeUnit.YEAR, new Date(2023, 5, 15), new Date(2024, 0, 1)],
+    [TimeUnit.MONTH, new Date(2023, 0, 15), new Date(2023, 1, 1)],
+    [TimeUnit.DATE, new Date(2023, 0, 15, 12), new Date(2023, 0, 16)],
+    [TimeUnit.HOUR, new Date(2023, 0, 15, 12, 30), new Date(2023, 0, 15, 13)],
+    [TimeUnit.MINUTE, new Date(2023, 0, 15, 12, 30, 30), new Date(2023, 0, 15, 12, 31)],
+    [TimeUnit.SECOND, new Date(2023, 0, 15, 12, 30, 30, 500), new Date(2023, 0, 15, 12, 30, 31)],
+  ])('rounds %s up to the next boundary', (unit, timestamp, expected) => {
+    expect(ceilToTimeUnit(timestamp, unit)).toEqual(expected);
+  });
+
+  it('preserves a timestamp already on the bucket boundary', () => {
+    const timestamp = new Date(2023, 0, 15, 12);
+
+    expect(ceilToTimeUnit(timestamp, TimeUnit.HOUR)).toEqual(timestamp);
+  });
+});

--- a/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/time.ts
+++ b/src/plugins/explore/public/components/visualizations/utils/data_transformation/utils/time.ts
@@ -37,3 +37,36 @@ export const roundToTimeUnit = (timestamp: Date, unit: TimeUnit): Date => {
       return d;
   }
 };
+
+/**
+ * Round timestamp up to the nearest time bucket boundary.
+ */
+export const ceilToTimeUnit = (timestamp: Date, unit: TimeUnit): Date => {
+  const bucketStart = roundToTimeUnit(timestamp, unit);
+  if (bucketStart.getTime() === timestamp.getTime()) {
+    return bucketStart;
+  }
+
+  switch (unit) {
+    case TimeUnit.YEAR:
+      bucketStart.setFullYear(bucketStart.getFullYear() + 1);
+      break;
+    case TimeUnit.MONTH:
+      bucketStart.setMonth(bucketStart.getMonth() + 1);
+      break;
+    case TimeUnit.DATE:
+      bucketStart.setDate(bucketStart.getDate() + 1);
+      break;
+    case TimeUnit.HOUR:
+      bucketStart.setHours(bucketStart.getHours() + 1);
+      break;
+    case TimeUnit.MINUTE:
+      bucketStart.setMinutes(bucketStart.getMinutes() + 1);
+      break;
+    case TimeUnit.SECOND:
+      bucketStart.setSeconds(bucketStart.getSeconds() + 1);
+      break;
+  }
+
+  return bucketStart;
+};


### PR DESCRIPTION
### Description
Fixes time-based bar charts whose first or last bars are truncated when Show full time range is enabled.

The full-range option applies the exact time-picker bounds as the ECharts axis minimum and maximum. However, bar timestamps represent bucket starts and can fall outside those exact bounds.

This occurs in both bucket modes:
- Auto: The visualization generates time buckets internally. The first bucket can begin before the picker’s from value.
- None: The query may already return bucketed data, such as SPAN(@timestamp, 4h). Although the visualization does not rebucket it, the first returned bucket can still begin before from.

ECharts centers bars on their timestamps, causing boundary bars outside the exact axis range to be partially clipped.
<!-- Describe what this change achieves-->

### Issues Resolved

<!-- List any issues this PR will resolve. Prefix the issue with the keyword closes, fixes, fix -->
<!-- Example: closes #1234 or fixes <Issue_URL> -->

## Screenshot

<!-- Attach any relevant screenshots. Any change to the UI requires an attached screenshot in the PR Description -->

## Testing the changes

<!--
  Please provide detailed steps for validating your changes. This could involve specific commands to run,
  pages to visit, scenarios to try or any other information that would help reviewers verify
  the functionality of your change
-->

### Check List

- [ ] All tests pass
  - [ ] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using --signoff
