### PR TITLE
fix: index dataset handling in visualization editors

### DIFF
--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
@@ -263,12 +263,12 @@ describe('IndexPatterns', () => {
     expect(await indexPatterns.isLongNumeralsSupported()).toBe(true);
   });
 
-  describe('getCache - excludeEngineTypes', () => {
-    const buildPattern = (id: string, dataSourceId?: string) => ({
+  describe('getCache filtering', () => {
+    const buildPattern = (id: string, dataSourceId?: string, datasetType?: string) => ({
       id,
       type: 'index-pattern',
       version: '1',
-      attributes: { title: id },
+      attributes: { title: id, ...(datasetType && { type: datasetType }) },
       references: dataSourceId ? [{ id: dataSourceId, type: 'data-source', name: 'ds' }] : [],
     });
 
@@ -314,6 +314,38 @@ describe('IndexPatterns', () => {
       });
       const cache = await indexPatterns.getCache({ excludeEngineTypes: [] });
       expect(cache?.map((o) => o.id)).toEqual(['a', 'b']);
+    });
+
+    test('excludes saved objects whose dataset type is blocked', async () => {
+      setupClientWithDataSources(
+        [
+          buildPattern('index-pattern'),
+          buildPattern('indexes-dataset', undefined, 'INDEXES'),
+          buildPattern('rollup', undefined, 'rollup'),
+        ],
+        {}
+      );
+      const cache = await indexPatterns.getCache({ excludeDatasetTypes: ['INDEXES'] });
+      expect(cache?.map((o) => o.id)).toEqual(['index-pattern', 'rollup']);
+    });
+
+    test('combines engine-type and dataset-type filters', async () => {
+      setupClientWithDataSources(
+        [
+          buildPattern('supported', 'ds-os'),
+          buildPattern('blocked-engine', 'ds-ae'),
+          buildPattern('blocked-dataset', 'ds-os', 'INDEXES'),
+        ],
+        {
+          'ds-os': 'OpenSearch',
+          'ds-ae': 'AnalyticEngine',
+        }
+      );
+      const cache = await indexPatterns.getCache({
+        excludeEngineTypes: ['AnalyticEngine'],
+        excludeDatasetTypes: ['INDEXES'],
+      });
+      expect(cache?.map((o) => o.id)).toEqual(['supported']);
     });
 
     test('excludes patterns whose data source has a blocked engine type', async () => {

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.test.ts
@@ -119,11 +119,11 @@ describe('IndexPatterns', () => {
     expect(indexPattern).toBe(await indexPatterns.get(id));
   });
 
-  test('savedObjectCache pre-fetches title and displayName', async () => {
+  test('savedObjectCache pre-fetches fields required for source compatibility filtering', async () => {
     expect(await indexPatterns.getIds()).toEqual(['id']);
     expect(savedObjectsClient.find).toHaveBeenCalledWith({
       type: 'index-pattern',
-      fields: ['title', 'displayName'],
+      fields: ['title', 'displayName', 'type'],
       perPage: 10000,
     });
   });

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -64,6 +64,7 @@ const savedObjectType = 'index-pattern';
 export interface IndexPatternSavedObjectAttrs {
   title: string;
   displayName?: string;
+  type?: string;
 }
 
 interface IndexPatternsServiceDeps {
@@ -121,7 +122,7 @@ export class IndexPatternsService {
   private async refreshSavedObjectsCache() {
     this.savedObjectsCache = await this.savedObjectsClient.find<IndexPatternSavedObjectAttrs>({
       type: 'index-pattern',
-      fields: ['title', 'displayName'],
+      fields: ['title', 'displayName', 'type'],
       perPage: 10000,
     });
 

--- a/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
+++ b/src/plugins/data/common/index_patterns/index_patterns/index_patterns.ts
@@ -230,14 +230,32 @@ export class IndexPatternsService {
     }
   };
 
-  getCache = async (options?: { excludeEngineTypes?: readonly string[] }) => {
+  getCache = async (options?: {
+    excludeEngineTypes?: readonly string[];
+    excludeDatasetTypes?: readonly string[];
+  }) => {
     if (!this.savedObjectsCache) {
       await this.refreshSavedObjectsCache();
     }
-    if (!options?.excludeEngineTypes?.length || !this.savedObjectsCache) {
+    if (!this.savedObjectsCache) {
       return this.savedObjectsCache;
     }
-    return this.applyEngineTypeFilter(this.savedObjectsCache, options.excludeEngineTypes);
+
+    let filteredSavedObjects = this.savedObjectsCache;
+    const excludeDatasetTypes = options?.excludeDatasetTypes;
+    if (excludeDatasetTypes?.length) {
+      filteredSavedObjects = filteredSavedObjects.filter(
+        (savedObject) => !excludeDatasetTypes.includes(savedObject.attributes.type ?? '')
+      );
+    }
+    if (options?.excludeEngineTypes?.length) {
+      filteredSavedObjects = await this.applyEngineTypeFilter(
+        filteredSavedObjects,
+        options.excludeEngineTypes
+      );
+    }
+
+    return filteredSavedObjects;
   };
 
   // Excludes saved objects whose backing data source's `dataSourceEngineType` is in

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
@@ -469,6 +469,7 @@ describe('DatasetService', () => {
         attributes: {
           title: 'DataSource',
           dataSourceEngineType: 'OpenSearch',
+          dataSourceVersion: '2.17.0',
         },
       }),
     } as unknown as IndexPatternsContract;
@@ -481,6 +482,8 @@ describe('DatasetService', () => {
         id: 'datasource-id',
         title: 'DataSource',
         type: 'OpenSearch',
+        engineType: 'OpenSearch',
+        version: '2.17.0',
       });
     });
   });

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.test.ts
@@ -462,14 +462,26 @@ describe('DatasetService', () => {
         id: 'id',
         title: 'my-index-*',
         type: DEFAULT_DATA.SET_TYPES.INDEX,
+        dataSourceRef: { id: 'datasource-id' },
       }),
-      getDataSource: jest.fn().mockResolvedValue(undefined),
+      getDataSource: jest.fn().mockResolvedValue({
+        id: 'datasource-id',
+        attributes: {
+          title: 'DataSource',
+          dataSourceEngineType: 'OpenSearch',
+        },
+      }),
     } as unknown as IndexPatternsContract;
     service.init(indexPatterns);
 
     await waitFor(() => {
       const def = service.getDefault();
       expect(def?.type).toBe(DEFAULT_DATA.SET_TYPES.INDEX);
+      expect(def?.dataSource).toMatchObject({
+        id: 'datasource-id',
+        title: 'DataSource',
+        type: 'OpenSearch',
+      });
     });
   });
 

--- a/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/dataset_service.ts
@@ -402,7 +402,14 @@ export class DatasetService {
             ? {
                 id: dataSource.id,
                 title: dataSource.attributes?.title,
-                type: dataSource.attributes?.dataSourceEngineType || '',
+                type:
+                  dataSource.attributes?.dataSourceEngineType ||
+                  DEFAULT_DATA.SOURCE_TYPES.OPENSEARCH,
+                meta: {
+                  type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+                  dataSourceEngineType: dataSource.attributes?.dataSourceEngineType,
+                  dataSourceVersion: dataSource.attributes?.dataSourceVersion,
+                },
               }
             : undefined,
         },

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
@@ -232,6 +232,32 @@ describe('indexTypeConfig', () => {
       });
     });
 
+    test('uses the leaf parent when the path does not contain a DATA_SOURCE node', () => {
+      const mockPath: DataStructure[] = [
+        {
+          id: 'index1',
+          title: 'Index 1',
+          type: DEFAULT_DATA.SET_TYPES.INDEX,
+          parent: {
+            id: 'datasource1',
+            title: 'DataSource 1',
+            type: 'OpenSearch',
+          },
+          meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
+        },
+      ];
+
+      const result = indexTypeConfig.toDataset(mockPath);
+
+      expect(result.dataSource).toEqual({
+        id: 'datasource1',
+        title: 'DataSource 1',
+        type: 'OpenSearch',
+        engineType: undefined,
+        version: '',
+      });
+    });
+
     test('falls back to LOCAL_DATASOURCE when there is no DATA_SOURCE node in path', () => {
       const mockPath: DataStructure[] = [
         {

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.test.ts
@@ -242,6 +242,11 @@ describe('indexTypeConfig', () => {
             id: 'datasource1',
             title: 'DataSource 1',
             type: 'OpenSearch',
+            meta: {
+              type: DATA_STRUCTURE_META_TYPES.CUSTOM,
+              dataSourceEngineType: 'OpenSearch',
+              dataSourceVersion: '2.17.0',
+            },
           },
           meta: { timeFieldName: '@timestamp', type: DATA_STRUCTURE_META_TYPES.CUSTOM },
         },
@@ -253,8 +258,8 @@ describe('indexTypeConfig', () => {
         id: 'datasource1',
         title: 'DataSource 1',
         type: 'OpenSearch',
-        engineType: undefined,
-        version: '',
+        engineType: 'OpenSearch',
+        version: '2.17.0',
       });
     });
 

--- a/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
+++ b/src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts
@@ -40,7 +40,7 @@ export const indexTypeConfig: DatasetTypeConfig = {
 
   toDataset: (path) => {
     const index = path[path.length - 1];
-    const dataSource = path.find((ds) => ds.type === 'DATA_SOURCE');
+    const dataSource = path.find((item) => item.type === 'DATA_SOURCE') ?? index.parent;
     const indexMeta = index.meta as DataStructureCustomMeta;
     const dataSourceMeta = dataSource?.meta as DataStructureCustomMeta | undefined;
     // Prefer the engine type/version carried on the DATA_SOURCE node's meta; fall back to the leaf

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.test.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.test.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SearchSelection } from './search_selection';
+
+describe('SearchSelection', () => {
+  test('excludes INDEXES datasets while preserving legacy-compatible index patterns', async () => {
+    const regularIndexPattern = {
+      id: 'regular-index-pattern',
+      type: 'index-pattern',
+      attributes: { title: 'logs-*' },
+      references: [],
+    };
+    const indexesDataset = {
+      id: 'indexes-dataset',
+      type: 'index-pattern',
+      attributes: { title: 'logs-2026.09.11', type: 'INDEXES' },
+      references: [],
+    };
+    const rollupIndexPattern = {
+      id: 'rollup-index-pattern',
+      type: 'index-pattern',
+      attributes: { title: 'logs-rollup', type: 'rollup' },
+      references: [],
+    };
+    const getCache = jest
+      .fn()
+      .mockResolvedValueOnce([regularIndexPattern, indexesDataset, rollupIndexPattern])
+      .mockResolvedValueOnce([regularIndexPattern, rollupIndexPattern]);
+
+    const component = new SearchSelection({
+      data: { indexPatterns: { getCache } },
+    } as any);
+    component.setState = ((nextState: any) => {
+      component.state = { ...component.state, ...nextState };
+    }) as any;
+
+    await component.componentDidMount();
+
+    expect([...component.state.indexPatternIds]).toEqual([
+      'regular-index-pattern',
+      'rollup-index-pattern',
+    ]);
+    expect(component.state.hasUnsupportedSources).toBe(true);
+    expect(getCache).toHaveBeenNthCalledWith(2, {
+      excludeEngineTypes: expect.any(Array),
+      excludeDatasetTypes: ['INDEXES'],
+    });
+  });
+});

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -72,12 +72,10 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
 
   async componentDidMount() {
     const allIndexPatterns = await this.props.data.indexPatterns.getCache();
-    const indexPatternList = await this.props.data.indexPatterns.getCache({
+    const legacyCompatibleIndexPatterns = await this.props.data.indexPatterns.getCache({
       excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
+      excludeDatasetTypes: [DEFAULT_DATA.SET_TYPES.INDEX],
     });
-    const legacyCompatibleIndexPatterns = indexPatternList?.filter(
-      (indexPattern) => indexPattern.attributes.type !== DEFAULT_DATA.SET_TYPES.INDEX
-    );
 
     this.setState({
       indexPatternIds: new Set(

--- a/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
+++ b/src/plugins/visualizations/public/wizard/search_selection/search_selection.tsx
@@ -43,7 +43,7 @@ import { ApplicationStart, IUiSettingsClient, SavedObjectsStart } from '../../..
 
 import { SavedObjectFinderUi } from '../../../../saved_objects/public';
 import { VisType } from '../../vis_types';
-import { UNSUPPORTED_ENGINE_TYPES } from '../../../../data/common';
+import { DEFAULT_DATA, UNSUPPORTED_ENGINE_TYPES } from '../../../../data/common';
 
 interface SearchSelectionProps {
   onSearchSelected: (searchId: string, searchType: string) => void;
@@ -56,7 +56,7 @@ interface SearchSelectionProps {
 
 interface SearchSelectionState {
   indexPatternIds: Set<string>;
-  hasAnalyticEngine: boolean;
+  hasUnsupportedSources: boolean;
 }
 
 export class SearchSelection extends React.Component<SearchSelectionProps, SearchSelectionState> {
@@ -66,7 +66,7 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
     super(props);
     this.state = {
       indexPatternIds: new Set(),
-      hasAnalyticEngine: false,
+      hasUnsupportedSources: false,
     };
   }
 
@@ -75,10 +75,16 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
     const indexPatternList = await this.props.data.indexPatterns.getCache({
       excludeEngineTypes: UNSUPPORTED_ENGINE_TYPES,
     });
+    const legacyCompatibleIndexPatterns = indexPatternList?.filter(
+      (indexPattern) => indexPattern.attributes.type !== DEFAULT_DATA.SET_TYPES.INDEX
+    );
 
     this.setState({
-      indexPatternIds: new Set(indexPatternList?.map((indexpattern) => indexpattern.id)),
-      hasAnalyticEngine: (allIndexPatterns?.length ?? 0) > (indexPatternList?.length ?? 0),
+      indexPatternIds: new Set(
+        legacyCompatibleIndexPatterns?.map((indexPattern) => indexPattern.id)
+      ),
+      hasUnsupportedSources:
+        (allIndexPatterns?.length ?? 0) > (legacyCompatibleIndexPatterns?.length ?? 0),
     });
   }
 
@@ -100,16 +106,16 @@ export class SearchSelection extends React.Component<SearchSelectionProps, Searc
           </EuiModalHeaderTitle>
         </EuiModalHeader>
         <EuiModalBody>
-          {this.state.hasAnalyticEngine && (
+          {this.state.hasUnsupportedSources && (
             <>
               <EuiCallOut
                 size="s"
                 iconType="iInCircle"
                 title={i18n.translate(
-                  'visualizations.newVisWizard.searchSelection.optimizedEngineNotSupported',
+                  'visualizations.newVisWizard.searchSelection.unsupportedSources',
                   {
                     defaultMessage:
-                      "This visualization type supports only DSL queries. Index patterns and saved searches backed by Optimized engine (AnalyticEngine type) data sources aren't supported and are hidden from the list below.",
+                      "Legacy visualizations support only DSL queries. Optimized engine (AnalyticEngine) index patterns and PPL/SQL-only index datasets, including their saved searches, aren't supported and are hidden from the list below.",
                   }
                 )}
               />


### PR DESCRIPTION
## Summary

Fix two compatibility issues involving `INDEXES` datasets:

1. Default `INDEXES` datasets lose their data-source ID, causing visualization requests to use the unavailable local-cluster client.
2. PPL/SQL-only `INDEXES` datasets appear in the legacy visualization picker, although legacy visualizations support only DSL queries.

## Issues

### Missing data-source ID

When an `INDEXES` dataset is the default index pattern, it is hydrated with:

```text
dataSource: { id: '', title: 'Default Cluster' }
```

When no local backend exists, this causes:

- `/app/visualize`: `503 No Living connections`
- `/app/visualization-editor`: background `resolve_index` request returns 500

A standard local environment can mask the problem because its local OpenSearch connection is healthy.

### Unsupported legacy visualization datasets

`visNewVisSearchDialog` lists `INDEXES` datasets even though they support only PPL/SQL. Selecting one for a legacy visualization leads to an unsupported query path.

## Reproduction

1. Create an **Indexes** dataset backed by a data source.
2. Set it as the default index pattern.
3. Hard-reload the application.
4. Open `/app/visualize` and run a query.
5. Observe `503 No Living connections` on an environment without a local backend.
6. Open `/app/visualization-editor`.
7. Observe that `resolve_index` is called without `data_source`(based on timing, no always reproducible locally)
8. Open the legacy visualization picker and observe that the PPL/SQL-only dataset is selectable.

## Root cause

`fetchDefaultDataset()` passes the resolved data source through the index node’s `parent` property. `indexTypeConfig.toDataset()` searched only for a separate `DATA_SOURCE` node in the path, discarded `index.parent`, and fell back to the empty local-cluster placeholder.

The legacy picker filtered unsupported engine types but did not check the saved object’s dataset type. Its lightweight index-pattern cache also did not include the `type` attribute required for that filtering.

## Fix

- Fall back to `index.parent` when resolving an index dataset’s data source.
- Include the saved object `type` in the index-pattern cache.
- Exclude `INDEXES` datasets and their saved searches from the legacy visualization picker.