### PR TITLE
feat(chat): hint when a tool result is clipped

### DIFF
--- a/src/plugins/chat/public/components/tool_result_renderer.test.tsx
+++ b/src/plugins/chat/public/components/tool_result_renderer.test.tsx
@@ -328,6 +328,29 @@ describe('ToolResultRenderer', () => {
     });
   });
 
+  describe('markdown clip notice', () => {
+    // The tip is gated on a source row count (> 10 content rows), so no DOM
+    // measurement is involved — build tables with more/fewer rows to drive it.
+    const makeTable = (rowCount: number): string => {
+      const header = '| Name | Value |\n|------|-------|';
+      const body = Array.from({ length: rowCount }, (_, i) => `| n${i} | v${i} |`).join('\n');
+      return `${header}\n${body}`;
+    };
+
+    it('should show a "more rows available" tip when the table has more rows than fit', () => {
+      // 15 data rows > the 10-row preview cap.
+      render(<ToolResultRenderer result={makeTable(15)} />);
+      expect(screen.getByText(/More rows available/)).toBeInTheDocument();
+      expect(screen.getByText(/fullscreen button above/)).toBeInTheDocument();
+    });
+
+    it('should NOT show the tip when the row count fits within the cap', () => {
+      // 3 data rows (header + 3 rows = 4 content rows) is well under the cap.
+      render(<ToolResultRenderer result={makeTable(3)} />);
+      expect(screen.queryByText(/More rows available/)).not.toBeInTheDocument();
+    });
+  });
+
   describe('fallback', () => {
     it('should render plain text in code block', () => {
       const result = 'Plain text result without any special formatting';
@@ -439,6 +462,42 @@ describe('ToolResultRenderer', () => {
         (el) => el.textContent?.length === 50000
       );
       expect(modalCode).toBeDefined();
+    });
+  });
+
+  describe('CodeBlock row-clip notice', () => {
+    // Plain (non-markdown, non-JSON) multi-line text with more lines than the
+    // preview cap but well under the char-truncation limit -- routed to a
+    // CodeBlock and clipped by CSS, so it should get the "more rows" tip.
+    const manyShortLines = (count: number): string =>
+      Array.from({ length: count }, (_, i) => `line ${i}`).join('\n');
+
+    it('should show the "more rows available" tip when a short-char block has more lines than fit', () => {
+      const result = manyShortLines(30);
+      expect(result.length).toBeLessThan(5000); // not char-truncated
+      render(<ToolResultRenderer result={result} />);
+      expect(screen.getByText(/More rows available/)).toBeInTheDocument();
+      expect(screen.getByText(/fullscreen button above/)).toBeInTheDocument();
+      // The row-clip case is NOT char truncation, so the char-count notice
+      // must not appear and the built-in copy (full content) is retained.
+      expect(screen.queryByText(/characters truncated/)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Copy full tool result')).not.toBeInTheDocument();
+    });
+
+    it('should NOT show the tip when a block fits within the line cap', () => {
+      const result = manyShortLines(5);
+      render(<ToolResultRenderer result={result} />);
+      expect(screen.queryByText(/More rows available/)).not.toBeInTheDocument();
+    });
+
+    it('should show the char-truncation notice (not the row tip) when a block is char-truncated', () => {
+      // 600 long lines: exceeds both the line cap and the char limit. The
+      // char-truncation path wins; the two notices are mutually exclusive.
+      const result = Array.from({ length: 600 }, (_, i) => `line ${i} padding-padding`).join('\n');
+      expect(result.length).toBeGreaterThan(5000);
+      render(<ToolResultRenderer result={result} />);
+      expect(screen.getByText(/characters truncated/)).toBeInTheDocument();
+      expect(screen.queryByText(/More rows available/)).not.toBeInTheDocument();
     });
   });
 

--- a/src/plugins/chat/public/components/tool_result_renderer.tsx
+++ b/src/plugins/chat/public/components/tool_result_renderer.tsx
@@ -42,6 +42,30 @@ const LINE_HEIGHT = 10;
 const MAX_PREVIEW_LINES = Math.floor(PREVIEW_MAX_HEIGHT / LINE_HEIGHT);
 
 /**
+ * Approximate number of content rows/lines that fit in a height-capped
+ * preview (MarkdownBlock or CodeBlock) before the CSS cap clips the rest.
+ * Used to decide whether to show the "more rows available" tip. This is a
+ * cheap row/line count of the source text — not a live DOM measurement — so
+ * it never triggers layout reads or re-renders; the tradeoff is that it
+ * approximates the pixel clip (rows with wrapped/multiline cells take more
+ * vertical space than the count implies), which is acceptable for a hint
+ * that just points at fullscreen. Kept slightly conservative so it prefers
+ * over-hinting (harmless) to hiding rows with no hint.
+ */
+const MAX_PREVIEW_ROWS = 10;
+
+/**
+ * Counts the visible content rows in a markdown string: every non-empty
+ * line, minus GFM table separator rows (e.g. `|---|---|`) which render as a
+ * border rather than a data row. Used only to gate the clip tip.
+ */
+const countMarkdownRows = (markdown: string): number => {
+  const lines = markdown.split('\n').filter((l) => l.trim().length > 0);
+  const separatorRows = lines.filter(isSeparatorRow).length;
+  return lines.length - separatorRows;
+};
+
+/**
  * Result of a wrapper-pattern parse: `matched` is true iff the text matched
  * the wrapper's shape (regardless of whether the captured content parsed as
  * JSON), so callers can distinguish "didn't look like this wrapper" from
@@ -181,11 +205,19 @@ interface ToolResultRendererProps {
  * `overflow: hidden` visual clip (no tokenizer cost to bound, since the
  * markdown renderer has no equivalent perf cliff to EuiCodeBlock's
  * refractor highlighter). The fullscreen button is always available since
- * there's no truncation signal to gate it on.
+ * there's no truncation signal to gate it on. When the source markdown has
+ * more content rows than fit the cap (a cheap row count, not a DOM
+ * measurement), a "more rows available" tip is shown below the preview
+ * pointing the user at the fullscreen control.
  */
 const MarkdownBlock: React.FC<{ markdown: string }> = ({ markdown }) => {
   const [isFullScreen, setIsFullScreen] = useState(false);
   const content = <Markdown markdown={markdown} openLinksInNewTab={true} />;
+
+  // Show the "more rows available" tip when the source has more content rows
+  // than fit in the capped preview. This is a cheap string count computed on
+  // render — no DOM measurement, refs, effects, or ResizeObserver needed.
+  const isClipped = countMarkdownRows(markdown) > MAX_PREVIEW_ROWS;
 
   return (
     <div className="toolResultMarkdown">
@@ -202,6 +234,14 @@ const MarkdownBlock: React.FC<{ markdown: string }> = ({ markdown }) => {
       <div className="toolResultMarkdown__preview" style={{ maxHeight: PREVIEW_MAX_HEIGHT }}>
         {content}
       </div>
+      {isClipped && (
+        <EuiText size="xs" color="subdued" style={{ marginTop: 4 }}>
+          {i18n.translate('chat.toolResult.markdownClippedNoticeFullscreen', {
+            defaultMessage:
+              'More rows available. Use the fullscreen button above to view the full result.',
+          })}
+        </EuiText>
+      )}
       {isFullScreen && (
         <EuiModal
           onClose={() => setIsFullScreen(false)}
@@ -354,6 +394,11 @@ function renderExtractedText(text: string): JSX.Element {
  * parsed `json` value (parse is skipped, language is forced to `'json'`).
  * Does no shape-guessing beyond JSON detection — it never unwraps `.text`
  * or inspects object keys; all extraction decisions happen upstream.
+ *
+ * Two notices, mutually exclusive: a char-truncation notice (when content
+ * exceeds MAX_DISPLAY_LENGTH and is sliced for perf) and a "more rows
+ * available" tip (when the untruncated content still has more lines than
+ * fit the height cap and is only CSS-clipped). Both point at fullscreen.
  */
 const CodeBlock: React.FC<{
   text?: string;
@@ -390,6 +435,13 @@ const CodeBlock: React.FC<{
         ? linePreview.slice(0, MAX_DISPLAY_LENGTH)
         : linePreview;
   }
+
+  // Even when NOT char-truncated, a block with more lines than fit the height
+  // cap is clipped by CSS with no other signal. Show the same "more rows
+  // available" tip in that case (mutually exclusive with the char-truncation
+  // notice below, which already points at fullscreen). A cheap line count, not
+  // a DOM measurement.
+  const isRowClipped = !isTruncated && formatted.split('\n').length > MAX_PREVIEW_ROWS;
 
   return (
     <div className="toolResultCodeBlock__wrapper">
@@ -437,6 +489,14 @@ const CodeBlock: React.FC<{
             values: {
               truncatedCount: (formatted.length - preview.length).toLocaleString(),
             },
+          })}
+        </EuiText>
+      )}
+      {isRowClipped && (
+        <EuiText size="xs" color="subdued" style={{ marginTop: 4 }}>
+          {i18n.translate('chat.toolResult.codeBlockClippedNoticeFullscreen', {
+            defaultMessage:
+              'More rows available. Use the fullscreen button above to view the full result.',
           })}
         </EuiText>
       )}


### PR DESCRIPTION
### Description

Tool result cards render inside a fixed, height-capped preview. When a tool returns a long markdown table or a long code/JSON block, the preview is clipped by CSS and there is no indication that more content exists below the fold. Users can miss that there are more rows to see.

This change adds a subtle, inline hint below the preview when the content has more rows/lines than fit: "More rows available. Use the fullscreen button above to view the full result." The existing fullscreen control then opens the complete, scrollable content in a modal.

Details:
- Applies to both `MarkdownBlock` (tables and other markdown) and `CodeBlock` (plain text and pretty-printed JSON).
- Detection is a cheap row/line count of the source text against a shared `MAX_PREVIEW_ROWS` threshold. There is no DOM measurement, ref, or `ResizeObserver`, so no layout reads or extra re-renders.
- For `MarkdownBlock`, GFM table separator rows (e.g. `|---|---|`) are excluded from the count so they do not inflate it.
- In `CodeBlock`, the new row-clip hint and the existing character-truncation notice are mutually exclusive: character truncation (content sliced for the syntax highlighter's performance) keeps its own notice, and the row-clip hint only fires when the untruncated content is merely CSS-clipped.
- The threshold is intentionally slightly conservative so it prefers over-hinting (harmless) to hiding rows with no hint.

### Issues Resolved

N/A

## Screenshot

<!-- UI change: please attach before/after screenshots of a tool result with more rows than fit the preview, showing the new hint and the fullscreen modal. -->

## Testing the changes

- `yarn test:jest src/plugins/chat/public/components/tool_result_renderer.test.tsx` (new cases cover: markdown table over/under the row cap, code block with more lines than fit, and that a character-truncated block shows the truncation notice rather than the row hint).
- Manual: open a chat tool result that returns a table or code block with more than ~10 rows; a hint appears under the preview; clicking the fullscreen button shows the full, scrollable content. A short result shows no hint.

### Check List

- [ ] All tests pass
  - [x] `yarn test:jest`
  - [ ] `yarn test:jest_integration`
- [x] New functionality includes testing.
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using --signoff
