### PR TITLE
fix(discover): fix apply_query_action returning 0 resultsCount when hits is 0 and rows are not empty

### DIFF
--- a/src/plugins/discover/public/application/view_components/actions/apply_query_action.test.tsx
+++ b/src/plugins/discover/public/application/view_components/actions/apply_query_action.test.tsx
@@ -286,6 +286,35 @@ describe('useApplyQueryAction', () => {
     expect(result.resultsCount).toBe(0);
   });
 
+  it('counts the fetched rows when a PPL response carries a zero hit total', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    h.queryComplete$.next({
+      data: { status: READY, hits: 0, rows: [{}, {}, {}] },
+      query: { query: 'source=logs', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.resultsCount).toBe(3);
+    expect(result.message).toContain('returned 3 result(s)');
+  });
+
+  it('prefers a positive hit total over the sampled rows', async () => {
+    const h = setup({ currentLanguage: 'PPL' });
+    const action = lastEnabled(h.registered);
+
+    const promise = action.handler({ query: 'source=logs' });
+    h.queryComplete$.next({
+      data: { status: READY, hits: 1204, rows: new Array(500).fill({}) },
+      query: { query: 'source=logs', language: 'PPL' },
+    });
+
+    const result = await promise;
+    expect(result.resultsCount).toBe(1204);
+  });
+
   it('reports a genuine empty result set as success with zero results', async () => {
     const h = setup({ currentLanguage: 'PPL' });
     const action = lastEnabled(h.registered);

--- a/src/plugins/discover/public/application/view_components/actions/apply_query_action.ts
+++ b/src/plugins/discover/public/application/view_components/actions/apply_query_action.ts
@@ -16,6 +16,7 @@ import {
   ResultStatus,
 } from '../utils/use_search';
 import { extractQueryError } from '../../../../../data/common';
+import { readResultsCount } from '../utils/read_query_outcome';
 
 export interface LanguageToolConfig {
   /** Language key stored on the query bar (matches query.language in page context). */
@@ -203,9 +204,7 @@ const createApplyHandler =
         }
 
         const noResults = status === ResultStatus.NO_RESULTS;
-        const resultsCount = noResults
-          ? 0
-          : (finalData.hits ?? finalData.rows?.length ?? undefined);
+        const resultsCount = noResults ? 0 : readResultsCount(finalData);
         return {
           success: true,
           executed: true,

--- a/src/plugins/discover/public/application/view_components/utils/read_query_outcome.test.ts
+++ b/src/plugins/discover/public/application/view_components/utils/read_query_outcome.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { readResultsCount } from './read_query_outcome';
+import { ResultStatus, SearchData } from './use_search';
+
+const searchData = (overrides: Partial<SearchData>): SearchData => ({
+  status: ResultStatus.READY,
+  ...overrides,
+});
+
+const rows = (count: number) => new Array(count).fill({}) as SearchData['rows'];
+
+describe('readResultsCount', () => {
+  it('uses the reported total when it exceeds the sampled rows', () => {
+    expect(readResultsCount(searchData({ hits: 1204, rows: rows(500) }))).toBe(1204);
+  });
+
+  it('uses the fetched rows when they exceed the reported total', () => {
+    expect(readResultsCount(searchData({ hits: 300, rows: rows(500) }))).toBe(500);
+  });
+
+  it('counts the fetched rows when the total is 0', () => {
+    // PPL and SQL leave hits.total at 0 unless a histogram aggregation ran.
+    expect(readResultsCount(searchData({ hits: 0, rows: rows(37) }))).toBe(37);
+  });
+
+  it('counts the fetched rows when there is no total at all', () => {
+    expect(readResultsCount(searchData({ rows: rows(12) }))).toBe(12);
+  });
+
+  it('keeps the reported total when no rows came back', () => {
+    expect(readResultsCount(searchData({ hits: 8, rows: [] }))).toBe(8);
+  });
+
+  it('keeps the reported total when there is no rows field', () => {
+    expect(readResultsCount(searchData({ hits: 42 }))).toBe(42);
+  });
+
+  it('reports 0 when both sides are empty', () => {
+    expect(readResultsCount(searchData({ hits: 0, rows: [] }))).toBe(0);
+  });
+
+  it('reports 0 for an empty total with no rows field', () => {
+    expect(readResultsCount(searchData({ hits: 0 }))).toBe(0);
+  });
+
+  it('reports 0 for an empty row set with no total', () => {
+    expect(readResultsCount(searchData({ rows: [] }))).toBe(0);
+  });
+
+  it('reports no count when neither is present', () => {
+    expect(readResultsCount(searchData({}))).toBeUndefined();
+  });
+});

--- a/src/plugins/discover/public/application/view_components/utils/read_query_outcome.ts
+++ b/src/plugins/discover/public/application/view_components/utils/read_query_outcome.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SearchData } from './use_search';
+
+export function readResultsCount(searchData: SearchData): number | undefined {
+  const hits = searchData.hits;
+  const rowCount = searchData.rows?.length;
+
+  if (hits === undefined) {
+    return rowCount;
+  }
+  if (rowCount === undefined) {
+    return hits;
+  }
+  return Math.max(hits, rowCount);
+}


### PR DESCRIPTION
### Description

There is a question when apply_dql_query / apply_lucene_query / apply_ppl_query / apply_sql_query report resultsCount: The tools read the count as finalData.hits ?? finalData.rows?.length ?? undefined, so the assistant gets 0 when hits is 0 and rows is not empty. 
This PR fixes that.

## Testing the changes

Unit tests:
yarn jest src/plugins/discover/public/application/view_components/utils/read_query_outcome.test.ts
yarn jest src/plugins/discover/public/application/view_components/actions/apply_query_action.test.tsx

Manual verification requires a data source where the PPL histogram aggregation does not run, so hits.total stays 0. Ask the AI assistant a question that should match data, for example "find men's clothing"; the resultsCount in the returned tool result should not be 0.

### Check List

- [x] All tests pass
- [x] New functionality includes testing.
- [x] Commits are signed per the DCO using --signoff
